### PR TITLE
Fixed php-di#306 modifying ParameterResolver and ObjectCreator

### DIFF
--- a/src/DI/Definition/Resolver/ObjectCreator.php
+++ b/src/DI/Definition/Resolver/ObjectCreator.php
@@ -151,9 +151,9 @@ class ObjectCreator implements DefinitionResolver
             );
 
             if (count($args) > 0) {
-                $object = $classReflection->newInstanceArgs($args);
+                $object = @$classReflection->newInstanceArgs($args);
             } else {
-                $object = $classReflection->newInstance();
+                $object = @$classReflection->newInstance();
             }
 
             $this->injectMethodsAndProperties($object, $definition);
@@ -168,6 +168,14 @@ class ObjectCreator implements DefinitionResolver
                 "Entry %s cannot be resolved: %s",
                 $definition->getName(),
                 $e->getMessage()
+            ));
+        }
+
+        if(is_object($object) === false) {
+            throw new DependencyException(sprintf(
+                "Entry %s cannot be resolved, %s could not be constructed",
+                $definition->getName(),
+                $classReflection->getName()
             ));
         }
 

--- a/src/DI/Definition/Resolver/ObjectCreator.php
+++ b/src/DI/Definition/Resolver/ObjectCreator.php
@@ -151,9 +151,9 @@ class ObjectCreator implements DefinitionResolver
             );
 
             if (count($args) > 0) {
-                $object = @$classReflection->newInstanceArgs($args);
+                $object = $classReflection->newInstanceArgs($args);
             } else {
-                $object = @$classReflection->newInstance();
+                $object = $classReflection->newInstance();
             }
 
             $this->injectMethodsAndProperties($object, $definition);
@@ -173,7 +173,7 @@ class ObjectCreator implements DefinitionResolver
 
         if(is_object($object) === false) {
             throw new DependencyException(sprintf(
-                "Entry %s cannot be resolved, %s could not be constructed",
+                "Entry %s cannot be resolved: %s could not be constructed",
                 $definition->getName(),
                 $classReflection->getName()
             ));

--- a/src/DI/Definition/Resolver/ParameterResolver.php
+++ b/src/DI/Definition/Resolver/ParameterResolver.php
@@ -59,10 +59,10 @@ class ParameterResolver
         foreach ($functionReflection->getParameters() as $index => $parameter) {
             if (array_key_exists($parameter->getName(), $parameters)) {
                 // Look in the $parameters array
-                $value = $parameters[$parameter->getName()];
+                $value = &$parameters[$parameter->getName()];
             } elseif (array_key_exists($index, $definitionParameters)) {
                 // Look in the definition
-                $value = $definitionParameters[$index];
+                $value = &$definitionParameters[$index];
             } else {
                 // If the parameter is optional and wasn't specified, we take its default value
                 if ($parameter->isOptional()) {
@@ -88,7 +88,7 @@ class ParameterResolver
                 }
             }
 
-            $args[] = $value;
+            $args[] = &$value;
         }
 
         return $args;

--- a/tests/UnitTest/ContainerGetTest.php
+++ b/tests/UnitTest/ContainerGetTest.php
@@ -135,4 +135,14 @@ class ContainerGetTest extends \PHPUnit_Framework_TestCase
         $container = ContainerBuilder::buildDevContainer();
         $container->get(new stdClass());
     }
+
+    /**
+     * Tests a class can be initialized with a parameter passed by reference
+     */
+    public function testPassByReferenceParameter()
+    {
+        $container = ContainerBuilder::buildDevContainer();
+        $object = $container->get('DI\Test\UnitTest\Fixtures\PassByReferenceDependency');
+        $this->assertInstanceOf('DI\Test\UnitTest\Fixtures\PassByReferenceDependency', $object);
+    }
 }

--- a/tests/UnitTest/ContainerMakeTest.php
+++ b/tests/UnitTest/ContainerMakeTest.php
@@ -123,4 +123,26 @@ class ContainerMakeTest extends \PHPUnit_Framework_TestCase
         $container = ContainerBuilder::buildDevContainer();
         $container->make(new stdClass());
     }
+
+    /**
+     * Tests a dependency can be made when a dependency is passed by reference
+     */
+    public function testPassByReferenceParameter()
+    {
+        $container = ContainerBuilder::buildDevContainer();
+        $container->make('DI\Test\UnitTest\Fixtures\PassByReferenceDependency');
+    }
+
+    /**
+     * Tests the parameter can be provided by reference
+     */
+    public function testProvidedPassByReferenceParameter()
+    {
+        $object = new stdClass();
+        $container = ContainerBuilder::buildDevContainer();
+        $fetched = $container->make('DI\Test\UnitTest\Fixtures\PassByReferenceDependency', [
+            'object' => &$object
+        ]);
+        $this->assertEquals('bar', $object->foo);
+    }
 }

--- a/tests/UnitTest/Fixtures/PassByReferenceDependency.php
+++ b/tests/UnitTest/Fixtures/PassByReferenceDependency.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace DI\Test\UnitTest\Fixtures;
+
+use stdClass;
+
+class PassByReferenceDependency
+{
+	public function __construct(stdClass &$object)
+	{
+		$object->foo = 'bar';
+	}
+}


### PR DESCRIPTION
`DI\Definition\Resolver\ParameterResolver` now handles the value by reference

`DI\Definition\Resolver\ObjectCreator` throws a `DI\DependencyException` if an object could not be created by `ReflectionClass` via `newInstanceArgs()` or `newInstance()`