### PR TITLE
Support references to arbitrary container entries for factory definitions

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -1,5 +1,15 @@
 # Change log
 
+## 5.2
+
+Improvements:
+
+- [#272](https://github.com/PHP-DI/PHP-DI/issues/272): Support 'Class::method' syntax for callables
+
+Bugfixes:
+
+- [#321](https://github.com/PHP-DI/PHP-DI/pull/321): Allow factory definitions to reference arbitrary container entries as callables
+
 ## 5.1
 
 Read the [news entry](news/16-php-di-5-1-released.md).

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=5.4.0",
         "container-interop/container-interop": "~1.0",
-        "php-di/invoker": "^1.0.1",
+        "php-di/invoker": "^1.1",
         "php-di/phpdoc-reader": "~2.0"
     },
     "require-dev": {

--- a/doc/php-definitions.md
+++ b/doc/php-definitions.md
@@ -100,7 +100,7 @@ Factories are PHP callables that return the instance. It allows to define an obj
 Here is an example using a closure:
 
 ```php
-use \Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface;
 
 return [
     'Foo' => function (ContainerInterface $c) {
@@ -143,6 +143,14 @@ return [
 ];
 ```
 
+Alternatively, you can write it as follows:
+
+```php
+return [
+    Foo::class => DI\factory('Namespace\To\FooFactory::create'),
+];
+```
+
 This configuration is equivalent to the following code:
 
 ```php
@@ -153,7 +161,8 @@ return $factory->create();
 Please note:
 
 - if `create()` is a **static** method then the object will not be created: `FooFactory::create()` will be called statically (as one would expect)
-- you can set any container entry name in the array, e.g. `factory(['foo_bar_baz', 'create'])`, allowing you to configure `foo_bar_baz` and its dependencies like any other object
+- you can set any container entry name in the array, e.g. `DI\factory(['foo_bar_baz', 'create'])` (or alternatively: `DI\factory('foo_bar_baz::create')`), allowing you to configure `foo_bar_baz` and its dependencies like any other object
+- as a factory can be any PHP callable, you can use invocable objects, too: `DI\factory(InvocableFooFactory::class)` (or alternatively: `DI\factory('invocable_foo_factory')`, if it's defined in the container)
 
 #### Decoration
 

--- a/tests/UnitTest/Definition/Resolver/FactoryResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/FactoryResolverTest.php
@@ -12,6 +12,8 @@ namespace DI\Test\UnitTest\Definition\Resolver;
 use DI\Definition\FactoryDefinition;
 use DI\Definition\Resolver\FactoryResolver;
 use EasyMock\EasyMock;
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_MockObject_MockObject;
 
 /**
  * @covers \DI\Definition\Resolver\FactoryResolver
@@ -19,23 +21,66 @@ use EasyMock\EasyMock;
 class FactoryResolverTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * @var ContainerInterface|PHPUnit_Framework_MockObject_MockObject
+     */
+    private $container;
+
+    /**
      * @var FactoryResolver
      */
     private $resolver;
 
     public function setUp()
     {
-        $container = EasyMock::mock('Interop\Container\ContainerInterface');
-        $this->resolver = new FactoryResolver($container);
+        $this->container = EasyMock::mock('Interop\Container\ContainerInterface');
+        $this->resolver = new FactoryResolver($this->container);
     }
 
     public function provideCallables()
     {
         return [
-            'closure'        => [function () { return 'bar'; }],
-            'string'         => [__NAMESPACE__ . '\FactoryDefinitionResolver_test'],
-            'array'          => [[new FactoryDefinitionResolverTestClass(), 'foo']],
-            'invokableClass' => [new FactoryDefinitionResolverCallableClass()],
+            'closure'               => [function () { return 'bar'; }],
+            'functionString'        => [__NAMESPACE__ . '\FactoryDefinitionResolver_test'],
+            'invokableObject'       => [new FactoryDefinitionResolverCallableClass],
+            '[object, method]'      => [[new FactoryDefinitionResolverTestClass, 'foo']],
+            '[Class, staticMethod]' => [[__NAMESPACE__ . '\FactoryDefinitionResolverTestClass', 'staticFoo']],
+            'Class::staticMethod'   => [__NAMESPACE__ . '\FactoryDefinitionResolverTestClass::staticFoo'],
+        ];
+    }
+
+    public function provideContainerCallables()
+    {
+        return [
+            'closureEntry' => [
+                'closure',
+                'closure',
+                function () { return 'bar'; },
+            ],
+            'invokableEntry' => [
+                'invokable',
+                'invokable',
+                new FactoryDefinitionResolverCallableClass,
+            ],
+            '[classEntry, method]' => [
+                [__NAMESPACE__ . '\FactoryDefinitionResolverTestClass', 'foo'],
+                __NAMESPACE__ . '\FactoryDefinitionResolverTestClass',
+                new FactoryDefinitionResolverTestClass,
+            ],
+            'classEntry::method' => [
+                __NAMESPACE__ . '\FactoryDefinitionResolverTestClass::foo',
+                __NAMESPACE__ . '\FactoryDefinitionResolverTestClass',
+                new FactoryDefinitionResolverTestClass,
+            ],
+            '[arbitraryClassEntry, method]' => [
+                ['some.class', 'foo'],
+                'some.class',
+                new FactoryDefinitionResolverTestClass,
+            ],
+            'arbitraryClassEntry::method' => [
+                'some.class::foo',
+                'some.class',
+                new FactoryDefinitionResolverTestClass,
+            ],
         ];
     }
 
@@ -54,6 +99,28 @@ class FactoryResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @dataProvider provideContainerCallables
+     */
+    public function should_resolve_callables_from_container($callable, $containerName, $containerEntry)
+    {
+        EasyMock::mock($this->container, [
+            'has' => function ($name) use ($containerName) {
+                return $name === $containerName;
+            },
+            'get' => function ($name) use ($containerName, $containerEntry) {
+                return $name === $containerName ? $containerEntry : false;
+            },
+        ]);
+
+        $definition = new FactoryDefinition('foo', $callable);
+
+        $value = $this->resolver->resolve($definition);
+
+        $this->assertEquals('bar', $value);
+    }
+
+    /**
+     * @test
      * @expectedException \DI\Definition\Exception\DefinitionException
      * @expectedExceptionMessage The factory definition "foo" is not callable
      */
@@ -63,10 +130,32 @@ class FactoryResolverTest extends \PHPUnit_Framework_TestCase
 
         $this->resolver->resolve($definition);
     }
+
+    /**
+     * @test
+     * @expectedException \DI\Definition\Exception\DefinitionException
+     * @expectedExceptionMessage The factory definition "foo" is not callable
+     */
+    public function should_throw_if_the_factory_is_not_callable_container_entry()
+    {
+        EasyMock::mock($this->container, [
+            'has' => true,
+            'get' => 42,
+        ]);
+
+        $definition = new FactoryDefinition('foo', 'Hello world');
+
+        $this->resolver->resolve($definition);
+    }
 }
 
 class FactoryDefinitionResolverTestClass
 {
+    public static function staticFoo()
+    {
+        return 'bar';
+    }
+
     public function foo()
     {
         return 'bar';


### PR DESCRIPTION
Currently, references to container entries in factory definitions are only possible, if they reference a class that actually exist with this exact FQN.

This PR enables you to to reference arbitrary container entries in factory definitions (as long as they are callables, of course), for example:
- `factory('my.closure')`
- `factory('my.invocable.object')`
- `factory(['my.class', 'method'])`

Todo:
- [x] write tests
- [x] update documentation

Closes #272 