### PR TITLE
Improve exception messages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=5.4.0",
         "container-interop/container-interop": "~1.0",
-        "php-di/invoker": "^1.1",
+        "php-di/invoker": "^1.1.1",
         "php-di/phpdoc-reader": "~2.0"
     },
     "require-dev": {

--- a/src/DI/Definition/Resolver/FactoryResolver.php
+++ b/src/DI/Definition/Resolver/FactoryResolver.php
@@ -65,7 +65,7 @@ class FactoryResolver implements DefinitionResolver
             return $this->invoker->call($definition->getCallable(), [$this->container]);
         } catch (NotCallableException $e) {
             throw new DefinitionException(sprintf(
-                'The factory definition "%s" is not callable: %s',
+                'Entry "%s" cannot be resolved: factory %s',
                 $definition->getName(),
                 $e->getMessage()
             ));

--- a/src/DI/Definition/Resolver/ObjectCreator.php
+++ b/src/DI/Definition/Resolver/ObjectCreator.php
@@ -150,13 +150,13 @@ class ObjectCreator implements DefinitionResolver
             $this->injectMethodsAndProperties($object, $definition);
         } catch (NotFoundException $e) {
             throw new DependencyException(sprintf(
-                "Error while injecting dependencies into %s: %s",
+                'Error while injecting dependencies into %s: %s',
                 $classReflection->getName(),
                 $e->getMessage()
             ), 0, $e);
         } catch (DefinitionException $e) {
             throw DefinitionException::create($definition, sprintf(
-                "Entry %s cannot be resolved: %s",
+                'Entry "%s" cannot be resolved: %s',
                 $definition->getName(),
                 $e->getMessage()
             ));
@@ -164,7 +164,7 @@ class ObjectCreator implements DefinitionResolver
 
         if (! $object) {
             throw new DependencyException(sprintf(
-                "Entry %s cannot be resolved: %s could not be constructed",
+                'Entry "%s" cannot be resolved: %s could not be constructed',
                 $definition->getName(),
                 $classReflection->getName()
             ));
@@ -236,7 +236,7 @@ class ObjectCreator implements DefinitionResolver
     {
         if (! $definition->classExists()) {
             throw DefinitionException::create($definition, sprintf(
-                "Entry %s cannot be resolved: the class doesn't exist",
+                'Entry "%s" cannot be resolved: the class doesn\'t exist',
                 $definition->getName(),
                 $definition->getClassName()
             ));
@@ -247,7 +247,7 @@ class ObjectCreator implements DefinitionResolver
     {
         if (! $definition->isInstantiable()) {
             throw DefinitionException::create($definition, sprintf(
-                "Entry %s cannot be resolved: the class is not instantiable",
+                'Entry "%s" cannot be resolved: the class is not instantiable',
                 $definition->getName(),
                 $definition->getClassName()
             ));

--- a/src/DI/Definition/Resolver/ObjectCreator.php
+++ b/src/DI/Definition/Resolver/ObjectCreator.php
@@ -235,9 +235,8 @@ class ObjectCreator implements DefinitionResolver
     private function assertClassExists(ObjectDefinition $definition)
     {
         if (! $definition->classExists()) {
-            throw DefinitionException::create($definition,
-            sprintf(
-                "Entry %s cannot be resolved: class %s doesn't exist",
+            throw DefinitionException::create($definition, sprintf(
+                "Entry %s cannot be resolved: the class doesn't exist",
                 $definition->getName(),
                 $definition->getClassName()
             ));
@@ -247,9 +246,8 @@ class ObjectCreator implements DefinitionResolver
     private function assertClassIsInstantiable(ObjectDefinition $definition)
     {
         if (! $definition->isInstantiable()) {
-            throw DefinitionException::create($definition,
-            sprintf(
-                "Entry %s cannot be resolved: class %s is not instantiable",
+            throw DefinitionException::create($definition, sprintf(
+                "Entry %s cannot be resolved: the class is not instantiable",
                 $definition->getName(),
                 $definition->getClassName()
             ));

--- a/src/DI/Definition/Resolver/ParameterResolver.php
+++ b/src/DI/Definition/Resolver/ParameterResolver.php
@@ -71,7 +71,7 @@ class ParameterResolver
                 }
 
                 throw new DefinitionException(sprintf(
-                    "The parameter '%s' of %s has no value defined or guessable",
+                    "The parameter $%s of %s has no value defined or guessable",
                     $parameter->getName(),
                     $this->getFunctionName($functionReflection)
                 ));
@@ -123,7 +123,7 @@ class ParameterResolver
     {
         if ($reflectionFunction instanceof \ReflectionMethod) {
             return sprintf(
-                '%s::%s',
+                '%s::%s()',
                 $reflectionFunction->getDeclaringClass()->getName(),
                 $reflectionFunction->getName()
             );

--- a/src/DI/Definition/Resolver/ParameterResolver.php
+++ b/src/DI/Definition/Resolver/ParameterResolver.php
@@ -13,11 +13,13 @@ use DI\Definition\ObjectDefinition;
 use DI\Definition\Exception\DefinitionException;
 use DI\Definition\Helper\DefinitionHelper;
 use DI\Definition\ObjectDefinition\MethodInjection;
+use ReflectionMethod;
+use ReflectionParameter;
 
 /**
  * Resolves parameters for a function call.
  *
- * @since 4.2
+ * @since  4.2
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
 class ParameterResolver
@@ -37,7 +39,7 @@ class ParameterResolver
 
     /**
      * @param MethodInjection             $definition
-     * @param \ReflectionFunctionAbstract $functionReflection
+     * @param \ReflectionFunctionAbstract $method
      * @param array                       $parameters
      *
      * @throws DefinitionException A parameter has no value defined or guessable.
@@ -45,18 +47,18 @@ class ParameterResolver
      */
     public function resolveParameters(
         MethodInjection $definition = null,
-        \ReflectionFunctionAbstract $functionReflection = null,
+        ReflectionMethod $method = null,
         array $parameters = []
     ) {
         $args = [];
 
-        if (! $functionReflection) {
+        if (! $method) {
             return $args;
         }
 
-        $definitionParameters = $definition ? $definition->getParameters() : array();
+        $definitionParameters = $definition ? $definition->getParameters() : [];
 
-        foreach ($functionReflection->getParameters() as $index => $parameter) {
+        foreach ($method->getParameters() as $index => $parameter) {
             if (array_key_exists($parameter->getName(), $parameters)) {
                 // Look in the $parameters array
                 $value = &$parameters[$parameter->getName()];
@@ -66,14 +68,14 @@ class ParameterResolver
             } else {
                 // If the parameter is optional and wasn't specified, we take its default value
                 if ($parameter->isOptional()) {
-                    $args[] = $this->getParameterDefaultValue($parameter, $functionReflection);
+                    $args[] = $this->getParameterDefaultValue($parameter, $method);
                     continue;
                 }
 
                 throw new DefinitionException(sprintf(
-                    "The parameter $%s of %s has no value defined or guessable",
+                    "Parameter $%s of %s has no value defined or guessable",
                     $parameter->getName(),
-                    $this->getFunctionName($functionReflection)
+                    $this->getFunctionName($method)
                 ));
             }
 
@@ -81,8 +83,8 @@ class ParameterResolver
                 $nestedDefinition = $value->getDefinition('');
 
                 // If the container cannot produce the entry, we can use the default parameter value
-                if ($parameter->isOptional() && !$this->definitionResolver->isResolvable($nestedDefinition)) {
-                    $value = $this->getParameterDefaultValue($parameter, $functionReflection);
+                if ($parameter->isOptional() && ! $this->definitionResolver->isResolvable($nestedDefinition)) {
+                    $value = $this->getParameterDefaultValue($parameter, $method);
                 } else {
                     $value = $this->definitionResolver->resolve($nestedDefinition);
                 }
@@ -97,15 +99,15 @@ class ParameterResolver
     /**
      * Returns the default value of a function parameter.
      *
-     * @param \ReflectionParameter        $parameter
-     * @param \ReflectionFunctionAbstract $function
+     * @param ReflectionParameter $parameter
+     * @param ReflectionMethod    $function
      *
      * @throws DefinitionException Can't get default values from PHP internal classes and functions
      * @return mixed
      */
     private function getParameterDefaultValue(
-        \ReflectionParameter $parameter,
-        \ReflectionFunctionAbstract $function
+        ReflectionParameter $parameter,
+        ReflectionMethod $function
     ) {
         try {
             return $parameter->getDefaultValue();
@@ -119,22 +121,8 @@ class ParameterResolver
         }
     }
 
-    private function getFunctionName(\ReflectionFunctionAbstract $reflectionFunction)
+    private function getFunctionName(ReflectionMethod $method)
     {
-        if ($reflectionFunction instanceof \ReflectionMethod) {
-            return sprintf(
-                '%s::%s()',
-                $reflectionFunction->getDeclaringClass()->getName(),
-                $reflectionFunction->getName()
-            );
-        } elseif ($reflectionFunction->isClosure()) {
-            return sprintf(
-                'closure defined in %s at line %d',
-                $reflectionFunction->getFileName(),
-                $reflectionFunction->getStartLine()
-            );
-        }
-
-        return $reflectionFunction->getName();
+        return $method->getName() . '()';
     }
 }

--- a/tests/IntegrationTest/CallFunctionTest.php
+++ b/tests/IntegrationTest/CallFunctionTest.php
@@ -205,7 +205,7 @@ class CallFunctionTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Invoker\Exception\NotCallableException
-     * @expectedExceptionMessage foo is neither a callable or a valid container entry
+     * @expectedExceptionMessage "foo" is neither a callable nor a valid container entry
      */
     public function test_not_callable()
     {

--- a/tests/IntegrationTest/ErrorMessages/ErrorMessagesTest.php
+++ b/tests/IntegrationTest/ErrorMessages/ErrorMessagesTest.php
@@ -28,7 +28,7 @@ MESSAGE;
     public function test_undefined_constructor_parameter()
     {
         $message = <<<'MESSAGE'
-Entry DI\Test\IntegrationTest\ErrorMessages\Buggy1 cannot be resolved: The parameter 'bar' of DI\Test\IntegrationTest\ErrorMessages\Buggy1::__construct has no value defined or guessable
+Entry DI\Test\IntegrationTest\ErrorMessages\Buggy1 cannot be resolved: The parameter $bar of DI\Test\IntegrationTest\ErrorMessages\Buggy1::__construct() has no value defined or guessable
 Full definition:
 Object (
     class = DI\Test\IntegrationTest\ErrorMessages\Buggy1
@@ -88,12 +88,22 @@ MESSAGE;
         $container->get('DI\Test\IntegrationTest\ErrorMessages\Buggy4');
     }
 
-    /**
-     * @expectedException \DI\Definition\Exception\DefinitionException
-     * @expectedExceptionMessage The parameter 'dependency' of DI\Test\IntegrationTest\ErrorMessages\Buggy5::setDependency has no value defined or guessable
-     */
     public function test_setter_injection_not_type_hinted()
     {
+        $message = <<<'MESSAGE'
+Entry DI\Test\IntegrationTest\ErrorMessages\Buggy5 cannot be resolved: The parameter $dependency of DI\Test\IntegrationTest\ErrorMessages\Buggy5::setDependency() has no value defined or guessable
+Full definition:
+Object (
+    class = DI\Test\IntegrationTest\ErrorMessages\Buggy5
+    scope = singleton
+    lazy = false
+    setDependency(
+        $dependency = #UNDEFINED#
+    )
+)
+MESSAGE;
+        $this->setExpectedException('DI\Definition\Exception\DefinitionException', $message);
+
         $builder = new ContainerBuilder();
         $builder->useAnnotations(true);
         $container = $builder->build();

--- a/tests/IntegrationTest/ErrorMessages/ErrorMessagesTest.php
+++ b/tests/IntegrationTest/ErrorMessages/ErrorMessagesTest.php
@@ -11,7 +11,7 @@ class ErrorMessagesTest extends \PHPUnit_Framework_TestCase
     public function test_non_instantiable_class()
     {
         $message = <<<'MESSAGE'
-Entry DI\Test\IntegrationTest\ErrorMessages\InterfaceFixture cannot be resolved: the class is not instantiable
+Entry "DI\Test\IntegrationTest\ErrorMessages\InterfaceFixture" cannot be resolved: the class is not instantiable
 Full definition:
 Object (
     class = #NOT INSTANTIABLE# DI\Test\IntegrationTest\ErrorMessages\InterfaceFixture
@@ -28,7 +28,7 @@ MESSAGE;
     public function test_non_existent_class()
     {
         $message = <<<'MESSAGE'
-Entry Acme\Foo\Bar\Bar cannot be resolved: the class doesn't exist
+Entry "Acme\Foo\Bar\Bar" cannot be resolved: the class doesn't exist
 Full definition:
 Object (
     class = #UNKNOWN# Acme\Foo\Bar\Bar
@@ -46,7 +46,7 @@ MESSAGE;
     public function test_undefined_constructor_parameter()
     {
         $message = <<<'MESSAGE'
-Entry DI\Test\IntegrationTest\ErrorMessages\Buggy1 cannot be resolved: Parameter $bar of __construct() has no value defined or guessable
+Entry "DI\Test\IntegrationTest\ErrorMessages\Buggy1" cannot be resolved: Parameter $bar of __construct() has no value defined or guessable
 Full definition:
 Object (
     class = DI\Test\IntegrationTest\ErrorMessages\Buggy1
@@ -109,7 +109,7 @@ MESSAGE;
     public function test_setter_injection_not_type_hinted()
     {
         $message = <<<'MESSAGE'
-Entry DI\Test\IntegrationTest\ErrorMessages\Buggy5 cannot be resolved: Parameter $dependency of setDependency() has no value defined or guessable
+Entry "DI\Test\IntegrationTest\ErrorMessages\Buggy5" cannot be resolved: Parameter $dependency of setDependency() has no value defined or guessable
 Full definition:
 Object (
     class = DI\Test\IntegrationTest\ErrorMessages\Buggy5
@@ -126,5 +126,16 @@ MESSAGE;
         $builder->useAnnotations(true);
         $container = $builder->build();
         $container->get('DI\Test\IntegrationTest\ErrorMessages\Buggy5');
+    }
+
+    /**
+     * @expectedException \DI\Definition\Exception\DefinitionException
+     * @expectedExceptionMessage Entry "foo" cannot be resolved: factory "bar" is neither a callable nor a valid container entry
+     */
+    public function test_factory_not_callable()
+    {
+        $container = ContainerBuilder::buildDevContainer();
+        $container->set('foo', \DI\factory('bar'));
+        $container->get('foo');
     }
 }

--- a/tests/IntegrationTest/ErrorMessages/ErrorMessagesTest.php
+++ b/tests/IntegrationTest/ErrorMessages/ErrorMessagesTest.php
@@ -11,7 +11,7 @@ class ErrorMessagesTest extends \PHPUnit_Framework_TestCase
     public function test_non_instantiable_class()
     {
         $message = <<<'MESSAGE'
-Entry DI\Test\IntegrationTest\ErrorMessages\InterfaceFixture cannot be resolved: class DI\Test\IntegrationTest\ErrorMessages\InterfaceFixture is not instantiable
+Entry DI\Test\IntegrationTest\ErrorMessages\InterfaceFixture cannot be resolved: the class is not instantiable
 Full definition:
 Object (
     class = #NOT INSTANTIABLE# DI\Test\IntegrationTest\ErrorMessages\InterfaceFixture
@@ -23,6 +23,24 @@ MESSAGE;
 
         $container = ContainerBuilder::buildDevContainer();
         $container->get('DI\Test\IntegrationTest\ErrorMessages\InterfaceFixture');
+    }
+
+    public function test_non_existent_class()
+    {
+        $message = <<<'MESSAGE'
+Entry Acme\Foo\Bar\Bar cannot be resolved: the class doesn't exist
+Full definition:
+Object (
+    class = #UNKNOWN# Acme\Foo\Bar\Bar
+    scope = singleton
+    lazy = false
+)
+MESSAGE;
+        $this->setExpectedException('DI\Definition\Exception\DefinitionException', $message);
+
+        $container = ContainerBuilder::buildDevContainer();
+        $container->set('Acme\Foo\Bar\Bar', \DI\object());
+        $container->get('Acme\Foo\Bar\Bar');
     }
 
     public function test_undefined_constructor_parameter()

--- a/tests/IntegrationTest/ErrorMessages/ErrorMessagesTest.php
+++ b/tests/IntegrationTest/ErrorMessages/ErrorMessagesTest.php
@@ -46,7 +46,7 @@ MESSAGE;
     public function test_undefined_constructor_parameter()
     {
         $message = <<<'MESSAGE'
-Entry DI\Test\IntegrationTest\ErrorMessages\Buggy1 cannot be resolved: The parameter $bar of DI\Test\IntegrationTest\ErrorMessages\Buggy1::__construct() has no value defined or guessable
+Entry DI\Test\IntegrationTest\ErrorMessages\Buggy1 cannot be resolved: Parameter $bar of __construct() has no value defined or guessable
 Full definition:
 Object (
     class = DI\Test\IntegrationTest\ErrorMessages\Buggy1
@@ -109,7 +109,7 @@ MESSAGE;
     public function test_setter_injection_not_type_hinted()
     {
         $message = <<<'MESSAGE'
-Entry DI\Test\IntegrationTest\ErrorMessages\Buggy5 cannot be resolved: The parameter $dependency of DI\Test\IntegrationTest\ErrorMessages\Buggy5::setDependency() has no value defined or guessable
+Entry DI\Test\IntegrationTest\ErrorMessages\Buggy5 cannot be resolved: Parameter $dependency of setDependency() has no value defined or guessable
 Full definition:
 Object (
     class = DI\Test\IntegrationTest\ErrorMessages\Buggy5

--- a/tests/UnitTest/Definition/Resolver/FactoryResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/FactoryResolverTest.php
@@ -122,7 +122,7 @@ class FactoryResolverTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      * @expectedException \DI\Definition\Exception\DefinitionException
-     * @expectedExceptionMessage The factory definition "foo" is not callable
+     * @expectedExceptionMessage Entry "foo" cannot be resolved: factory "Hello world" is neither a callable nor a valid container entry
      */
     public function should_throw_if_the_factory_is_not_callable()
     {
@@ -134,7 +134,7 @@ class FactoryResolverTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      * @expectedException \DI\Definition\Exception\DefinitionException
-     * @expectedExceptionMessage The factory definition "foo" is not callable
+     * @expectedExceptionMessage Entry "foo" cannot be resolved: factory 42 is not a callable
      */
     public function should_throw_if_the_factory_is_not_callable_container_entry()
     {

--- a/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
+++ b/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
@@ -186,7 +186,7 @@ class ObjectCreatorTest extends \PHPUnit_Framework_TestCase
     public function testUnknownClass()
     {
         $message = <<<MESSAGE
-Entry foo cannot be resolved: class bar doesn't exist
+Entry foo cannot be resolved: the class doesn't exist
 Full definition:
 Object (
     class = #UNKNOWN# bar
@@ -204,7 +204,7 @@ MESSAGE;
     public function testNotInstantiable()
     {
         $message = <<<MESSAGE
-Entry ArrayAccess cannot be resolved: class ArrayAccess is not instantiable
+Entry ArrayAccess cannot be resolved: the class is not instantiable
 Full definition:
 Object (
     class = #NOT INSTANTIABLE# ArrayAccess

--- a/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
+++ b/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
@@ -186,7 +186,7 @@ class ObjectCreatorTest extends \PHPUnit_Framework_TestCase
     public function testUnknownClass()
     {
         $message = <<<MESSAGE
-Entry foo cannot be resolved: the class doesn't exist
+Entry "foo" cannot be resolved: the class doesn't exist
 Full definition:
 Object (
     class = #UNKNOWN# bar
@@ -204,7 +204,7 @@ MESSAGE;
     public function testNotInstantiable()
     {
         $message = <<<MESSAGE
-Entry ArrayAccess cannot be resolved: the class is not instantiable
+Entry "ArrayAccess" cannot be resolved: the class is not instantiable
 Full definition:
 Object (
     class = #NOT INSTANTIABLE# ArrayAccess
@@ -222,7 +222,7 @@ MESSAGE;
     public function testUndefinedInjection()
     {
         $message = <<<'MESSAGE'
-Entry DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureClass cannot be resolved: Parameter $param1 of __construct() has no value defined or guessable
+Entry "DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureClass" cannot be resolved: Parameter $param1 of __construct() has no value defined or guessable
 Full definition:
 Object (
     class = DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureClass

--- a/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
+++ b/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
@@ -221,8 +221,8 @@ MESSAGE;
 
     public function testUndefinedInjection()
     {
-        $message = <<<MESSAGE
-Entry DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureClass cannot be resolved: The parameter 'param1' of DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureClass::__construct has no value defined or guessable
+        $message = <<<'MESSAGE'
+Entry DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureClass cannot be resolved: The parameter $param1 of DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureClass::__construct() has no value defined or guessable
 Full definition:
 Object (
     class = DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureClass

--- a/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
+++ b/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
@@ -222,7 +222,7 @@ MESSAGE;
     public function testUndefinedInjection()
     {
         $message = <<<'MESSAGE'
-Entry DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureClass cannot be resolved: The parameter $param1 of DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureClass::__construct() has no value defined or guessable
+Entry DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureClass cannot be resolved: Parameter $param1 of __construct() has no value defined or guessable
 Full definition:
 Object (
     class = DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureClass


### PR DESCRIPTION
Improve exception messages: simpler and more consistent. Added more tests too.

---

Before

```
Entry DI\Test\IntegrationTest\ErrorMessages\Buggy1 cannot be resolved: The parameter 'bar' of DI\Test\IntegrationTest\ErrorMessages\Buggy1::__construct has no value defined or guessable
Object (
    class = DI\Test\IntegrationTest\ErrorMessages\Buggy1
    scope = singleton
    lazy = false
    __construct(
        $foo = 'some value'
        $bar = #UNDEFINED#
        $default = (default value) 123
    )
)
```

After

```
Entry "DI\Test\IntegrationTest\ErrorMessages\Buggy1" cannot be resolved: Parameter $bar of __construct() has no value defined or guessable
Object (
    class = DI\Test\IntegrationTest\ErrorMessages\Buggy1
    scope = singleton
    lazy = false
    __construct(
        $foo = 'some value'
        $bar = #UNDEFINED#
        $default = (default value) 123
    )
)
```

---

Before

```
Entry DI\Test\IntegrationTest\ErrorMessages\InterfaceFixture cannot be resolved: class DI\Test\IntegrationTest\ErrorMessages\InterfaceFixture is not instantiable
Full definition:
Object (
    class = #NOT INSTANTIABLE# DI\Test\IntegrationTest\ErrorMessages\InterfaceFixture
    scope = singleton
    lazy = false
)
```

After

```
Entry "DI\Test\IntegrationTest\ErrorMessages\InterfaceFixture" cannot be resolved: the class is not instantiable
Full definition:
Object (
    class = #NOT INSTANTIABLE# DI\Test\IntegrationTest\ErrorMessages\InterfaceFixture
    scope = singleton
    lazy = false
)
```

---

Before

```
The factory definition "Acme\UserRepository" is not callable: RepositoryFactory is neither a callable or a valid container entry
```

After

```
Entry "Acme\UserRepository" cannot be resolved: factory "RepositoryFactory" is neither a callable nor a valid container entry
```