### PR TITLE
Add replace clause to composer.json for mnapoli package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
         "doctrine/annotations": "~1.2",
         "ocramius/proxy-manager": "~1.0"
     },
+    "replace": {
+      "mnapoli/php-di": "*"
+    },
     "suggest": {
         "doctrine/cache": "Install it if you want to use the cache (version ~1.0)",
         "doctrine/annotations": "Install it if you want to use annotations (version ~1.2)",


### PR DESCRIPTION
Without this replace clause, it's possible to install both the `mnapoli/php-di` and `php-di/php-di` packages in the same project. Here is a sample `composer.json` which demonstrates this problem:
```
{
    "name": "nstory/tstprj",
    "require": {
      "php-di/php-di": "*",
      "mnapoli/php-di": "*"
    }
}
```

Running `composer update` with the above will create both `vendor/mnapoli/php-di` and `vendor/php-di/php-di`.