### PR TITLE
Fix markdown syntax

### DIFF
--- a/doc/frameworks/symfony2.md
+++ b/doc/frameworks/symfony2.md
@@ -155,7 +155,7 @@ There was a bug in FOSRestBundle that would prevent using "Controller as service
 
 This bug has been fixed and will be released in >=1.3.2 (not released yet at the time of writing).
 
-Full details are here: [FOSRestBundle#743](https://github.com/FriendsOfSymfony/FOSRestBundle/pull/743]
+Full details are here: [FOSRestBundle#743](https://github.com/FriendsOfSymfony/FOSRestBundle/pull/743)
 
 
 ## More


### PR DESCRIPTION
A link syntax of markdown.

It'll not affect the implementation :octocat: 
