### PR TITLE
PHP 5.3.3 support

### DIFF
--- a/src/DI/Definition/Resolver/ClassDefinitionResolver.php
+++ b/src/DI/Definition/Resolver/ClassDefinitionResolver.php
@@ -200,7 +200,11 @@ class ClassDefinitionResolver implements DefinitionResolver
                 $parameters
             );
 
-            $object = $classReflection->newInstanceArgs($args);
+            if (count($args) > 0) {
+                $object = $classReflection->newInstanceArgs($args);
+            } else {
+                $object = $classReflection->newInstance();
+            }
 
             $this->injectMethodsAndProperties($object, $classDefinition);
         } catch (NotFoundException $e) {


### PR DESCRIPTION
Added PHP 5.3.3 support by fixing a bug that would only appear with that version.

Now Travis runs the test for 5.3.3 so any other regression should be catched instantly.
