### PR TITLE
Check if file is not a dir

### DIFF
--- a/src/DI/Definition/FileLoader/DefinitionFileLoader.php
+++ b/src/DI/Definition/FileLoader/DefinitionFileLoader.php
@@ -33,11 +33,12 @@ abstract class DefinitionFileLoader
      */
     public function __construct($fileName)
     {
-        if (!file_exists($fileName)) {
+        if (!is_file($fileName)) {
             throw new FileNotFoundException("The definition file '$fileName' has not been found");
         } elseif (!is_readable($fileName)) {
             throw new ParseException("The definition file '$fileName' is not readable");
         }
+
         $this->definitionFile = $fileName;
     }
 

--- a/tests/UnitTests/DI/Definition/FileLoader/DefinitionFileLoaderTest.php
+++ b/tests/UnitTests/DI/Definition/FileLoader/DefinitionFileLoaderTest.php
@@ -21,4 +21,12 @@ class DefinitionFileLoaderTest extends \PHPUnit_Framework_TestCase
     {
         $this->getMockForAbstractClass('DI\Definition\FileLoader\DefinitionFileLoader', array('abcFile.php'));
     }
+
+    /**
+     * @expectedException \DI\Definition\FileLoader\Exception\FileNotFoundException
+     */
+    public function testFileIsNotADir()
+    {
+        $this->getMockForAbstractClass('DI\Definition\FileLoader\DefinitionFileLoader', array(__DIR__));
+    }
 }


### PR DESCRIPTION
`DefinitionFileLoader` doesn't take into account filetype. It causes confusing error message like

```
Invalid argument supplied for foreach()
```
