### PR TITLE
Uninstantiable defaulted constructor parameter injection issue

### DIFF
--- a/tests/IntegrationTests/DI/Fixtures/Class3.php
+++ b/tests/IntegrationTests/DI/Fixtures/Class3.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://mnapoli.github.io/PHP-DI/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace IntegrationTests\DI\Fixtures;
+
+/**
+ * Fixture class
+ */
+class Class3 implements Interface2
+{
+    public function __construct(Interface3 $param = null)
+    {
+    }
+}

--- a/tests/IntegrationTests/DI/Fixtures/Interface2.php
+++ b/tests/IntegrationTests/DI/Fixtures/Interface2.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://mnapoli.github.io/PHP-DI/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace IntegrationTests\DI\Fixtures;
+
+interface Interface2
+{
+}

--- a/tests/IntegrationTests/DI/Fixtures/Interface3.php
+++ b/tests/IntegrationTests/DI/Fixtures/Interface3.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://mnapoli.github.io/PHP-DI/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace IntegrationTests\DI\Fixtures;
+
+interface Interface3
+{
+}

--- a/tests/IntegrationTests/DI/Fixtures/definitions.php
+++ b/tests/IntegrationTests/DI/Fixtures/definitions.php
@@ -30,6 +30,7 @@ return array(
 
     'IntegrationTests\DI\Fixtures\Interface1' => DI\object('IntegrationTests\DI\Fixtures\Implementation1')
             ->scope(Scope::SINGLETON()),
+    'IntegrationTests\DI\Fixtures\Interface2' => DI\object('IntegrationTests\DI\Fixtures\Class3'),
 
     'namedDependency' => DI\object('IntegrationTests\DI\Fixtures\Class2'),
 

--- a/tests/IntegrationTests/DI/Issues/UninstantiableDefaultedConstructorParamTest.php
+++ b/tests/IntegrationTests/DI/Issues/UninstantiableDefaultedConstructorParamTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://mnapoli.github.io/PHP-DI/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace IntegrationTests\DI\Issues;
+
+use DI\ContainerBuilder;
+
+/**
+ * Test for constructor injection of parameters that are optional, and use an
+ * interface (or other uninstantiable) type hint.
+ *
+ * @coversNothing Because integration test
+ */
+class UninstantiableDefaultedConstructorParamTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIssue()
+    {
+        $builder = new ContainerBuilder();
+        $builder->useAutowiring(true);
+        $builder->useAnnotations(false);
+        $builder->addDefinitions(__DIR__ . '/../Fixtures/definitions.php');
+        $container = $builder->build();
+        $service = $container->get('IntegrationTests\DI\Fixtures\Interface2');
+
+        $this->assertInstanceOf('IntegrationTests\DI\Fixtures\Class3', $service);
+    }
+}


### PR DESCRIPTION
I keep encountering this issue, so I thought I'd have a crack at a fix. Unfortunately it wasn't as simple as it initially seemed, so this is only a test case to demonstrate the issue.

A common pattern we use in my workplace is to have defaulted constructor parameters. We also use interfaces for just about everything, so the class may look something like this:

``` php
class Foo implements FooInterface
{
    public function __construct(BarInterface $bar, BazInterface $baz = null)
    {
        if (null === $baz) {
            $baz = new Baz;
        }

        $this->bar = $bar;
        $this->baz = $baz;
    }

    // ...
}
```

So I would add definitions to our container something like:

``` php
return array(
    'BarInterface' => DI\object('Bar'),
    'FooInterface' => DI\object('Foo'),
);
```

Leaving out a definition for `BazInterface` beacuse we just want to use the default. Now when you request `FooInterface` from the container:

``` php
$container->get('FooInterface');
```

You get a nasty exception something like:

```
Entry BazInterface cannot be resolved: BazInterface is not instantiable
```

The _expected_ result is that `get()` returns an instance of `Foo` using the default value for `$baz`.

This PR includes a rough integration test that currently fails because of the issue mentioned above. It is not intended to be merged as it doesn't follow the style of your other tests, but should be good enough to aid in diagnosing the cause of the issue.

Thanks!
