### PR TITLE
Add hasSingleton

### DIFF
--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -179,6 +179,19 @@ class Container implements ContainerInterface, FactoryInterface
     }
 
     /**
+     * Test if the container already has something for the given name. This will not change the state of the container.
+     *
+     * @param string $name Entry name or a class name.
+     *
+     * @throws InvalidArgumentException The name parameter must be of type string.
+     * @return bool
+     */
+    public function hasSingleton($name)
+    {
+        return array_key_exists($name, $this->singletonEntries);
+    }
+
+    /**
      * Inject all dependencies on an existing instance
      *
      * @param object $instance Object to perform injection upon
@@ -207,18 +220,13 @@ class Container implements ContainerInterface, FactoryInterface
      */
     public function set($name, $value)
     {
-        // Clear existing entry if it exists
-        if (array_key_exists($name, $this->singletonEntries)) {
-            unset($this->singletonEntries[$name]);
-        }
-
         if ($value instanceof DefinitionHelper) {
+            unset($this->singletonEntries[$name]);
             $definition = $value->getDefinition($name);
+            $this->definitionManager->addDefinition($definition);
         } else {
-            $definition = new ValueDefinition($name, $value);
+            $this->singletonEntries[$name] = $value;
         }
-
-        $this->definitionManager->addDefinition($definition);
     }
 
     /**

--- a/tests/UnitTests/DI/ContainerMakeTest.php
+++ b/tests/UnitTests/DI/ContainerMakeTest.php
@@ -19,14 +19,6 @@ use stdClass;
  */
 class ContainerMakeTest extends \PHPUnit_Framework_TestCase
 {
-    public function testSetMake()
-    {
-        $container = ContainerBuilder::buildDevContainer();
-        $dummy = new stdClass();
-        $container->set('key', $dummy);
-        $this->assertSame($dummy, $container->make('key'));
-    }
-
     /**
      * @expectedException \DI\NotFoundException
      */
@@ -34,19 +26,6 @@ class ContainerMakeTest extends \PHPUnit_Framework_TestCase
     {
         $container = ContainerBuilder::buildDevContainer();
         $container->make('key');
-    }
-
-    /**
-     * @coversNothing
-     */
-    public function testClosureIsNotResolved()
-    {
-        $closure = function () {
-            return 'hello';
-        };
-        $container = ContainerBuilder::buildDevContainer();
-        $container->set('key', $closure);
-        $this->assertSame($closure, $container->make('key'));
     }
 
     public function testMakeWithClassName()

--- a/tests/UnitTests/DI/ContainerTest.php
+++ b/tests/UnitTests/DI/ContainerTest.php
@@ -40,6 +40,31 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $container->has(new stdClass());
     }
 
+    public function testHasSingletonDoesNotChangeContainer() {
+        $container = ContainerBuilder::buildDevContainer();
+        $class_name = 'UnitTests\DI\Fixtures\Singleton';
+
+        $this->assertFalse($container->hasSingleton($class_name));
+        $this->assertFalse($container->hasSingleton($class_name));
+    }
+
+    public function testHasSingletonDoesSeeSetSingletons() {
+        $container = ContainerBuilder::buildDevContainer();
+        $this->assertFalse($container->hasSingleton('stdClass'));
+        $container->set('stdClass', new StdClass());
+        $this->assertTrue($container->hasSingleton('stdClass'));
+    }
+
+    public function testHasSingletonDoeSeeFetchedSingletons() {
+        $container = ContainerBuilder::buildDevContainer();
+
+        $class_name = 'UnitTests\DI\Fixtures\Singleton';
+
+        $this->assertFalse($container->hasSingleton($class_name));
+        $container->get($class_name);
+        $this->assertTrue($container->hasSingleton($class_name));
+    }
+
     /**
      * Test that injecting an existing object returns the same reference to that object
      */


### PR DESCRIPTION
Enables checking for singletons. Similar to the new has method but will never create a new instance. It only draws from existing singletons or objects that have been explicitly set at runtime.

In order to do this though set() has been changed so that if a value is given it will be explicitly set as a singleton. This changes the way make() works as it will no longer behave like get for sets with explicit values.
