### PR TITLE
Better error handling

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -1,5 +1,13 @@
 # Change log
 
+## 3.0.2
+
+* [#64](https://github.com/mnapoli/PHP-DI/issues/64): Non PHP-DI exceptions are not captured-rethrown anymore when injecting dependencies (cleaner stack trace)
+
+## 3.0.1
+
+* [#62](https://github.com/mnapoli/PHP-DI/issues/62): When using aliases, definitions are now merged
+
 ## 3.0
 
 Major compatibility breaks with 2.x.

--- a/src/DI/Factory.php
+++ b/src/DI/Factory.php
@@ -54,17 +54,25 @@ class Factory implements FactoryInterface
         // Create an instance without calling its constructor
         $instance = $this->newInstanceWithoutConstructor($classReflection);
 
-        // Property injections
-        foreach ($classDefinition->getPropertyInjections() as $propertyInjection) {
-            $this->injectProperty($instance, $propertyInjection);
-        }
+        try {
+            // Property injections
+            foreach ($classDefinition->getPropertyInjections() as $propertyInjection) {
+                $this->injectProperty($instance, $propertyInjection);
+            }
 
-        // Constructor injection
-        $this->injectConstructor($instance, $classReflection, $classDefinition->getConstructorInjection());
+            // Constructor injection
+            $this->injectConstructor($instance, $classReflection, $classDefinition->getConstructorInjection());
 
-        // Method injections
-        foreach ($classDefinition->getMethodInjections() as $methodInjection) {
-            $this->injectMethod($instance, $methodInjection);
+            // Method injections
+            foreach ($classDefinition->getMethodInjections() as $methodInjection) {
+                $this->injectMethod($instance, $methodInjection);
+            }
+        } catch (DependencyException $e) {
+            throw $e;
+        } catch (DefinitionException $e) {
+            throw $e;
+        } catch (NotFoundException $e) {
+            throw new DependencyException("Error while injecting dependencies into $classReflection->name: " . $e->getMessage(), 0, $e);
         }
 
         return $instance;

--- a/tests/IntegrationTests/DI/BuggyInjectionsTest.php
+++ b/tests/IntegrationTests/DI/BuggyInjectionsTest.php
@@ -28,7 +28,8 @@ class BuggyInjectionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \DI\NotFoundException
+     * @expectedException \DI\DependencyException
+     * @expectedExceptionMessage Error while injecting dependencies into IntegrationTests\DI\Fixtures\ConstructorInjectionTest\Buggy2: No entry or class found for 'nonExistentEntry'
      */
     public function testConstructorNonExistentEntry()
     {
@@ -37,7 +38,8 @@ class BuggyInjectionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Exception
+     * @expectedException \DI\DependencyException
+     * @expectedExceptionMessage Error while injecting 'namedDependency' in IntegrationTests\DI\Fixtures\SetterInjectionTest\NamedInjectionClass::dependency. No entry or class found for 'namedDependency'
      */
     public function testSetterNamedInjectionNotFound()
     {
@@ -57,7 +59,8 @@ class BuggyInjectionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \DI\NotFoundException
+     * @expectedException \DI\DependencyException
+     * @expectedExceptionMessage Error while injecting dependencies into IntegrationTests\DI\Fixtures\SetterInjectionTest\Buggy3: No entry or class found for 'nonExistentBean'
      */
     public function testSetterNamedUnknownBean()
     {


### PR DESCRIPTION
This is a merge of #64 with the following changes:
- PHP-DI specific exceptions are catched and rethrown to have a nicer error message
- other exceptions are not catched, which leaves the stack trace clean and gives the user the behavior he may expect (he may want to catch the exception)
