### PR TITLE
Provide faster implementation of ArrayCache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "phpunit/phpunit": "~4.5",
         "mnapoli/phpunit-easymock": "~0.1.4",
-        "doctrine/cache": "~1.0",
+        "doctrine/cache": "~1.4",
         "doctrine/annotations": "~1.2",
         "ocramius/proxy-manager": "~1.0"
     },
@@ -36,7 +36,7 @@
         "mnapoli/php-di": "*"
     },
     "suggest": {
-        "doctrine/cache": "Install it if you want to use the cache (version ~1.0)",
+        "doctrine/cache": "Install it if you want to use the cache (version ~1.4)",
         "doctrine/annotations": "Install it if you want to use annotations (version ~1.2)",
         "ocramius/proxy-manager": "Install it if you want to use lazy injection (version ~1.0)"
     }

--- a/src/DI/Cache/ArrayCache.php
+++ b/src/DI/Cache/ArrayCache.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Cache;
+
+use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\ClearableCache;
+use Doctrine\Common\Cache\FlushableCache;
+
+/**
+ * Simple implementation of a cache based on an array.
+ *
+ * This implementation can be used instead of Doctrine's ArrayCache for
+ * better performances (because simpler implementation).
+ *
+ * The code is based on Doctrine's ArrayCache provider:
+ * @see \Doctrine\Common\Cache\ArrayCache
+ * @link   www.doctrine-project.org
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author Jonathan Wage <jonwage@gmail.com>
+ * @author Roman Borschel <roman@code-factory.org>
+ * @author David Abdemoulaie <dave@hobodave.com>
+ */
+class ArrayCache implements Cache, FlushableCache, ClearableCache
+{
+    /**
+     * @var array $data
+     */
+    private $data = [];
+
+    public function fetch($id)
+    {
+        return $this->contains($id) ? $this->data[$id] : false;
+    }
+
+    public function contains($id)
+    {
+        // isset() is required for performance optimizations, to avoid unnecessary function calls to array_key_exists.
+        return isset($this->data[$id]) || array_key_exists($id, $this->data);
+    }
+
+    public function save($id, $data, $lifeTime = 0)
+    {
+        $this->data[$id] = $data;
+
+        return true;
+    }
+
+    public function delete($id)
+    {
+        unset($this->data[$id]);
+
+        return true;
+    }
+
+    public function getStats()
+    {
+        return null;
+    }
+
+    public function flushAll()
+    {
+        $this->data = array();
+
+        return true;
+    }
+
+    public function deleteAll()
+    {
+        return $this->flushAll();
+    }
+}

--- a/tests/UnitTest/Cache/ArrayCacheTest.php
+++ b/tests/UnitTest/Cache/ArrayCacheTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace DI\Test\UnitTest\Cache;
+
+use DI\Cache\ArrayCache;
+
+/**
+ * Copy of Doctrine's test.
+ */
+class ArrayCacheTest extends CacheTest
+{
+    protected function getCacheDriver()
+    {
+        return new ArrayCache();
+    }
+}

