### PR TITLE
auto-register also the DI\FactoryInterface and DI\InvokerInterface

### DIFF
--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -85,6 +85,8 @@ class Container implements ContainerInteropInterface, ContainerInterface, Factor
         // Auto-register the container
         $this->singletonEntries['DI\Container'] = $this;
         $this->singletonEntries['DI\ContainerInterface'] = $this;
+        $this->singletonEntries['DI\FactoryInterface'] = $this;
+        $this->singletonEntries['DI\InvokerInterface'] = $this;
     }
 
     /**

--- a/tests/UnitTests/DI/ContainerTest.php
+++ b/tests/UnitTests/DI/ContainerTest.php
@@ -96,6 +96,26 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * The container auto-registers itself (with the factory interface)
+     */
+    public function testFactoryInterfaceIsRegistered()
+    {
+        $container = ContainerBuilder::buildDevContainer();
+
+        $this->assertSame($container, $container->get('DI\FactoryInterface'));
+    }
+
+    /**
+     * The container auto-registers itself (with the invoker interface)
+     */
+    public function testInvokerInterfaceIsRegistered()
+    {
+        $container = ContainerBuilder::buildDevContainer();
+
+        $this->assertSame($container, $container->get('DI\InvokerInterface'));
+    }
+
+    /**
      * @see https://github.com/mnapoli/PHP-DI/issues/126
      * @test
      */


### PR DESCRIPTION
In some cases complex factory service classes might need the container injected as a `DI\FactoryInterface` to be able to `make` other services.
These changes ease the configuration of the container.
