### PR TITLE
Add an 'edit this' button to the documentation

### DIFF
--- a/website/documentation.twig
+++ b/website/documentation.twig
@@ -25,6 +25,12 @@
         </div>
 
         <article>
+            <div class="pull-right">
+                <a href="https://github.com/PHP-DI/PHP-DI/edit/master/{{ currentFile }}" class="btn btn-default btn-sm">
+                    Edit this page on GitHub
+                </a>
+            </div>
+
             {{ content|raw }}
         </article>
 


### PR DESCRIPTION
Wasn't sure if it's better to link to GitHub's [markdown preview page](https://github.com/PHP-DI/PHP-DI/blob/master/doc/getting-started.md), or to the form where you can [directly edit the document](https://github.com/PHP-DI/PHP-DI/edit/master/doc/getting-started.md). 

The latter will show a message that you have to fork the repository first, if you haven't already done so:
![github-edit](https://cloud.githubusercontent.com/assets/424602/9917324/34ca3e68-5cc1-11e5-8e51-6d0fe4a66d1f.png)

So, which one do you prefer? I chose the second one for now.

Closes #132 