--- a/tests/UnitTest/Cache/CacheTest.php
+++ b/tests/UnitTest/Cache/CacheTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace DI\Test\UnitTest\Cache;
+
+use ArrayObject;
+
+/**
+ * Copy of Doctrine's test.
+ */
+abstract class CacheTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideCrudValues
+     */
+    public function testBasicCrudOperations($value)
+    {
+        $cache = $this->getCacheDriver();
+
+        // Test saving a value, checking if it exists, and fetching it back
+        $this->assertTrue($cache->save('key', 'value'));
+        $this->assertTrue($cache->contains('key'));
+        $this->assertEquals('value', $cache->fetch('key'));
+
+        // Test updating the value of a cache entry
+        $this->assertTrue($cache->save('key', 'value-changed'));
+        $this->assertTrue($cache->contains('key'));
+        $this->assertEquals('value-changed', $cache->fetch('key'));
+
+        // Test deleting a value
+        $this->assertTrue($cache->delete('key'));
+        $this->assertFalse($cache->contains('key'));
+    }
+
+
+    public function provideCrudValues()
+    {
+        return array(
+            'array' => array(array('one', 2, 3.0)),
+            'string' => array('value'),
+            'integer' => array(1),
+            'float' => array(1.5),
+            'object' => array(new ArrayObject()),
+            'null' => array(null),
+        );
+    }
+
+    public function testDeleteAll()
+    {
+        $cache = $this->getCacheDriver();
+
+        $this->assertTrue($cache->save('key1', 1));
+        $this->assertTrue($cache->save('key2', 2));
+        $this->assertTrue($cache->deleteAll());
+        $this->assertFalse($cache->contains('key1'));
+        $this->assertFalse($cache->contains('key2'));
+    }
+
+    public function testFlushAll()
+    {
+        $cache = $this->getCacheDriver();
+
+        $this->assertTrue($cache->save('key1', 1));
+        $this->assertTrue($cache->save('key2', 2));
+        $this->assertTrue($cache->flushAll());
+        $this->assertFalse($cache->contains('key1'));
+        $this->assertFalse($cache->contains('key2'));
+    }
+
+    public function testFetchMissShouldReturnFalse()
+    {
+        $cache = $this->getCacheDriver();
+
+        /* Ensure that caches return boolean false instead of null on a fetch
+         * miss to be compatible with ORM integration.
+         */
+        $result = $cache->fetch('nonexistent_key');
+
+        $this->assertFalse($result);
+        $this->assertNotNull($result);
+    }
+
+    /**
+     * Check to see that, even if the user saves a value that can be interpreted as false,
+     * the cache adapter will still recognize its existence there.
+     *
+     * @dataProvider falseCastedValuesProvider
+     */
+    public function testFalseCastedValues($value)
+    {
+        $cache = $this->getCacheDriver();
+
+        $this->assertTrue($cache->save('key', $value));
+        $this->assertTrue($cache->contains('key'));
+        $this->assertEquals($value, $cache->fetch('key'));
+    }
+
+    /**
+     * The following values get converted to FALSE if you cast them to a boolean.
+     * @see http://php.net/manual/en/types.comparisons.php
+     */
+    public function falseCastedValuesProvider()
+    {
+        return array(
+            array(false),
+            array(null),
+            array(array()),
+            array('0'),
+            array(0),
+            array(0.0),
+            array('')
+        );
+    }
+
+    /**
+     * Check to see that objects are correctly serialized and unserialized by the cache
+     * provider.
+     */
+    public function testCachedObject()
+    {
+        $cache = $this->getCacheDriver();
+        $cache->deleteAll();
+        $obj = new \stdClass();
+        $obj->foo = "bar";
+        $obj2 = new \stdClass();
+        $obj2->bar = "foo";
+        $obj2->obj = $obj;
+        $obj->obj2 = $obj2;
+        $cache->save("obj", $obj);
+
+        $fetched = $cache->fetch("obj");
+
+        $this->assertInstanceOf("stdClass", $obj);
+        $this->assertInstanceOf("stdClass", $obj->obj2);
+        $this->assertInstanceOf("stdClass", $obj->obj2->obj);
+        $this->assertEquals("bar", $fetched->foo);
+        $this->assertEquals("foo", $fetched->obj2->bar);
+    }
+
+    /**
+     * @return \Doctrine\Common\Cache\CacheProvider
+     */
+    abstract protected function getCacheDriver();
+}


### PR DESCRIPTION
See #296

Provide an `ArrayCache` implementation simpler (and faster) than Doctrine's own ArrayCache. This implementation doesn't have namespaces.

Profiling the most simple check (creating 1 object) shows a 12% performance improvements (in total time). I guess in production there wouldn't be really any difference since this cache shouldn't be used there, but in some use cases it could help. And in micro-benchmarks (that seem to be very popular, even  if not realistic) it makes a difference, so let's play the game…