### PR TITLE
Fix getting-started.md so that `composer.json` contains valid JSON

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -12,7 +12,7 @@ Create a file named `composer.json` in your project root:
 ```json
 {
     "require": {
-        "mnapoli/php-di": "3.0.*",
+        "mnapoli/php-di": "3.0.*"
     }
 }
 ```


### PR DESCRIPTION
The suggested content for `composer.json` is invalid JSON and causes the following error if used as is:

  [Seld\JsonLint\ParsingException]
  "composer.json" does not contain valid JSON
  Parse error on line 3:
}
  ----------------------^
  Expected: 'STRING' - It appears you have an extra trailing comma
