### PR TITLE
Added support for array-style callable to FunctionCallDefinitionDumper.

### DIFF
--- a/src/DI/Definition/Dumper/FunctionCallDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/FunctionCallDefinitionDumper.php
@@ -35,7 +35,12 @@ class FunctionCallDefinitionDumper implements DefinitionDumper
 
         $callable = $definition->getCallable();
 
-        $functionReflection = new \ReflectionFunction($callable);
+        if (is_array($callable)) {
+            list($object, $method) = $callable;
+            $functionReflection = new \ReflectionMethod($object, $method);
+        } else {
+            $functionReflection = new \ReflectionFunction($callable);
+        }
 
         $functionName = $this->getFunctionName($functionReflection);
         $parameters = $this->dumpMethodParameters($definition, $functionReflection);
@@ -90,6 +95,12 @@ class FunctionCallDefinitionDumper implements DefinitionDumper
                 'closure defined in %s at line %d',
                 $reflectionFunction->getFileName(),
                 $reflectionFunction->getStartLine()
+            );
+        } elseif ($reflectionFunction instanceof \ReflectionMethod) {
+            return sprintf(
+                '%s::%s',
+                $reflectionFunction->getDeclaringClass()->getName(),
+                $reflectionFunction->getName()
             );
         }
 

--- a/tests/UnitTests/DI/Definition/Dumper/FunctionCallDefinitionDumperTest.php
+++ b/tests/UnitTests/DI/Definition/Dumper/FunctionCallDefinitionDumperTest.php
@@ -36,4 +36,17 @@ class FunctionCallDefinitionDumperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($str, $dumper->dump($definition));
     }
+
+    public function testDumpWithMethod()
+    {
+        $object = new \SplDoublyLinkedList;
+        $definition = new FunctionCallDefinition([$object, 'push']);
+        $dumper = new FunctionCallDefinitionDumper();
+
+        $str = 'SplDoublyLinkedList::push(
+    $value = #UNDEFINED#
+)';
+
+        $this->assertEquals($str, $dumper->dump($definition));
+    }
 }


### PR DESCRIPTION
I had a definition failure occur with the following code:

``` php
$container->call([$object, 'injectDependencies']);
```

And the dumper failed with the error message:

`ReflectionFunction::__construct() expects parameter 1 to be string, array given`

This PR adds explicit report for array callables to the dumper.
