### PR TITLE
Obsolete 5.0

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -1,5 +1,15 @@
 # Change log
 
+## 5.0
+
+Improvements:
+
+- Lighter package: requires 4 less Composer dependencies by default
+
+BC breaks:
+
+- [#198](https://github.com/mnapoli/PHP-DI/issues/198) `ocramius/proxy-manager` is not installed by default anymore, you need to require it in `composer.json` if you want to use **lazy injection**
+
 ## 4.4
 
 Read the [news entry](news/13-php-di-4-4-released.md).

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,14 @@
         "doctrine/cache": "1.*",
         "mnapoli/phpdocreader": "~1.3",
         "myclabs/php-enum": "1.*",
-        "ocramius/proxy-manager": "~0.3",
         "container-interop/container-interop": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~4.0",
+        "ocramius/proxy-manager": "~0.3"
+    },
+    "suggest": {
+        "ocramius/proxy-manager": "Install it if you want to use lazy injection"
     },
     "extra": {
         "branch-alias": {

--- a/doc/lazy-injection.md
+++ b/doc/lazy-injection.md
@@ -77,6 +77,21 @@ $proxy->doSomething();
 
 You can define an object as "lazy". If it is injected as a dependency, then a proxy will be injected instead.
 
+### Installation
+
+Lazy injection requires the [Ocramius/ProxyManager](https://github.com/Ocramius/ProxyManager) library. This library is not installed by default with PHP-DI, you need to require it in your `composer.json`:
+
+```json
+{
+    "require": {
+        "mnapoli/php-di": "*",
+        "ocramius/proxy-manager": "~0.3"
+    }
+}
+```
+
+Then run `composer update`.
+
 ### Annotations
 
 ```php

--- a/doc/migration/5.0.md
+++ b/doc/migration/5.0.md
@@ -1,0 +1,28 @@
+---
+template: documentation
+---
+
+# Migrating from PHP-DI 4.x to 5.0
+
+PHP-DI 5.0 is a new major version that comes with backward compatibility breaks.
+
+This guide will (hopefully) help you migrate from a 4.x version to 5.0.
+
+## Lazy injection
+
+The [Ocramius/ProxyManager](https://github.com/Ocramius/ProxyManager) package comes with a lot of dependencies and is only useful only for lazy injection.
+
+This package is not installed by default in v5.0 in order to lighten PHP-DI's dependencies.
+
+If you want to use **lazy injection**, you now need to install it explicitly:
+
+```json
+{
+    "require": {
+        "mnapoli/php-di": "~5.0",
+        "ocramius/proxy-manager": "~0.3"
+    }
+}
+```
+
+Read more in [#198](https://github.com/mnapoli/PHP-DI/issues/198) or in the [Lazy Injection documentation](../lazy-injection.md).


### PR DESCRIPTION
This is the pull request for the future major version 5.0.
- [x] #198 Less Composer dependencies: make Ocramius/ProxyManager (lazy injection) optional

Before release:
- [ ] Update the changelog
- [ ] Update the migration guide
- [ ] Remove the branch alias in `composer.json`
