### PR TITLE
Adds PHP-Bench to Composer dev requirements.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,8 @@
 		"php": ">=5.3.0",
 		"doctrine/annotations": "1.*",
 		"doctrine/cache": "1.*"
-	}
+	},
+    "require-dev" : {
+        "mnapoli/phpbench": "dev-master"
+    }
 }


### PR DESCRIPTION
When composer is run with `--dev` PHP-Bench will be installed as well.
