### PR TITLE
Make unit tests pass in Windows

### DIFF
--- a/src/DI/Definition/Dumper/ArrayDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/ArrayDefinitionDumper.php
@@ -60,6 +60,6 @@ class ArrayDefinitionDumper implements DefinitionDumper
 
     private function indent($str)
     {
-        return str_replace("\n", "\n    ", $str);
+        return str_replace(PHP_EOL, PHP_EOL . "    ", $str);
     }
 }

--- a/src/DI/Definition/Dumper/EnvironmentVariableDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/EnvironmentVariableDefinitionDumper.php
@@ -35,7 +35,7 @@ class EnvironmentVariableDefinitionDumper implements DefinitionDumper
         }
 
         $str = "    variable = " . $definition->getVariableName();
-        $str .= "\n    optional = " . ($definition->isOptional() ? 'yes' : 'no');
+        $str .= PHP_EOL . "    optional = " . ($definition->isOptional() ? 'yes' : 'no');
 
         if ($definition->isOptional()) {
             $defaultValue = $definition->getDefaultValue();
@@ -47,17 +47,17 @@ class EnvironmentVariableDefinitionDumper implements DefinitionDumper
                 $defaultValueStr = var_export($defaultValue, true);
             }
 
-            $str .= "\n    default = " . $defaultValueStr;
+            $str .= PHP_EOL . "    default = " . $defaultValueStr;
         }
 
         return sprintf(
-            "Environment variable (\n%s\n)",
+            "Environment variable (" . PHP_EOL . "%s" . PHP_EOL . ")",
             $str
         );
     }
 
     private function indent($str)
     {
-        return str_replace("\n", "\n    ", $str);
+        return str_replace(PHP_EOL, PHP_EOL . "    ", $str);
     }
 }

--- a/src/DI/Definition/Dumper/ObjectDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/ObjectDefinitionDumper.php
@@ -49,10 +49,10 @@ class ObjectDefinitionDumper implements DefinitionDumper
         $str = sprintf('    class = %s%s', $warning, $className);
 
         // Scope
-        $str .= "\n    scope = " . $definition->getScope();
+        $str .= PHP_EOL . "    scope = " . $definition->getScope();
 
         // Lazy
-        $str .= "\n    lazy = " . var_export($definition->isLazy(), true);
+        $str .= PHP_EOL . "    lazy = " . var_export($definition->isLazy(), true);
 
         if ($classExist) {
             // Constructor
@@ -65,7 +65,7 @@ class ObjectDefinitionDumper implements DefinitionDumper
             $str .= $this->dumpMethods($className, $definition);
         }
 
-        return sprintf("Object (\n%s\n)", $str);
+        return sprintf("Object (" . PHP_EOL . "%s" . PHP_EOL . ")", $str);
     }
 
     private function dumpConstructor($className, ObjectDefinition $definition)
@@ -77,7 +77,7 @@ class ObjectDefinitionDumper implements DefinitionDumper
         if ($constructorInjection !== null) {
             $parameters = $this->dumpMethodParameters($className, $constructorInjection);
 
-            $str .= sprintf("\n    __construct(\n        %s\n    )", $parameters);
+            $str .= sprintf(PHP_EOL . "    __construct(" . PHP_EOL . "        %s" . PHP_EOL . "    )", $parameters);
         }
 
         return $str;
@@ -95,7 +95,7 @@ class ObjectDefinitionDumper implements DefinitionDumper
                 $valueStr = var_export($value, true);
             }
 
-            $str .= sprintf("\n    $%s = %s", $propertyInjection->getPropertyName(), $valueStr);
+            $str .= sprintf(PHP_EOL . "    $%s = %s", $propertyInjection->getPropertyName(), $valueStr);
         }
 
         return $str;
@@ -108,7 +108,7 @@ class ObjectDefinitionDumper implements DefinitionDumper
         foreach ($definition->getMethodInjections() as $methodInjection) {
             $parameters = $this->dumpMethodParameters($className, $methodInjection);
 
-            $str .= sprintf("\n    %s(\n        %s\n    )", $methodInjection->getMethodName(), $parameters);
+            $str .= sprintf(PHP_EOL . "    %s(" . PHP_EOL . "        %s" . PHP_EOL . "    )", $methodInjection->getMethodName(), $parameters);
         }
 
         return $str;

--- a/src/DI/Definition/Dumper/ValueDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/ValueDefinitionDumper.php
@@ -37,7 +37,7 @@ class ValueDefinitionDumper implements DefinitionDumper
         var_dump($definition->getValue());
 
         return sprintf(
-            "Value (\n    %s\n)",
+            "Value (" . PHP_EOL . "    %s" . PHP_EOL . ")",
             trim(ob_get_clean())
         );
     }

--- a/src/DI/Definition/Exception/DefinitionException.php
+++ b/src/DI/Definition/Exception/DefinitionException.php
@@ -22,7 +22,7 @@ class DefinitionException extends \Exception
     public static function create(Definition $definition, $message)
     {
         return new self(sprintf(
-            "%s\nFull definition:\n%s",
+            "%s" . PHP_EOL . "Full definition:" . PHP_EOL . "%s",
             $message,
             Debug::dumpDefinition($definition)
         ));


### PR DESCRIPTION
Replace all "\n" by PHP_EOL to make unit tests pass in Windows.