### PR TITLE
No error if object definition extends an incompatible definition

### DIFF
--- a/src/DI/Definition/ObjectDefinition.php
+++ b/src/DI/Definition/ObjectDefinition.php
@@ -215,11 +215,7 @@ class ObjectDefinition implements Definition, CacheableDefinition, HasSubDefinit
     public function setSubDefinition(Definition $definition)
     {
         if (! $definition instanceof ObjectDefinition) {
-            throw new DefinitionException(sprintf(
-                "Container entry '%s' extends entry '%s' which is not an object",
-                $this->getName(),
-                $definition->getName()
-            ));
+            return;
         }
 
         // The current prevails

--- a/tests/UnitTest/Definition/ObjectDefinitionTest.php
+++ b/tests/UnitTest/Definition/ObjectDefinitionTest.php
@@ -55,13 +55,14 @@ class ObjectDefinitionTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException \DI\Definition\Exception\DefinitionException
-     * @expectedExceptionMessage Container entry 'foo' extends entry 'bar' which is not an object
      */
-    public function should_only_accept_compatible_subdefinitions()
+    public function should_only_merge_with_object_subdefinitions()
     {
         $definition = new ObjectDefinition('foo', 'bar');
         $definition->setSubDefinition(new ValueDefinition('bar', 'Hello'));
+
+        // Unchanged definition
+        $this->assertEquals(new ObjectDefinition('foo', 'bar'), $definition);
     }
 
     /**


### PR DESCRIPTION
Fix #300: if an object definition "extends" an incompatible definition, ignore it instead of throwing an exception.