### PR TITLE
Improved factory definition/resolver tests

### DIFF
--- a/tests/IntegrationTest/Definitions/FactoryDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/FactoryDefinitionTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Test\IntegrationTest\Definitions;
+
+use DI\ContainerBuilder;
+
+/**
+ * Test factory definitions
+ *
+ * @coversNothing
+ */
+class FactoryDefinitionTest extends \PHPUnit_Framework_TestCase
+{
+    public function provideCallables()
+    {
+        return [
+            'closure'               => [function () { return 'bar'; }],
+            'function'              => [__NAMESPACE__ . '\FactoryDefinition_test'],
+            'invokableObject'       => [new FactoryDefinitionInvokableTestClass],
+            'invokableClass'        => [__NAMESPACE__ . '\FactoryDefinitionInvokableTestClass'],
+            '[Class, staticMethod]' => [[__NAMESPACE__ . '\FactoryDefinitionTestClass', 'staticFoo']],
+            'Class::staticMethod'   => [__NAMESPACE__ . '\FactoryDefinitionTestClass::staticFoo'],
+            '[object, method]'      => [[new FactoryDefinitionTestClass, 'foo']],
+            '[class, method]'       => [[__NAMESPACE__ . '\FactoryDefinitionTestClass', 'foo']],
+            'class::method'         => [__NAMESPACE__ . '\FactoryDefinitionTestClass::foo'],
+        ];
+    }
+
+    public function provideArbitraryNamedContainerObjectCallables()
+    {
+        return [
+            '[arbitraryClassEntry, method]' => [['bar_baz', 'foo']],
+            'arbitraryClassEntry::method'   => ['bar_baz::foo'],
+        ];
+    }
+
+    public function test_simple_closure_as_factory()
+    {
+        $container = $this->createContainer([
+            'factory' => function () {
+                return 'bar';
+            },
+        ]);
+
+        $factory = $container->get('factory');
+
+        $this->assertSame('bar', $factory);
+    }
+
+    /**
+     * @dataProvider provideCallables
+     */
+    public function test_factory_helper_function($callable)
+    {
+        $container = $this->createContainer([
+            'factory' => \DI\factory($callable),
+        ]);
+
+        $factory = $container->get('factory');
+
+        $this->assertSame('bar', $factory);
+    }
+
+    /**
+     * @dataProvider provideArbitraryNamedContainerObjectCallables
+     */
+    public function test_arbitrary_named_container_object_as_factory($callable)
+    {
+        $container = $this->createContainer([
+            'bar_baz' => \DI\object(__NAMESPACE__ . '\FactoryDefinitionTestClass'),
+            'factory' => \DI\factory($callable),
+        ]);
+
+        $factory = $container->get('factory');
+
+        $this->assertSame('bar', $factory);
+    }
+
+    public function test_arbitrary_named_invokable_container_object_as_factory()
+    {
+        $container = $this->createContainer([
+            'bar_baz' => \DI\object(__NAMESPACE__ . '\FactoryDefinitionInvokableTestClass'),
+            'factory' => \DI\factory('bar_baz'),
+        ]);
+
+        $factory = $container->get('factory');
+
+        $this->assertSame('bar', $factory);
+    }
+
+    /**
+     * @expectedException \DI\Definition\Exception\DefinitionException
+     * @expectedExceptionMessage Entry "foo" cannot be resolved: factory "Hello World" is neither a callable nor a valid container entry
+     */
+    public function test_not_callable_factory_definition()
+    {
+        $container = $this->createContainer([
+            'foo' => \DI\factory('Hello World'),
+        ]);
+
+        $container->get('foo');
+    }
+
+    private function createContainer(array $definitions)
+    {
+        $builder = new ContainerBuilder();
+        $builder->addDefinitions($definitions);
+
+        return $builder->build();
+    }
+}
+
+class FactoryDefinitionTestClass
+{
+    public static function staticFoo()
+    {
+        return 'bar';
+    }
+
+    public function foo()
+    {
+        return 'bar';
+    }
+}
+
+class FactoryDefinitionInvokableTestClass
+{
+    public function __invoke()
+    {
+        return 'bar';
+    }
+}
+
+function FactoryDefinition_test()
+{
+    return 'bar';
+}

--- a/tests/UnitTest/Definition/Resolver/DecoratorResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/DecoratorResolverTest.php
@@ -39,16 +39,6 @@ class DecoratorResolverTest extends \PHPUnit_Framework_TestCase
         $this->resolver = new DecoratorResolver($container, $this->parentResolver);
     }
 
-    public function provideCallables()
-    {
-        return [
-            'closure'        => [function () { return 'bar'; }],
-            'string'         => [__NAMESPACE__ . '\FactoryDefinitionResolver_test'],
-            'array'          => [[new FactoryDefinitionResolverTestClass(), 'foo']],
-            'invokableClass' => [new FactoryDefinitionResolverCallableClass()],
-        ];
-    }
-
     /**
      * @test
      */


### PR DESCRIPTION
I realized that my tests for the factory resolver/definitions from #321 were not very good and should be improved.

Thus I refactored them so that the unit tests for the `FactoryResolver` only test what this class really does. The tests that utilize the invoker/container were moved to integration tests where they belong, so that the real behaviour is tested.

I also removed an unused data provider from `DecoratorResolverTest`.