### PR TITLE
Improve exception message on unknown method argument

### DIFF
--- a/src/DI/Definition/Helper/ClassDefinitionHelper.php
+++ b/src/DI/Definition/Helper/ClassDefinitionHelper.php
@@ -12,6 +12,7 @@ namespace DI\Definition\Helper;
 use DI\Definition\ClassDefinition;
 use DI\Definition\ClassDefinition\MethodInjection;
 use DI\Definition\ClassDefinition\PropertyInjection;
+use DI\Definition\Exception\DefinitionException;
 use DI\Scope;
 
 /**
@@ -237,6 +238,7 @@ class ClassDefinitionHelper implements DefinitionHelper
      * @param ClassDefinition $definition
      * @param string          $method
      * @param array           $parameters
+     * @throws DefinitionException
      * @return array
      */
     private function fixParameters(ClassDefinition $definition, $method, $parameters)
@@ -247,7 +249,11 @@ class ClassDefinitionHelper implements DefinitionHelper
             // Parameter indexed by the parameter name, we reindex it with its position
             if (is_string($index)) {
                 $callable = array($definition->getClassName(), $method);
-                $reflectionParameter = new \ReflectionParameter($callable, $index);
+                try {
+                    $reflectionParameter = new \ReflectionParameter($callable, $index);
+                } catch (\ReflectionException $e) {
+                    throw DefinitionException::create($definition, "Parameter with name '$index' could not be found.");
+                }
 
                 $index = $reflectionParameter->getPosition();
             }

--- a/tests/UnitTest/Definition/Helper/ClassDefinitionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/ClassDefinitionHelperTest.php
@@ -151,7 +151,7 @@ class ClassDefinitionHelperTest extends \PHPUnit_Framework_TestCase
     {
         $helper = new ClassDefinitionHelper();
         $helper->methodParameter('__construct', 'wrongName', 42);
-        $this->setExpectedExceptionRegExp('DI\Definition\Exception\DefinitionException', "/^Parameter with name 'wrongName' could not be found./");
+        $this->setExpectedException('DI\Definition\Exception\DefinitionException', "Parameter with name 'wrongName' could not be found.");
         $helper->getDefinition('DI\Test\UnitTest\Definition\Helper\Fixtures\Class1');
     }
 }

--- a/tests/UnitTest/Definition/Helper/ClassDefinitionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/ClassDefinitionHelperTest.php
@@ -151,7 +151,7 @@ class ClassDefinitionHelperTest extends \PHPUnit_Framework_TestCase
     {
         $helper = new ClassDefinitionHelper();
         $helper->methodParameter('__construct', 'wrongName', 42);
-        $this->setExpectedExceptionRegExp(DefinitionException::class, "/^Parameter with name 'wrongName' could not be found./");
+        $this->setExpectedExceptionRegExp('DI\Definition\Exception\DefinitionException', "/^Parameter with name 'wrongName' could not be found./");
         $helper->getDefinition('DI\Test\UnitTest\Definition\Helper\Fixtures\Class1');
     }
 }

--- a/tests/UnitTest/Definition/Helper/ClassDefinitionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/ClassDefinitionHelperTest.php
@@ -10,6 +10,7 @@
 namespace DI\Test\UnitTest\Definition\Helper;
 
 use DI\Definition\ClassDefinition\MethodInjection;
+use DI\Definition\Exception\DefinitionException;
 use DI\Definition\Helper\ClassDefinitionHelper;
 use DI\Scope;
 
@@ -144,5 +145,13 @@ class ClassDefinitionHelperTest extends \PHPUnit_Framework_TestCase
 
         // Check that injections are in the good order (matching the real parameters order)
         $this->assertEquals(array('val1', 'val2'), $methodInjection->getParameters());
+    }
+
+    public function testErrorMessageOnUnknownParameter()
+    {
+        $helper = new ClassDefinitionHelper();
+        $helper->methodParameter('__construct', 'wrongName', 42);
+        $this->setExpectedExceptionRegExp(DefinitionException::class, "/^Parameter with name 'wrongName' could not be found./");
+        $helper->getDefinition('DI\Test\UnitTest\Definition\Helper\Fixtures\Class1');
     }
 }


### PR DESCRIPTION
Hi,

Sometimes when class implementation changes and container definition is out of date it really gets hard to debug where is the issue. Currently exception message contains this:

```
The parameter specified by its name could not be found
```

Also it throws `\ReflectionException` currently. There is nothing in the stack trace which can help in finding invalid definition as well.

This PR improves this situation by:

* Adding name of the argument in the exception message
* Throwing `DefinitionException` which makes more sense since we actually have invalid container definition.