### PR TITLE
Resolve/instantiate factories using the container

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -1,5 +1,11 @@
 # Change log
 
+## 5.1
+
+Improvements:
+
+- [#308](https://github.com/PHP-DI/PHP-DI/pull/308): Instantiate factories using the container (`DI\factory(['FooFactory', 'create'])`)
+
 ## 5.0
 
 This is the complete change log. You can also read the [migration guide](doc/migration/5.0.md) for upgrading, or [the news article](news/15-php-di-5-0-released.md) for a nicer introduction to this new version.

--- a/doc/definition-overriding.md
+++ b/doc/definition-overriding.md
@@ -142,3 +142,5 @@ return [
 ```
 
 The first parameter of the callable is the instance returned by the previous definition (i.e. the one we wish to decorate), the second parameter is the container.
+
+You can use `DI\decorate()` over any kind of previous definition (factory but also object, value, environment variable, …).

--- a/doc/php-definitions.md
+++ b/doc/php-definitions.md
@@ -116,22 +116,26 @@ You can also use a factory class - as an example, let's assume you have a simple
 ```php
 class FooFactory
 {
-    public function create($container) // (note: $container can be omitted if not needed)
+    // note: $container can be omitted if not needed
+    public function create($container)
     {
         return new Foo();
     }
 }
 ```
 
-You can choose to eagerly load `FooFactory`, at definition time:
+You can choose to eagerly load `FooFactory` at definition time:
 
 ```php
 return [
-    Foo::class => DI\factory([new FooFactory(), 'create']),
+    // not recommended!
+    Foo::class => DI\factory([new FooFactory, 'create']),
 ];
 ```
 
-Or, if `FooFactory::create()` were a static method, you could use this definition:
+But the factory will be created on every request (`new FooFactory`) even if not used. Additionally with this method it's harder to pass dependencies in the factory.
+
+The recommended solution is let the container create the factory:
 
 ```php
 return [
@@ -139,7 +143,16 @@ return [
 ];
 ```
 
-(Note that support for lazy creation of a factory instance is planned for a future release.)
+This configuration is equivalent to the following code:
+
+```php
+$factory = $container->get(FooFactory::class);
+return $factory->create();
+```
+
+Please note that `create()` can also be a static method. In that case PHP-DI will not try to instantiate the factory: it will instead simply call `FooFactory::create()` statically.
+
+#### Decoration
 
 When using a system with multiple definition files, you can override a previous entry using a decorator:
 
@@ -151,6 +164,8 @@ return [
     }),
 ];
 ```
+
+Please read the [definition overriding guide](definition-overriding.md) to learn more about this.
 
 ### Objects
 

--- a/src/DI/Definition/Resolver/FactoryResolver.php
+++ b/src/DI/Definition/Resolver/FactoryResolver.php
@@ -13,6 +13,8 @@ use DI\Definition\Exception\DefinitionException;
 use DI\Definition\FactoryDefinition;
 use DI\Definition\Definition;
 use Interop\Container\ContainerInterface;
+use Invoker\Invoker;
+use Invoker\ParameterResolver\NumericArrayResolver;
 
 /**
  * Resolves a factory definition to a value.
@@ -26,6 +28,11 @@ class FactoryResolver implements DefinitionResolver
      * @var ContainerInterface
      */
     private $container;
+
+    /**
+     * @var Invoker|null
+     */
+    private $invoker;
 
     /**
      * The resolver needs a container. This container will be passed to the factory as a parameter
@@ -60,7 +67,11 @@ class FactoryResolver implements DefinitionResolver
             ));
         }
 
-        return call_user_func($callable, $this->container);
+        if (! $this->invoker) {
+            $this->invoker = new Invoker(new NumericArrayResolver, $this->container);
+        }
+
+        return $this->invoker->call($callable, [$this->container]);
     }
 
     /**


### PR DESCRIPTION
Fix #179, start of #197

```php
return [
    'Foo' => DI\factory(['FooFactory', 'create']),
];
```

With this configuration, `FooFactory` will be created by the container.

Performance tests and profiling showed a performance regression of up to +40% (worst case) to resolve factories (after working on optimizations). I think this is acceptable given it's only a small part of the whole container (the total performance regression should be negligible, especially since 5.1 already brings good improvements to compensate).

TODO:

- [ ] documentation
- [ ] changelog