### PR TITLE
Allow indexed non-empty arrays being valid parameter values

### DIFF
--- a/doc/definition.md
+++ b/doc/definition.md
@@ -166,6 +166,12 @@ $container = new Container();
 $container->set('db.host', 'localhost');
 $container->set('db.port', 5000);
 
+// Indexed non-empty array as value
+$container->set('report.recipients', array(
+	'bob@acme.example.com',
+	'alice@acme.example.com'
+));
+
 // Direct mapping (not needed if you didn't disable Reflection)
 $container->set('SomeClass');
 
@@ -230,8 +236,14 @@ return [
     'db.host' => 'localhost',
     'db.port' => 5000,
 
+    // Indexed non-empty array as value
+    'report.recipients' => [
+        'bob@acme.example.com',
+        'alice@acme.example.com'
+    ],
+
     // Direct mapping (not needed if you didn't disable Reflection)
-    'SomeClass' => array(),
+    'SomeClass' => [],
 
     // This is not recommended: will instantiate the class even when not used, prevents caching
     'SomeOtherClass' => new SomeOtherClass(1, "hello"),
@@ -298,6 +310,11 @@ Example of a `config/di.yml` file:
 db.host: localhost
 db.port: 5000
 
+# Indexed non-empty array as value
+report.recipients:
+    - bob@acme.example.com
+    - alice@acme.example.com
+
 # Direct mapping (not needed if you didn't disable Reflection)
 SomeClass:
 
@@ -330,3 +347,4 @@ My\Interface:
 myNamedInstance:
     class: My\Class
 ```
+

--- a/src/DI/Definition/Source/ArrayDefinitionSource.php
+++ b/src/DI/Definition/Source/ArrayDefinitionSource.php
@@ -54,7 +54,7 @@ class ArrayDefinitionSource implements DefinitionSource
         }
 
         // Value definition
-        if (!is_array($arrayDefinition)) {
+        if (!is_array($arrayDefinition) || ($arrayDefinition && array_values($arrayDefinition) === $arrayDefinition)) {
             return new ValueDefinition($name, $arrayDefinition);
         }
 
@@ -281,5 +281,4 @@ class ArrayDefinitionSource implements DefinitionSource
             }
         }
     }
-
 }

--- a/tests/UnitTests/DI/Definition/FileLoader/Fixtures/definitions.json
+++ b/tests/UnitTests/DI/Definition/FileLoader/Fixtures/definitions.json
@@ -1,4 +1,5 @@
 {
+	"value4": ["bob@acme.example.com", "alice@acme.example.com"],
 	"value3": true,
 	"value2": 123,
 	"value1": "abc",

--- a/tests/UnitTests/DI/Definition/FileLoader/Fixtures/definitions.php
+++ b/tests/UnitTests/DI/Definition/FileLoader/Fixtures/definitions.php
@@ -6,6 +6,7 @@ return array(
     'value1' => 'abc',
     'value2' => 123,
     'value3' => true,
+    'value4' => array('bob@acme.example.com', 'alice@acme.example.com'),
     'namespace\class1' => array(
         'scope' => 'singleton',
         'lazy' => true,

--- a/tests/UnitTests/DI/Definition/FileLoader/Fixtures/definitions.yaml
+++ b/tests/UnitTests/DI/Definition/FileLoader/Fixtures/definitions.yaml
@@ -1,6 +1,9 @@
 value1: abc
 value2: 123
 value3: true
+value4:
+  - bob@acme.example.com
+  - alice@acme.example.com
 namespace\class1:
   scope: singleton
   lazy: true

--- a/tests/UnitTests/DI/Definition/Source/ArrayDefinitionSourceTest.php
+++ b/tests/UnitTests/DI/Definition/Source/ArrayDefinitionSourceTest.php
@@ -304,6 +304,17 @@ class ArrayDefinitionSourceTest extends \PHPUnit_Framework_TestCase
         $source->getDefinition('foo');
     }
 
+    public function testIndexedNonEmptyArrayAsValidValue()
+    {
+        $source = new ArrayDefinitionSource();
+        $source->addDefinitions(
+            array(
+                'foo' => array('a', 'b', 'c')
+            )
+        );
+        $source->getDefinition('foo');
+    }
+
     public function testClosureDefinition()
     {
         $source = new ArrayDefinitionSource();


### PR DESCRIPTION
Currently, there is no way to store indexed arrays as values except direct call `$container->set(...)`:

```
DI\Definition\Exception\DefinitionException: Invalid key '0' in definition of entry 'foo'; Valid keys are: class, scope, lazy, constructor, properties, methods
```

By the way, it's impossible to discern type of parameter (simple value or service) in case of empty array.

P.S. I didn't add this feature for `XmlDefinitionFileLoader`, anyway it looks not fully supported at this moment.
