### PR TITLE
Apply and enforce code style

### DIFF
--- a/src/DI/Annotation/Inject.php
+++ b/src/DI/Annotation/Inject.php
@@ -5,7 +5,7 @@ namespace DI\Annotation;
 use DI\Definition\Exception\AnnotationException;
 
 /**
- * "Inject" annotation
+ * "Inject" annotation.
  *
  * Marks a property or method as an injection point
  *
@@ -17,13 +17,13 @@ use DI\Definition\Exception\AnnotationException;
 final class Inject
 {
     /**
-     * Entry name
+     * Entry name.
      * @var string
      */
     private $name;
 
     /**
-     * Parameters, indexed by the parameter number (index) or name
+     * Parameters, indexed by the parameter number (index) or name.
      *
      * Used if the annotation is set on a method
      * @var array
@@ -40,6 +40,7 @@ final class Inject
         // @Inject(name="foo")
         if (isset($values['name']) && is_string($values['name'])) {
             $this->name = $values['name'];
+
             return;
         }
 

--- a/src/DI/Annotation/Inject.php
+++ b/src/DI/Annotation/Inject.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Annotation;
 

--- a/src/DI/Annotation/Injectable.php
+++ b/src/DI/Annotation/Injectable.php
@@ -6,7 +6,7 @@ use DI\Scope;
 use UnexpectedValueException;
 
 /**
- * "Injectable" annotation
+ * "Injectable" annotation.
  *
  * Marks a class as injectable
  *
@@ -19,14 +19,14 @@ use UnexpectedValueException;
 final class Injectable
 {
     /**
-     * The scope of an class: prototype, singleton
+     * The scope of an class: prototype, singleton.
      * @var string|null
      */
     private $scope;
 
     /**
-     * Should the object be lazy-loaded
-     * @var boolean|null
+     * Should the object be lazy-loaded.
+     * @var bool|null
      */
     private $lazy;
 
@@ -58,7 +58,7 @@ final class Injectable
     }
 
     /**
-     * @return boolean|null
+     * @return bool|null
      */
     public function isLazy()
     {

--- a/src/DI/Annotation/Injectable.php
+++ b/src/DI/Annotation/Injectable.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Annotation;
 

--- a/src/DI/Cache/ArrayCache.php
+++ b/src/DI/Cache/ArrayCache.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Cache;
 

--- a/src/DI/Cache/ArrayCache.php
+++ b/src/DI/Cache/ArrayCache.php
@@ -24,7 +24,7 @@ use Doctrine\Common\Cache\FlushableCache;
 class ArrayCache implements Cache, FlushableCache, ClearableCache
 {
     /**
-     * @var array $data
+     * @var array
      */
     private $data = [];
 
@@ -60,7 +60,7 @@ class ArrayCache implements Cache, FlushableCache, ClearableCache
 
     public function flushAll()
     {
-        $this->data = array();
+        $this->data = [];
 
         return true;
     }

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI;
 

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -2,16 +2,16 @@
 
 namespace DI;
 
-use DI\Definition\ObjectDefinition;
 use DI\Definition\Definition;
 use DI\Definition\FactoryDefinition;
+use DI\Definition\Helper\DefinitionHelper;
 use DI\Definition\InstanceDefinition;
+use DI\Definition\ObjectDefinition;
+use DI\Definition\Resolver\DefinitionResolver;
 use DI\Definition\Resolver\ResolverDispatcher;
 use DI\Definition\Source\CachedDefinitionSource;
 use DI\Definition\Source\DefinitionSource;
 use DI\Definition\Source\MutableDefinitionSource;
-use DI\Definition\Helper\DefinitionHelper;
-use DI\Definition\Resolver\DefinitionResolver;
 use DI\Invoker\DefinitionParameterResolver;
 use DI\Proxy\ProxyFactory;
 use Exception;
@@ -200,7 +200,7 @@ class Container implements ContainerInterface, FactoryInterface, \DI\InvokerInte
     }
 
     /**
-     * Inject all dependencies on an existing instance
+     * Inject all dependencies on an existing instance.
      *
      * @param object $instance Object to perform injection upon
      * @throws InvalidArgumentException

--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI;
 

--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -3,11 +3,11 @@
 namespace DI;
 
 use DI\Definition\Source\AnnotationReader;
-use DI\Definition\Source\DefinitionArray;
-use DI\Definition\Source\CachedDefinitionSource;
-use DI\Definition\Source\DefinitionSource;
-use DI\Definition\Source\DefinitionFile;
 use DI\Definition\Source\Autowiring;
+use DI\Definition\Source\CachedDefinitionSource;
+use DI\Definition\Source\DefinitionArray;
+use DI\Definition\Source\DefinitionFile;
+use DI\Definition\Source\DefinitionSource;
 use DI\Definition\Source\SourceChain;
 use DI\Proxy\ProxyFactory;
 use Doctrine\Common\Cache\Cache;
@@ -36,17 +36,17 @@ class ContainerBuilder
     private $containerClass;
 
     /**
-     * @var boolean
+     * @var bool
      */
     private $useAutowiring = true;
 
     /**
-     * @var boolean
+     * @var bool
      */
     private $useAnnotations = false;
 
     /**
-     * @var boolean
+     * @var bool
      */
     private $ignorePhpDocErrors = false;
 
@@ -57,7 +57,7 @@ class ContainerBuilder
 
     /**
      * If true, write the proxies to disk to improve performances.
-     * @var boolean
+     * @var bool
      */
     private $writeProxiesToFile = false;
 
@@ -86,6 +86,7 @@ class ContainerBuilder
     public static function buildDevContainer()
     {
         $builder = new self();
+
         return $builder->build();
     }
 
@@ -134,12 +135,13 @@ class ContainerBuilder
      *
      * Enabled by default.
      *
-     * @param boolean $bool
+     * @param bool $bool
      * @return ContainerBuilder
      */
     public function useAutowiring($bool)
     {
         $this->useAutowiring = $bool;
+
         return $this;
     }
 
@@ -148,24 +150,26 @@ class ContainerBuilder
      *
      * Disabled by default.
      *
-     * @param boolean $bool
+     * @param bool $bool
      * @return ContainerBuilder
      */
     public function useAnnotations($bool)
     {
         $this->useAnnotations = $bool;
+
         return $this;
     }
 
     /**
-     * Enable or disable ignoring phpdoc errors (non-existent classes in `@param` or `@var`)
+     * Enable or disable ignoring phpdoc errors (non-existent classes in `@param` or `@var`).
      *
-     * @param boolean $bool
+     * @param bool $bool
      * @return ContainerBuilder
      */
     public function ignorePhpDocErrors($bool)
     {
         $this->ignorePhpDocErrors = $bool;
+
         return $this;
     }
 
@@ -178,20 +182,20 @@ class ContainerBuilder
     public function setDefinitionCache(Cache $cache)
     {
         $this->cache = $cache;
+
         return $this;
     }
 
     /**
-     * Configure the proxy generation
+     * Configure the proxy generation.
      *
      * For dev environment, use writeProxiesToFile(false) (default configuration)
      * For production environment, use writeProxiesToFile(true, 'tmp/proxies')
      *
-     * @param boolean     $writeToFile    If true, write the proxies to disk to improve performances
+     * @param bool     $writeToFile    If true, write the proxies to disk to improve performances
      * @param string|null $proxyDirectory Directory where to write the proxies
-     * @return ContainerBuilder
-     *
      * @throws InvalidArgumentException when writeToFile is set to true and the proxy directory is null
+     * @return ContainerBuilder
      */
     public function writeProxiesToFile($writeToFile, $proxyDirectory = null)
     {

--- a/src/DI/Debug.php
+++ b/src/DI/Debug.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI;
 

--- a/src/DI/Definition/AliasDefinition.php
+++ b/src/DI/Definition/AliasDefinition.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition;
 

--- a/src/DI/Definition/AliasDefinition.php
+++ b/src/DI/Definition/AliasDefinition.php
@@ -12,13 +12,13 @@ use DI\Scope;
 class AliasDefinition implements CacheableDefinition
 {
     /**
-     * Entry name
+     * Entry name.
      * @var string
      */
     private $name;
 
     /**
-     * Name of the target entry
+     * Name of the target entry.
      * @var string
      */
     private $targetEntryName;

--- a/src/DI/Definition/ArrayDefinition.php
+++ b/src/DI/Definition/ArrayDefinition.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition;
 

--- a/src/DI/Definition/ArrayDefinition.php
+++ b/src/DI/Definition/ArrayDefinition.php
@@ -13,7 +13,7 @@ use DI\Scope;
 class ArrayDefinition implements Definition
 {
     /**
-     * Entry name
+     * Entry name.
      * @var string
      */
     private $name;

--- a/src/DI/Definition/ArrayDefinitionExtension.php
+++ b/src/DI/Definition/ArrayDefinitionExtension.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition;
 

--- a/src/DI/Definition/CacheableDefinition.php
+++ b/src/DI/Definition/CacheableDefinition.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition;
 

--- a/src/DI/Definition/CacheableDefinition.php
+++ b/src/DI/Definition/CacheableDefinition.php
@@ -3,7 +3,7 @@
 namespace DI\Definition;
 
 /**
- * Cacheable definition
+ * Cacheable definition.
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */

--- a/src/DI/Definition/DecoratorDefinition.php
+++ b/src/DI/Definition/DecoratorDefinition.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition;
 

--- a/src/DI/Definition/Definition.php
+++ b/src/DI/Definition/Definition.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition;
 

--- a/src/DI/Definition/Definition.php
+++ b/src/DI/Definition/Definition.php
@@ -3,21 +3,21 @@
 namespace DI\Definition;
 
 /**
- * Definition
+ * Definition.
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
 interface Definition
 {
     /**
-     * Returns the name of the entry in the container
+     * Returns the name of the entry in the container.
      *
      * @return string
      */
     public function getName();
 
     /**
-     * Returns the scope of the entry
+     * Returns the scope of the entry.
      *
      * @return string
      */

--- a/src/DI/Definition/Dumper/AliasDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/AliasDefinitionDumper.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Dumper;
 

--- a/src/DI/Definition/Dumper/ArrayDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/ArrayDefinitionDumper.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Dumper;
 

--- a/src/DI/Definition/Dumper/DecoratorDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/DecoratorDefinitionDumper.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Dumper;
 

--- a/src/DI/Definition/Dumper/DefinitionDumper.php
+++ b/src/DI/Definition/Dumper/DefinitionDumper.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Dumper;
 

--- a/src/DI/Definition/Dumper/DefinitionDumperDispatcher.php
+++ b/src/DI/Definition/Dumper/DefinitionDumperDispatcher.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Dumper;
 

--- a/src/DI/Definition/Dumper/EnvironmentVariableDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/EnvironmentVariableDefinitionDumper.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Dumper;
 

--- a/src/DI/Definition/Dumper/FactoryDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/FactoryDefinitionDumper.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Dumper;
 

--- a/src/DI/Definition/Dumper/ObjectDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/ObjectDefinitionDumper.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Dumper;
 

--- a/src/DI/Definition/Dumper/ObjectDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/ObjectDefinitionDumper.php
@@ -2,12 +2,11 @@
 
 namespace DI\Definition\Dumper;
 
-use DI\Definition\ObjectDefinition;
-use DI\Definition\ObjectDefinition\MethodInjection;
 use DI\Definition\Definition;
 use DI\Definition\EntryReference;
+use DI\Definition\ObjectDefinition;
+use DI\Definition\ObjectDefinition\MethodInjection;
 use ReflectionException;
-use ReflectionMethod;
 
 /**
  * Dumps object definitions.
@@ -88,7 +87,7 @@ class ObjectDefinitionDumper implements DefinitionDumper
                 $valueStr = var_export($value, true);
             }
 
-            $str .= sprintf(PHP_EOL . "    $%s = %s", $propertyInjection->getPropertyName(), $valueStr);
+            $str .= sprintf(PHP_EOL . '    $%s = %s', $propertyInjection->getPropertyName(), $valueStr);
         }
 
         return $str;

--- a/src/DI/Definition/Dumper/StringDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/StringDefinitionDumper.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Dumper;
 

--- a/src/DI/Definition/Dumper/ValueDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/ValueDefinitionDumper.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Dumper;
 

--- a/src/DI/Definition/EntryReference.php
+++ b/src/DI/Definition/EntryReference.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition;
 

--- a/src/DI/Definition/EntryReference.php
+++ b/src/DI/Definition/EntryReference.php
@@ -14,7 +14,7 @@ use DI\Definition\Helper\DefinitionHelper;
 class EntryReference implements DefinitionHelper
 {
     /**
-     * Entry name
+     * Entry name.
      * @var string
      */
     private $name;

--- a/src/DI/Definition/EnvironmentVariableDefinition.php
+++ b/src/DI/Definition/EnvironmentVariableDefinition.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition;
 

--- a/src/DI/Definition/EnvironmentVariableDefinition.php
+++ b/src/DI/Definition/EnvironmentVariableDefinition.php
@@ -13,29 +13,29 @@ use DI\Scope;
 class EnvironmentVariableDefinition implements CacheableDefinition
 {
     /**
-     * Entry name
+     * Entry name.
      * @var string
      */
     private $name;
 
     /**
-     * The name of the environment variable
+     * The name of the environment variable.
      * @var string
      */
     private $variableName;
 
     /**
-     * Whether or not the environment variable definition is optional
+     * Whether or not the environment variable definition is optional.
      *
      * If true and the environment variable given by $variableName has not been
      * defined, $defaultValue is used.
      *
-     * @var boolean
+     * @var bool
      */
     private $isOptional;
 
     /**
-     * The default value to use if the environment variable is optional and not provided
+     * The default value to use if the environment variable is optional and not provided.
      * @var mixed
      */
     private $defaultValue;
@@ -48,7 +48,7 @@ class EnvironmentVariableDefinition implements CacheableDefinition
     /**
      * @param string $name Entry name
      * @param string $variableName The name of the environment variable
-     * @param boolean $isOptional Whether or not the environment variable definition is optional
+     * @param bool $isOptional Whether or not the environment variable definition is optional
      * @param mixed $defaultValue The default value to use if the environment variable is optional and not provided
      */
     public function __construct($name, $variableName, $isOptional = false, $defaultValue = null)
@@ -76,7 +76,7 @@ class EnvironmentVariableDefinition implements CacheableDefinition
     }
 
     /**
-     * @return boolean Whether or not the environment variable definition is optional
+     * @return bool Whether or not the environment variable definition is optional
      */
     public function isOptional()
     {

--- a/src/DI/Definition/Exception/AnnotationException.php
+++ b/src/DI/Definition/Exception/AnnotationException.php
@@ -3,7 +3,7 @@
 namespace DI\Definition\Exception;
 
 /**
- * Exception in the definitions using annotations
+ * Exception in the definitions using annotations.
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */

--- a/src/DI/Definition/Exception/AnnotationException.php
+++ b/src/DI/Definition/Exception/AnnotationException.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Exception;
 

--- a/src/DI/Definition/Exception/DefinitionException.php
+++ b/src/DI/Definition/Exception/DefinitionException.php
@@ -6,7 +6,7 @@ use DI\Debug;
 use DI\Definition\Definition;
 
 /**
- * Invalid DI definitions
+ * Invalid DI definitions.
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */

--- a/src/DI/Definition/Exception/DefinitionException.php
+++ b/src/DI/Definition/Exception/DefinitionException.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Exception;
 

--- a/src/DI/Definition/FactoryDefinition.php
+++ b/src/DI/Definition/FactoryDefinition.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition;
 

--- a/src/DI/Definition/HasSubDefinition.php
+++ b/src/DI/Definition/HasSubDefinition.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition;
 

--- a/src/DI/Definition/Helper/ArrayDefinitionExtensionHelper.php
+++ b/src/DI/Definition/Helper/ArrayDefinitionExtensionHelper.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Helper;
 

--- a/src/DI/Definition/Helper/DefinitionHelper.php
+++ b/src/DI/Definition/Helper/DefinitionHelper.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Helper;
 

--- a/src/DI/Definition/Helper/EnvironmentVariableDefinitionHelper.php
+++ b/src/DI/Definition/Helper/EnvironmentVariableDefinitionHelper.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Helper;
 

--- a/src/DI/Definition/Helper/EnvironmentVariableDefinitionHelper.php
+++ b/src/DI/Definition/Helper/EnvironmentVariableDefinitionHelper.php
@@ -12,30 +12,30 @@ use DI\Definition\EnvironmentVariableDefinition;
 class EnvironmentVariableDefinitionHelper implements DefinitionHelper
 {
     /**
-     * The name of the environment variable
+     * The name of the environment variable.
      * @var string
      */
     private $variableName;
 
     /**
-     * Whether or not the environment variable definition is optional
+     * Whether or not the environment variable definition is optional.
      *
      * If true and the environment variable given by $variableName has not been
      * defined, $defaultValue is used.
      *
-     * @var boolean
+     * @var bool
      */
     private $isOptional;
 
     /**
-     * The default value to use if the environment variable is optional and not provided
+     * The default value to use if the environment variable is optional and not provided.
      * @var mixed
      */
     private $defaultValue;
 
     /**
      * @param string  $variableName The name of the environment variable
-     * @param boolean $isOptional   Whether or not the environment variable definition is optional
+     * @param bool $isOptional   Whether or not the environment variable definition is optional
      * @param mixed   $defaultValue The default value to use if the environment variable is optional and not provided
      */
     public function __construct($variableName, $isOptional, $defaultValue = null)

--- a/src/DI/Definition/Helper/FactoryDefinitionHelper.php
+++ b/src/DI/Definition/Helper/FactoryDefinitionHelper.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Helper;
 

--- a/src/DI/Definition/Helper/FactoryDefinitionHelper.php
+++ b/src/DI/Definition/Helper/FactoryDefinitionHelper.php
@@ -47,6 +47,7 @@ class FactoryDefinitionHelper implements DefinitionHelper
     public function scope($scope)
     {
         $this->scope = $scope;
+
         return $this;
     }
 

--- a/src/DI/Definition/Helper/ObjectDefinitionHelper.php
+++ b/src/DI/Definition/Helper/ObjectDefinitionHelper.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Helper;
 

--- a/src/DI/Definition/Helper/ObjectDefinitionHelper.php
+++ b/src/DI/Definition/Helper/ObjectDefinitionHelper.php
@@ -2,10 +2,10 @@
 
 namespace DI\Definition\Helper;
 
+use DI\Definition\Exception\DefinitionException;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\ObjectDefinition\MethodInjection;
 use DI\Definition\ObjectDefinition\PropertyInjection;
-use DI\Definition\Exception\DefinitionException;
 
 /**
  * Helps defining how to create an instance of a class.
@@ -20,7 +20,7 @@ class ObjectDefinitionHelper implements DefinitionHelper
     private $className;
 
     /**
-     * @var boolean|null
+     * @var bool|null
      */
     private $lazy;
 
@@ -68,6 +68,7 @@ class ObjectDefinitionHelper implements DefinitionHelper
     public function lazy()
     {
         $this->lazy = true;
+
         return $this;
     }
 
@@ -81,6 +82,7 @@ class ObjectDefinitionHelper implements DefinitionHelper
     public function scope($scope)
     {
         $this->scope = $scope;
+
         return $this;
     }
 
@@ -97,6 +99,7 @@ class ObjectDefinitionHelper implements DefinitionHelper
     public function constructor()
     {
         $this->constructor = func_get_args();
+
         return $this;
     }
 
@@ -116,6 +119,7 @@ class ObjectDefinitionHelper implements DefinitionHelper
     public function constructorParameter($parameter, $value)
     {
         $this->constructor[$parameter] = $value;
+
         return $this;
     }
 
@@ -130,6 +134,7 @@ class ObjectDefinitionHelper implements DefinitionHelper
     public function property($property, $value)
     {
         $this->properties[$property] = $value;
+
         return $this;
     }
 
@@ -183,6 +188,7 @@ class ObjectDefinitionHelper implements DefinitionHelper
         // Special case for the constructor
         if ($method === '__construct') {
             $this->constructor[$parameter] = $value;
+
             return $this;
         }
 

--- a/src/DI/Definition/Helper/StringDefinitionHelper.php
+++ b/src/DI/Definition/Helper/StringDefinitionHelper.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Helper;
 

--- a/src/DI/Definition/Helper/ValueDefinitionHelper.php
+++ b/src/DI/Definition/Helper/ValueDefinitionHelper.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Helper;
 

--- a/src/DI/Definition/InstanceDefinition.php
+++ b/src/DI/Definition/InstanceDefinition.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition;
 

--- a/src/DI/Definition/ObjectDefinition.php
+++ b/src/DI/Definition/ObjectDefinition.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition;
 

--- a/src/DI/Definition/ObjectDefinition.php
+++ b/src/DI/Definition/ObjectDefinition.php
@@ -15,31 +15,31 @@ use ReflectionClass;
 class ObjectDefinition implements Definition, CacheableDefinition, HasSubDefinition
 {
     /**
-     * Entry name (most of the time, same as $classname)
+     * Entry name (most of the time, same as $classname).
      * @var string
      */
     private $name;
 
     /**
-     * Class name (if null, then the class name is $name)
+     * Class name (if null, then the class name is $name).
      * @var string|null
      */
     private $className;
 
     /**
-     * Constructor parameter injection
+     * Constructor parameter injection.
      * @var MethodInjection|null
      */
     private $constructorInjection;
 
     /**
-     * Property injections
+     * Property injections.
      * @var PropertyInjection[]
      */
     private $propertyInjections = [];
 
     /**
-     * Method calls
+     * Method calls.
      * @var MethodInjection[][]
      */
     private $methodInjections = [];
@@ -50,7 +50,7 @@ class ObjectDefinition implements Definition, CacheableDefinition, HasSubDefinit
     private $scope;
 
     /**
-     * @var boolean|null
+     * @var bool|null
      */
     private $lazy;
 
@@ -104,6 +104,7 @@ class ObjectDefinition implements Definition, CacheableDefinition, HasSubDefinit
         if ($this->className !== null) {
             return $this->className;
         }
+
         return $this->name;
     }
 
@@ -158,6 +159,7 @@ class ObjectDefinition implements Definition, CacheableDefinition, HasSubDefinit
         array_walk_recursive($this->methodInjections, function ($injection) use (&$injections) {
             $injections[] = $injection;
         });
+
         return $injections;
     }
 
@@ -190,7 +192,7 @@ class ObjectDefinition implements Definition, CacheableDefinition, HasSubDefinit
     }
 
     /**
-     * @param boolean|null $lazy
+     * @param bool|null $lazy
      */
     public function setLazy($lazy)
     {
@@ -239,7 +241,7 @@ class ObjectDefinition implements Definition, CacheableDefinition, HasSubDefinit
      */
     public function setSubDefinition(Definition $definition)
     {
-        if (! $definition instanceof ObjectDefinition) {
+        if (! $definition instanceof self) {
             return;
         }
 
@@ -321,6 +323,7 @@ class ObjectDefinition implements Definition, CacheableDefinition, HasSubDefinit
 
         if (! $this->classExists) {
             $this->isInstantiable = false;
+
             return;
         }
 

--- a/src/DI/Definition/ObjectDefinition/MethodInjection.php
+++ b/src/DI/Definition/ObjectDefinition/MethodInjection.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\ObjectDefinition;
 

--- a/src/DI/Definition/ObjectDefinition/PropertyInjection.php
+++ b/src/DI/Definition/ObjectDefinition/PropertyInjection.php
@@ -10,13 +10,13 @@ namespace DI\Definition\ObjectDefinition;
 class PropertyInjection
 {
     /**
-     * Property name
+     * Property name.
      * @var string
      */
     private $propertyName;
 
     /**
-     * Value that should be injected in the property
+     * Value that should be injected in the property.
      * @var mixed
      */
     private $value;

--- a/src/DI/Definition/ObjectDefinition/PropertyInjection.php
+++ b/src/DI/Definition/ObjectDefinition/PropertyInjection.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\ObjectDefinition;
 

--- a/src/DI/Definition/Resolver/AliasResolver.php
+++ b/src/DI/Definition/Resolver/AliasResolver.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://mnapoli.github.com/PHP-DI/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Resolver;
 

--- a/src/DI/Definition/Resolver/ArrayResolver.php
+++ b/src/DI/Definition/Resolver/ArrayResolver.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://mnapoli.github.com/PHP-DI/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Resolver;
 

--- a/src/DI/Definition/Resolver/DecoratorResolver.php
+++ b/src/DI/Definition/Resolver/DecoratorResolver.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://mnapoli.github.com/PHP-DI/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Resolver;
 

--- a/src/DI/Definition/Resolver/DecoratorResolver.php
+++ b/src/DI/Definition/Resolver/DecoratorResolver.php
@@ -3,8 +3,8 @@
 namespace DI\Definition\Resolver;
 
 use DI\Definition\DecoratorDefinition;
-use DI\Definition\Exception\DefinitionException;
 use DI\Definition\Definition;
+use DI\Definition\Exception\DefinitionException;
 use Interop\Container\ContainerInterface;
 
 /**

--- a/src/DI/Definition/Resolver/DefinitionResolver.php
+++ b/src/DI/Definition/Resolver/DefinitionResolver.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://mnapoli.github.com/PHP-DI/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Resolver;
 

--- a/src/DI/Definition/Resolver/EnvironmentVariableResolver.php
+++ b/src/DI/Definition/Resolver/EnvironmentVariableResolver.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://mnapoli.github.com/PHP-DI/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Resolver;
 

--- a/src/DI/Definition/Resolver/FactoryResolver.php
+++ b/src/DI/Definition/Resolver/FactoryResolver.php
@@ -2,9 +2,9 @@
 
 namespace DI\Definition\Resolver;
 
+use DI\Definition\Definition;
 use DI\Definition\Exception\DefinitionException;
 use DI\Definition\FactoryDefinition;
-use DI\Definition\Definition;
 use Interop\Container\ContainerInterface;
 use Invoker\Exception\NotCallableException;
 use Invoker\Invoker;

--- a/src/DI/Definition/Resolver/FactoryResolver.php
+++ b/src/DI/Definition/Resolver/FactoryResolver.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://mnapoli.github.com/PHP-DI/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Resolver;
 

--- a/src/DI/Definition/Resolver/InstanceInjector.php
+++ b/src/DI/Definition/Resolver/InstanceInjector.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://mnapoli.github.com/PHP-DI/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Resolver;
 

--- a/src/DI/Definition/Resolver/ObjectCreator.php
+++ b/src/DI/Definition/Resolver/ObjectCreator.php
@@ -2,11 +2,11 @@
 
 namespace DI\Definition\Resolver;
 
-use DI\Definition\ObjectDefinition;
 use DI\Definition\Definition;
 use DI\Definition\Exception\DefinitionException;
-use DI\Definition\ObjectDefinition\PropertyInjection;
 use DI\Definition\Helper\DefinitionHelper;
+use DI\Definition\ObjectDefinition;
+use DI\Definition\ObjectDefinition\PropertyInjection;
 use DI\DependencyException;
 use DI\Proxy\ProxyFactory;
 use Exception;
@@ -84,7 +84,7 @@ class ObjectCreator implements DefinitionResolver
     }
 
     /**
-     * Returns a proxy instance
+     * Returns a proxy instance.
      *
      * @param ObjectDefinition $definition
      * @param array           $parameters

--- a/src/DI/Definition/Resolver/ObjectCreator.php
+++ b/src/DI/Definition/Resolver/ObjectCreator.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://mnapoli.github.com/PHP-DI/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Resolver;
 

--- a/src/DI/Definition/Resolver/ParameterResolver.php
+++ b/src/DI/Definition/Resolver/ParameterResolver.php
@@ -2,7 +2,6 @@
 
 namespace DI\Definition\Resolver;
 
-use DI\Definition\ObjectDefinition;
 use DI\Definition\Exception\DefinitionException;
 use DI\Definition\Helper\DefinitionHelper;
 use DI\Definition\ObjectDefinition\MethodInjection;

--- a/src/DI/Definition/Resolver/ParameterResolver.php
+++ b/src/DI/Definition/Resolver/ParameterResolver.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://mnapoli.github.com/PHP-DI/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Resolver;
 

--- a/src/DI/Definition/Resolver/ResolverDispatcher.php
+++ b/src/DI/Definition/Resolver/ResolverDispatcher.php
@@ -90,46 +90,55 @@ class ResolverDispatcher implements DefinitionResolver
                 if (! $this->objectResolver) {
                     $this->objectResolver = new ObjectCreator($this, $this->proxyFactory);
                 }
+
                 return $this->objectResolver;
             case ($definition instanceof \DI\Definition\ValueDefinition):
                 if (! $this->valueResolver) {
                     $this->valueResolver = new ValueResolver();
                 }
+
                 return $this->valueResolver;
             case ($definition instanceof \DI\Definition\AliasDefinition):
                 if (! $this->aliasResolver) {
                     $this->aliasResolver = new AliasResolver($this->container);
                 }
+
                 return $this->aliasResolver;
             case ($definition instanceof \DI\Definition\DecoratorDefinition):
                 if (! $this->decoratorResolver) {
                     $this->decoratorResolver = new DecoratorResolver($this->container, $this);
                 }
+
                 return $this->decoratorResolver;
             case ($definition instanceof \DI\Definition\FactoryDefinition):
                 if (! $this->factoryResolver) {
                     $this->factoryResolver = new FactoryResolver($this->container);
                 }
+
                 return $this->factoryResolver;
             case ($definition instanceof \DI\Definition\ArrayDefinition):
                 if (! $this->arrayResolver) {
                     $this->arrayResolver = new ArrayResolver($this);
                 }
+
                 return $this->arrayResolver;
             case ($definition instanceof \DI\Definition\EnvironmentVariableDefinition):
                 if (! $this->envVariableResolver) {
                     $this->envVariableResolver = new EnvironmentVariableResolver($this);
                 }
+
                 return $this->envVariableResolver;
             case ($definition instanceof \DI\Definition\StringDefinition):
                 if (! $this->stringResolver) {
                     $this->stringResolver = new StringResolver($this->container);
                 }
+
                 return $this->stringResolver;
             case ($definition instanceof \DI\Definition\InstanceDefinition):
                 if (! $this->instanceResolver) {
                     $this->instanceResolver = new InstanceInjector($this, $this->proxyFactory);
                 }
+
                 return $this->instanceResolver;
             default:
                 throw new \RuntimeException('No definition resolver was configured for definition of type ' . get_class($definition));

--- a/src/DI/Definition/Resolver/StringResolver.php
+++ b/src/DI/Definition/Resolver/StringResolver.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://mnapoli.github.com/PHP-DI/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Resolver;
 

--- a/src/DI/Definition/Resolver/ValueResolver.php
+++ b/src/DI/Definition/Resolver/ValueResolver.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://mnapoli.github.com/PHP-DI/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Resolver;
 

--- a/src/DI/Definition/Source/AnnotationReader.php
+++ b/src/DI/Definition/Source/AnnotationReader.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Source;
 

--- a/src/DI/Definition/Source/AnnotationReader.php
+++ b/src/DI/Definition/Source/AnnotationReader.php
@@ -4,10 +4,10 @@ namespace DI\Definition\Source;
 
 use DI\Annotation\Inject;
 use DI\Annotation\Injectable;
-use DI\Definition\ObjectDefinition;
 use DI\Definition\EntryReference;
 use DI\Definition\Exception\AnnotationException;
 use DI\Definition\Exception\DefinitionException;
+use DI\Definition\ObjectDefinition;
 use DI\Definition\ObjectDefinition\MethodInjection;
 use DI\Definition\ObjectDefinition\PropertyInjection;
 use Doctrine\Common\Annotations\AnnotationRegistry;

--- a/src/DI/Definition/Source/Autowiring.php
+++ b/src/DI/Definition/Source/Autowiring.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Source;
 

--- a/src/DI/Definition/Source/Autowiring.php
+++ b/src/DI/Definition/Source/Autowiring.php
@@ -2,8 +2,8 @@
 
 namespace DI\Definition\Source;
 
-use DI\Definition\ObjectDefinition;
 use DI\Definition\EntryReference;
+use DI\Definition\ObjectDefinition;
 use DI\Definition\ObjectDefinition\MethodInjection;
 
 /**

--- a/src/DI/Definition/Source/CachedDefinitionSource.php
+++ b/src/DI/Definition/Source/CachedDefinitionSource.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Source;
 

--- a/src/DI/Definition/Source/CachedDefinitionSource.php
+++ b/src/DI/Definition/Source/CachedDefinitionSource.php
@@ -14,7 +14,7 @@ use Doctrine\Common\Cache\Cache;
 class CachedDefinitionSource implements DefinitionSource
 {
     /**
-     * Prefix for cache key, to avoid conflicts with other systems using the same cache
+     * Prefix for cache key, to avoid conflicts with other systems using the same cache.
      * @var string
      */
     const CACHE_PREFIX = 'DI\\Definition\\';
@@ -64,10 +64,10 @@ class CachedDefinitionSource implements DefinitionSource
     }
 
     /**
-     * Fetches a definition from the cache
+     * Fetches a definition from the cache.
      *
      * @param string $name Entry name
-     * @return Definition|null|boolean The cached definition, null or false if the value is not already cached
+     * @return Definition|null|bool The cached definition, null or false if the value is not already cached
      */
     private function fetchFromCache($name)
     {
@@ -83,7 +83,7 @@ class CachedDefinitionSource implements DefinitionSource
     }
 
     /**
-     * Saves a definition to the cache
+     * Saves a definition to the cache.
      *
      * @param string          $name Entry name
      * @param Definition|null $definition

--- a/src/DI/Definition/Source/DefinitionArray.php
+++ b/src/DI/Definition/Source/DefinitionArray.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Source;
 

--- a/src/DI/Definition/Source/DefinitionArray.php
+++ b/src/DI/Definition/Source/DefinitionArray.php
@@ -3,11 +3,11 @@
 namespace DI\Definition\Source;
 
 use DI\Definition\ArrayDefinition;
-use DI\Definition\ObjectDefinition;
 use DI\Definition\Definition;
 use DI\Definition\FactoryDefinition;
-use DI\Definition\ValueDefinition;
 use DI\Definition\Helper\DefinitionHelper;
+use DI\Definition\ObjectDefinition;
+use DI\Definition\ValueDefinition;
 
 /**
  * Reads DI definitions from a PHP array.
@@ -18,12 +18,12 @@ class DefinitionArray implements DefinitionSource, MutableDefinitionSource
 {
     const WILDCARD = '*';
     /**
-     * Matches anything except "\"
+     * Matches anything except "\".
      */
     const WILDCARD_PATTERN = '([^\\\\]+)';
 
     /**
-     * DI definitions in a PHP array
+     * DI definitions in a PHP array.
      * @var array
      */
     private $definitions = [];

--- a/src/DI/Definition/Source/DefinitionFile.php
+++ b/src/DI/Definition/Source/DefinitionFile.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Source;
 

--- a/src/DI/Definition/Source/DefinitionSource.php
+++ b/src/DI/Definition/Source/DefinitionSource.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Source;
 

--- a/src/DI/Definition/Source/SourceChain.php
+++ b/src/DI/Definition/Source/SourceChain.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition\Source;
 

--- a/src/DI/Definition/Source/SourceChain.php
+++ b/src/DI/Definition/Source/SourceChain.php
@@ -54,6 +54,7 @@ class SourceChain implements DefinitionSource, MutableDefinitionSource
                 if ($definition instanceof HasSubDefinition) {
                     $this->resolveSubDefinition($definition, $i);
                 }
+
                 return $definition;
             }
         }

--- a/src/DI/Definition/StringDefinition.php
+++ b/src/DI/Definition/StringDefinition.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition;
 

--- a/src/DI/Definition/StringDefinition.php
+++ b/src/DI/Definition/StringDefinition.php
@@ -13,7 +13,7 @@ use DI\Scope;
 class StringDefinition implements Definition
 {
     /**
-     * Entry name
+     * Entry name.
      * @var string
      */
     private $name;

--- a/src/DI/Definition/ValueDefinition.php
+++ b/src/DI/Definition/ValueDefinition.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Definition;
 

--- a/src/DI/Definition/ValueDefinition.php
+++ b/src/DI/Definition/ValueDefinition.php
@@ -12,7 +12,7 @@ use DI\Scope;
 class ValueDefinition implements Definition
 {
     /**
-     * Entry name
+     * Entry name.
      * @var string
      */
     private $name;

--- a/src/DI/DependencyException.php
+++ b/src/DI/DependencyException.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI;
 

--- a/src/DI/DependencyException.php
+++ b/src/DI/DependencyException.php
@@ -5,7 +5,7 @@ namespace DI;
 use Interop\Container\Exception\ContainerException;
 
 /**
- * Exception for the Container
+ * Exception for the Container.
  */
 class DependencyException extends \Exception implements ContainerException
 {

--- a/src/DI/FactoryInterface.php
+++ b/src/DI/FactoryInterface.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI;
 

--- a/src/DI/InvokerInterface.php
+++ b/src/DI/InvokerInterface.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI;
 

--- a/src/DI/NotFoundException.php
+++ b/src/DI/NotFoundException.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI;
 

--- a/src/DI/NotFoundException.php
+++ b/src/DI/NotFoundException.php
@@ -5,7 +5,7 @@ namespace DI;
 use Interop\Container\Exception\NotFoundException as BaseNotFoundException;
 
 /**
- * Exception thrown when a class or a value is not found in the container
+ * Exception thrown when a class or a value is not found in the container.
  */
 class NotFoundException extends \Exception implements BaseNotFoundException
 {

--- a/src/DI/Proxy/ProxyFactory.php
+++ b/src/DI/Proxy/ProxyFactory.php
@@ -20,7 +20,7 @@ class ProxyFactory
 {
     /**
      * If true, write the proxies to disk to improve performances.
-     * @var boolean
+     * @var bool
      */
     private $writeProxiesToFile;
 
@@ -43,7 +43,7 @@ class ProxyFactory
 
     /**
      * Creates a new lazy proxy instance of the given class with
-     * the given initializer
+     * the given initializer.
      *
      * @param string   $className   name of the class to be proxied
      * @param \Closure $initializer initializer to be passed to the proxy

--- a/src/DI/Proxy/ProxyFactory.php
+++ b/src/DI/Proxy/ProxyFactory.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Proxy;
 

--- a/src/DI/Scope.php
+++ b/src/DI/Scope.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI;
 

--- a/src/DI/functions.php
+++ b/src/DI/functions.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI;
 

--- a/src/DI/functions.php
+++ b/src/DI/functions.php
@@ -4,11 +4,11 @@ namespace DI;
 
 use DI\Definition\EntryReference;
 use DI\Definition\Helper\ArrayDefinitionExtensionHelper;
+use DI\Definition\Helper\EnvironmentVariableDefinitionHelper;
 use DI\Definition\Helper\FactoryDefinitionHelper;
 use DI\Definition\Helper\ObjectDefinitionHelper;
-use DI\Definition\Helper\EnvironmentVariableDefinitionHelper;
-use DI\Definition\Helper\ValueDefinitionHelper;
 use DI\Definition\Helper\StringDefinitionHelper;
+use DI\Definition\Helper\ValueDefinitionHelper;
 
 if (! function_exists('DI\value')) {
     /**

--- a/tests/IntegrationTest/Annotations/A.php
+++ b/tests/IntegrationTest/Annotations/A.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Annotations;
 

--- a/tests/IntegrationTest/Annotations/AnnotationsTest.php
+++ b/tests/IntegrationTest/Annotations/AnnotationsTest.php
@@ -72,7 +72,7 @@ class AnnotationsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Check that @ var annotation takes "use" statements into account
+     * Check that @ var annotation takes "use" statements into account.
      * @test
      * @link https://github.com/PHP-DI/PHP-DI/issues/1
      */
@@ -108,6 +108,7 @@ class AnnotationsTest extends \PHPUnit_Framework_TestCase
         if ($definitions) {
             $builder->addDefinitions($definitions);
         }
+
         return $builder->build();
     }
 }

--- a/tests/IntegrationTest/Annotations/AnnotationsTest.php
+++ b/tests/IntegrationTest/Annotations/AnnotationsTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Annotations;
 

--- a/tests/IntegrationTest/Annotations/B.php
+++ b/tests/IntegrationTest/Annotations/B.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Annotations;
 

--- a/tests/IntegrationTest/Annotations/C.php
+++ b/tests/IntegrationTest/Annotations/C.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Annotations;
 

--- a/tests/IntegrationTest/Annotations/D.php
+++ b/tests/IntegrationTest/Annotations/D.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Annotations;
 

--- a/tests/IntegrationTest/Annotations/InjectWithUseStatements.php
+++ b/tests/IntegrationTest/Annotations/InjectWithUseStatements.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Annotations;
 

--- a/tests/IntegrationTest/Annotations/InjectWithUseStatements/InjectWithUseStatements2.php
+++ b/tests/IntegrationTest/Annotations/InjectWithUseStatements/InjectWithUseStatements2.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Annotations\InjectWithUseStatements;
 

--- a/tests/IntegrationTest/Annotations/NamedInjection.php
+++ b/tests/IntegrationTest/Annotations/NamedInjection.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Annotations;
 

--- a/tests/IntegrationTest/Annotations/NotFoundVarAnnotation.php
+++ b/tests/IntegrationTest/Annotations/NotFoundVarAnnotation.php
@@ -2,7 +2,7 @@
 
 namespace DI\Test\IntegrationTest\Annotations;
 
-use \DI\Annotation\Inject;
+use DI\Annotation\Inject;
 
 class NotFoundVarAnnotation
 {

--- a/tests/IntegrationTest/Annotations/NotFoundVarAnnotation.php
+++ b/tests/IntegrationTest/Annotations/NotFoundVarAnnotation.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Annotations;
 

--- a/tests/IntegrationTest/CacheTest.php
+++ b/tests/IntegrationTest/CacheTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest;
 

--- a/tests/IntegrationTest/CallFunctionTest.php
+++ b/tests/IntegrationTest/CallFunctionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest;
 

--- a/tests/IntegrationTest/CallFunctionTest.php
+++ b/tests/IntegrationTest/CallFunctionTest.php
@@ -24,7 +24,7 @@ class CallFunctionTest extends \PHPUnit_Framework_TestCase
 
     public function test_no_parameters()
     {
-        $result = $this->container->call(function() {
+        $result = $this->container->call(function () {
             return 42;
         });
         $this->assertEquals(42, $result);
@@ -32,15 +32,15 @@ class CallFunctionTest extends \PHPUnit_Framework_TestCase
 
     public function test_parameters_ordered()
     {
-        $result = $this->container->call(function($foo, $bar) {
+        $result = $this->container->call(function ($foo, $bar) {
             return $foo . $bar;
-        }, ['foo', 'bar',]);
+        }, ['foo', 'bar']);
         $this->assertEquals('foobar', $result);
     }
 
     public function test_parameters_indexed_by_name()
     {
-        $result = $this->container->call(function($foo, $bar) {
+        $result = $this->container->call(function ($foo, $bar) {
             return $foo . $bar;
         }, [
             'bar' => 'buzz',
@@ -54,8 +54,9 @@ class CallFunctionTest extends \PHPUnit_Framework_TestCase
         $this->container->set('bar', 'bam');
 
         $self = $this;
-        $result = $this->container->call(function($foo, $bar) use ($self) {
+        $result = $this->container->call(function ($foo, $bar) use ($self) {
             $self->assertInstanceOf('stdClass', $bar);
+
             return $foo;
         }, [
             'bar' => \DI\object('stdClass'),
@@ -69,8 +70,9 @@ class CallFunctionTest extends \PHPUnit_Framework_TestCase
         $this->container->set('bar', 'bam');
 
         $self = $this;
-        $result = $this->container->call(function($foo, $bar) use ($self) {
+        $result = $this->container->call(function ($foo, $bar) use ($self) {
             $self->assertInstanceOf('stdClass', $bar);
+
             return $foo;
         }, [\DI\get('bar'),\DI\object('stdClass')]);
         $this->assertEquals('bam', $result);
@@ -78,7 +80,7 @@ class CallFunctionTest extends \PHPUnit_Framework_TestCase
 
     public function test_parameter_default_value()
     {
-        $result = $this->container->call(function($foo = 'hello') {
+        $result = $this->container->call(function ($foo = 'hello') {
             return $foo;
         });
         $this->assertEquals('hello', $result);
@@ -86,14 +88,14 @@ class CallFunctionTest extends \PHPUnit_Framework_TestCase
 
     public function test_parameter_explicit_value_overrides_default_value()
     {
-        $result = $this->container->call(function($foo = 'hello') {
+        $result = $this->container->call(function ($foo = 'hello') {
             return $foo;
         }, [
             'foo' => 'test',
         ]);
         $this->assertEquals('test', $result);
 
-        $result = $this->container->call(function($foo = 'hello') {
+        $result = $this->container->call(function ($foo = 'hello') {
             return $foo;
         }, ['test']);
         $this->assertEquals('test', $result);
@@ -104,7 +106,7 @@ class CallFunctionTest extends \PHPUnit_Framework_TestCase
         $value = new \stdClass();
         $this->container->set('stdClass', $value);
 
-        $result = $this->container->call(function(\stdClass $foo) {
+        $result = $this->container->call(function (\stdClass $foo) {
             return $foo;
         });
         $this->assertEquals($value, $result);
@@ -120,7 +122,7 @@ class CallFunctionTest extends \PHPUnit_Framework_TestCase
         $subContainerBuilder->wrapContainer($rootContainer);
         $subContainer = $subContainerBuilder->build();
 
-        $result = $subContainer->call(function(\stdClass $foo) {
+        $result = $subContainer->call(function (\stdClass $foo) {
             return $foo;
         });
         $this->assertSame($value, $result, 'The root container was not used for the type-hint');
@@ -193,7 +195,7 @@ class CallFunctionTest extends \PHPUnit_Framework_TestCase
      */
     public function test_not_enough_parameters()
     {
-        $this->container->call(function($foo) {});
+        $this->container->call(function ($foo) {});
     }
 
     /**
@@ -227,6 +229,7 @@ class CallableTestClass
     }
 }
 
-function CallFunctionTest_function($str) {
+function CallFunctionTest_function($str)
+{
     return strlen($str);
 }

--- a/tests/IntegrationTest/Definitions/ArrayDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/ArrayDefinitionTest.php
@@ -6,7 +6,7 @@ use DI\ContainerBuilder;
 use DI\Scope;
 
 /**
- * Test array definitions
+ * Test array definitions.
  *
  * @coversNothing
  */
@@ -73,7 +73,7 @@ class ArrayDefinitionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * An array entry is a singleton
+     * An array entry is a singleton.
      */
     public function test_array_with_prototype_entries()
     {

--- a/tests/IntegrationTest/Definitions/ArrayDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/ArrayDefinitionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Definitions;
 

--- a/tests/IntegrationTest/Definitions/DecoratorDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/DecoratorDefinitionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Definitions;
 

--- a/tests/IntegrationTest/Definitions/DecoratorDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/DecoratorDefinitionTest.php
@@ -6,7 +6,7 @@ use DI\ContainerBuilder;
 use Interop\Container\ContainerInterface;
 
 /**
- * Test decorator definitions
+ * Test decorator definitions.
  *
  * @coversNothing
  */
@@ -55,6 +55,7 @@ class DecoratorDefinitionTest extends \PHPUnit_Framework_TestCase
         $builder->addDefinitions([
             'foo' => \DI\decorate(function ($previous) {
                 $previous->foo = 'bar';
+
                 return $previous;
             }),
         ]);

--- a/tests/IntegrationTest/Definitions/EnvironmentVariableDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/EnvironmentVariableDefinitionTest.php
@@ -5,7 +5,7 @@ namespace DI\Test\IntegrationTest\Definitions;
 use DI\ContainerBuilder;
 
 /**
- * Test environment variable definitions
+ * Test environment variable definitions.
  *
  * @coversNothing
  */

--- a/tests/IntegrationTest/Definitions/EnvironmentVariableDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/EnvironmentVariableDefinitionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Definitions;
 

--- a/tests/IntegrationTest/Definitions/FactoryDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/FactoryDefinitionTest.php
@@ -5,7 +5,7 @@ namespace DI\Test\IntegrationTest\Definitions;
 use DI\ContainerBuilder;
 
 /**
- * Test factory definitions
+ * Test factory definitions.
  *
  * @coversNothing
  */

--- a/tests/IntegrationTest/Definitions/FactoryDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/FactoryDefinitionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Definitions;
 

--- a/tests/IntegrationTest/Definitions/NestedDefinitionsTest.php
+++ b/tests/IntegrationTest/Definitions/NestedDefinitionsTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Definitions;
 

--- a/tests/IntegrationTest/Definitions/ObjectDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/ObjectDefinitionTest.php
@@ -5,7 +5,7 @@ namespace DI\Test\IntegrationTest\Definitions;
 use DI\ContainerBuilder;
 
 /**
- * Test object definitions
+ * Test object definitions.
  *
  * TODO add more tests
  *

--- a/tests/IntegrationTest/Definitions/ObjectDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/ObjectDefinitionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Definitions;
 

--- a/tests/IntegrationTest/Definitions/StringDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/StringDefinitionTest.php
@@ -5,7 +5,7 @@ namespace DI\Test\IntegrationTest\Definitions;
 use DI\ContainerBuilder;
 
 /**
- * Test string definitions
+ * Test string definitions.
  *
  * @coversNothing
  */

--- a/tests/IntegrationTest/Definitions/StringDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/StringDefinitionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Definitions;
 

--- a/tests/IntegrationTest/Definitions/ValueDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/ValueDefinitionTest.php
@@ -7,7 +7,7 @@ use DI\ContainerBuilder;
 use stdClass;
 
 /**
- * Test value definitions
+ * Test value definitions.
  *
  * @coversNothing
  */

--- a/tests/IntegrationTest/Definitions/ValueDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/ValueDefinitionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Definitions;
 

--- a/tests/IntegrationTest/Definitions/WildcardDefinitionsTest.php
+++ b/tests/IntegrationTest/Definitions/WildcardDefinitionsTest.php
@@ -4,10 +4,9 @@ namespace DI\Test\IntegrationTest\Definitions;
 
 use DI\Annotation\Inject;
 use DI\ContainerBuilder;
-use DI\Test\IntegrationTest\Annotations\InjectWithUseStatements;
 
 /**
- * Test definitions using wildcards
+ * Test definitions using wildcards.
  *
  * @coversNothing
  */

--- a/tests/IntegrationTest/Definitions/WildcardDefinitionsTest.php
+++ b/tests/IntegrationTest/Definitions/WildcardDefinitionsTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Definitions;
 

--- a/tests/IntegrationTest/DefinitionsTest.php
+++ b/tests/IntegrationTest/DefinitionsTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest;
 

--- a/tests/IntegrationTest/DefinitionsTest.php
+++ b/tests/IntegrationTest/DefinitionsTest.php
@@ -52,6 +52,7 @@ class DefinitionsTest extends \PHPUnit_Framework_TestCase
         if (! empty($definitions2)) {
             $builder->addDefinitions($definitions2);
         }
+
         return $builder->build();
     }
 }

--- a/tests/IntegrationTest/ErrorMessages/Buggy2.php
+++ b/tests/IntegrationTest/ErrorMessages/Buggy2.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\ErrorMessages;
 

--- a/tests/IntegrationTest/ErrorMessages/Buggy3.php
+++ b/tests/IntegrationTest/ErrorMessages/Buggy3.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\ErrorMessages;
 

--- a/tests/IntegrationTest/ErrorMessages/Buggy4.php
+++ b/tests/IntegrationTest/ErrorMessages/Buggy4.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\ErrorMessages;
 

--- a/tests/IntegrationTest/ErrorMessages/Buggy5.php
+++ b/tests/IntegrationTest/ErrorMessages/Buggy5.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\ErrorMessages;
 

--- a/tests/IntegrationTest/ErrorMessages/ErrorMessagesTest.php
+++ b/tests/IntegrationTest/ErrorMessages/ErrorMessagesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace DI\Test\IntegrationTest\ErrorMessages;
 
 use DI\ContainerBuilder;

--- a/tests/IntegrationTest/Fixtures/Class1.php
+++ b/tests/IntegrationTest/Fixtures/Class1.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Fixtures;
 

--- a/tests/IntegrationTest/Fixtures/Class1.php
+++ b/tests/IntegrationTest/Fixtures/Class1.php
@@ -6,7 +6,7 @@ use DI\Annotation\Inject;
 use DI\Annotation\Injectable;
 
 /**
- * Fixture class
+ * Fixture class.
  * @Injectable(scope="prototype")
  */
 class Class1
@@ -68,7 +68,7 @@ class Class1
         $this->constructorParam3 = $param3;
 
         if ($optional !== true) {
-            throw new \Exception("Expected optional parameter to not be defined");
+            throw new \Exception('Expected optional parameter to not be defined');
         }
     }
 
@@ -84,7 +84,7 @@ class Class1
         $this->method1Param1 = $param1;
 
         if ($optional !== true) {
-            throw new \Exception("Expected optional parameter to not be defined");
+            throw new \Exception('Expected optional parameter to not be defined');
         }
     }
 

--- a/tests/IntegrationTest/Fixtures/Class2.php
+++ b/tests/IntegrationTest/Fixtures/Class2.php
@@ -3,12 +3,12 @@
 namespace DI\Test\IntegrationTest\Fixtures;
 
 /**
- * Fixture class
+ * Fixture class.
  */
 class Class2
 {
     /**
-     * @return boolean
+     * @return bool
      */
     public function getBoolean()
     {

--- a/tests/IntegrationTest/Fixtures/Class2.php
+++ b/tests/IntegrationTest/Fixtures/Class2.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Fixtures;
 

--- a/tests/IntegrationTest/Fixtures/Implementation1.php
+++ b/tests/IntegrationTest/Fixtures/Implementation1.php
@@ -3,9 +3,8 @@
 namespace DI\Test\IntegrationTest\Fixtures;
 
 /**
- * Fixture class
+ * Fixture class.
  */
 class Implementation1 implements Interface1
 {
-
 }

--- a/tests/IntegrationTest/Fixtures/Implementation1.php
+++ b/tests/IntegrationTest/Fixtures/Implementation1.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Fixtures;
 

--- a/tests/IntegrationTest/Fixtures/InheritanceTest/BaseClass.php
+++ b/tests/IntegrationTest/Fixtures/InheritanceTest/BaseClass.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Fixtures\InheritanceTest;
 

--- a/tests/IntegrationTest/Fixtures/InheritanceTest/BaseClass.php
+++ b/tests/IntegrationTest/Fixtures/InheritanceTest/BaseClass.php
@@ -5,7 +5,7 @@ namespace DI\Test\IntegrationTest\Fixtures\InheritanceTest;
 use DI\Annotation\Inject;
 
 /**
- * Fixture class
+ * Fixture class.
  */
 abstract class BaseClass
 {

--- a/tests/IntegrationTest/Fixtures/InheritanceTest/Dependency.php
+++ b/tests/IntegrationTest/Fixtures/InheritanceTest/Dependency.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Fixtures\InheritanceTest;
 

--- a/tests/IntegrationTest/Fixtures/InheritanceTest/Dependency.php
+++ b/tests/IntegrationTest/Fixtures/InheritanceTest/Dependency.php
@@ -3,17 +3,15 @@
 namespace DI\Test\IntegrationTest\Fixtures\InheritanceTest;
 
 /**
- * Fixture class
+ * Fixture class.
  */
 class Dependency
 {
-
     /**
-     * @return boolean
+     * @return bool
      */
     public function getBoolean()
     {
         return true;
     }
-
 }

--- a/tests/IntegrationTest/Fixtures/InheritanceTest/SubClass.php
+++ b/tests/IntegrationTest/Fixtures/InheritanceTest/SubClass.php
@@ -5,7 +5,7 @@ namespace DI\Test\IntegrationTest\Fixtures\InheritanceTest;
 use DI\Annotation\Inject;
 
 /**
- * Fixture class
+ * Fixture class.
  */
 class SubClass extends BaseClass
 {

--- a/tests/IntegrationTest/Fixtures/InheritanceTest/SubClass.php
+++ b/tests/IntegrationTest/Fixtures/InheritanceTest/SubClass.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Fixtures\InheritanceTest;
 

--- a/tests/IntegrationTest/Fixtures/Interface1.php
+++ b/tests/IntegrationTest/Fixtures/Interface1.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Fixtures;
 

--- a/tests/IntegrationTest/Fixtures/Interface1.php
+++ b/tests/IntegrationTest/Fixtures/Interface1.php
@@ -5,10 +5,9 @@ namespace DI\Test\IntegrationTest\Fixtures;
 use DI\Annotation\Injectable;
 
 /**
- * Fixture interface
+ * Fixture interface.
  * @Injectable(scope="singleton")
  */
 interface Interface1
 {
-
 }

--- a/tests/IntegrationTest/Fixtures/LazyDependency.php
+++ b/tests/IntegrationTest/Fixtures/LazyDependency.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Fixtures;
 

--- a/tests/IntegrationTest/Fixtures/LazyDependency.php
+++ b/tests/IntegrationTest/Fixtures/LazyDependency.php
@@ -5,13 +5,13 @@ namespace DI\Test\IntegrationTest\Fixtures;
 use DI\Annotation\Injectable;
 
 /**
- * Fixture class
+ * Fixture class.
  * @Injectable(lazy=true)
  */
 class LazyDependency
 {
     /**
-     * @return boolean
+     * @return bool
      */
     public function getValue()
     {

--- a/tests/IntegrationTest/FunctionsTest.php
+++ b/tests/IntegrationTest/FunctionsTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest;
 

--- a/tests/IntegrationTest/InheritanceTest.php
+++ b/tests/IntegrationTest/InheritanceTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest;
 

--- a/tests/IntegrationTest/InheritanceTest.php
+++ b/tests/IntegrationTest/InheritanceTest.php
@@ -7,14 +7,14 @@ use DI\ContainerBuilder;
 use DI\Test\IntegrationTest\Fixtures\InheritanceTest\SubClass;
 
 /**
- * Test class for bean injection
+ * Test class for bean injection.
  *
  * @coversNothing
  */
 class InheritanceTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * Test a dependency is injected if the injection is defined on a parent class
+     * Test a dependency is injected if the injection is defined on a parent class.
      *
      * @dataProvider containerProvider
      */
@@ -30,7 +30,7 @@ class InheritanceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test a dependency is injected if the injection is defined on a child class
+     * Test a dependency is injected if the injection is defined on a child class.
      *
      * @dataProvider containerProvider
      */
@@ -45,10 +45,9 @@ class InheritanceTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('DI\Test\IntegrationTest\Fixtures\InheritanceTest\Dependency', $instance->property4);
     }
 
-
     /**
      * PHPUnit data provider: generates container configurations for running the same tests
-     * for each configuration possible
+     * for each configuration possible.
      * @return array
      */
     public static function containerProvider()

--- a/tests/IntegrationTest/InjectionTest.php
+++ b/tests/IntegrationTest/InjectionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest;
 

--- a/tests/IntegrationTest/InjectionTest.php
+++ b/tests/IntegrationTest/InjectionTest.php
@@ -2,16 +2,16 @@
 
 namespace DI\Test\IntegrationTest;
 
+use DI\Container;
 use DI\ContainerBuilder;
 use DI\Scope;
-use DI\Container;
 use DI\Test\IntegrationTest\Fixtures\Class1;
 use DI\Test\IntegrationTest\Fixtures\Class2;
 use DI\Test\IntegrationTest\Fixtures\Implementation1;
 use DI\Test\IntegrationTest\Fixtures\LazyDependency;
 
 /**
- * Test class for injection
+ * Test class for injection.
  *
  * @coversNothing Because integration test
  */
@@ -24,7 +24,7 @@ class InjectionTest extends \PHPUnit_Framework_TestCase
 
     /**
      * PHPUnit data provider: generates container configurations for running the same tests
-     * for each configuration possible
+     * for each configuration possible.
      * @return array
      */
     public static function containerProvider()
@@ -226,8 +226,10 @@ class InjectionTest extends \PHPUnit_Framework_TestCase
             /** @var LazyDependency|\ProxyManager\Proxy\LazyLoadingInterface $proxy */
             $proxy = $class1->constructorParam3;
             $this->assertFalse($proxy->isProxyInitialized());
+
             return $proxy;
         }
+
         return null;
     }
 
@@ -243,6 +245,7 @@ class InjectionTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('DI\Test\IntegrationTest\Fixtures\LazyDependency', $proxy);
         $this->assertInstanceOf('ProxyManager\Proxy\LazyLoadingInterface', $proxy);
         $this->assertFalse($proxy->isProxyInitialized());
+
         return $proxy;
     }
 

--- a/tests/IntegrationTest/Issues/Issue141Test.php
+++ b/tests/IntegrationTest/Issues/Issue141Test.php
@@ -5,7 +5,7 @@ namespace DI\Test\IntegrationTest\Issues;
 use DI\ContainerBuilder;
 
 /**
- * Test that chaining several sources works
+ * Test that chaining several sources works.
  *
  * @see https://github.com/mnapoli/PHP-DI/issues/141
  *

--- a/tests/IntegrationTest/Issues/Issue141Test.php
+++ b/tests/IntegrationTest/Issues/Issue141Test.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Issues;
 

--- a/tests/IntegrationTest/Issues/Issue168Test.php
+++ b/tests/IntegrationTest/Issues/Issue168Test.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Issues;
 

--- a/tests/IntegrationTest/Issues/Issue70and76Test.php
+++ b/tests/IntegrationTest/Issues/Issue70and76Test.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Issues;
 

--- a/tests/IntegrationTest/Issues/Issue72/Class1.php
+++ b/tests/IntegrationTest/Issues/Issue72/Class1.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Issues\Issue72;
 

--- a/tests/IntegrationTest/Issues/Issue72/definitions.php
+++ b/tests/IntegrationTest/Issues/Issue72/definitions.php
@@ -4,6 +4,7 @@ return [
     'service2' => \DI\factory(function () {
         $value = new \stdClass();
         $value->foo = 'bar';
+
         return $value;
     }),
     'DI\Test\IntegrationTest\Issues\Issue72\Class1' => \DI\object()

--- a/tests/IntegrationTest/Issues/Issue72/definitions2.php
+++ b/tests/IntegrationTest/Issues/Issue72/definitions2.php
@@ -4,6 +4,7 @@ return [
     'service3' => \DI\factory(function () {
         $value = new \stdClass();
         $value->foo = 'baz';
+
         return $value;
     }),
     'DI\Test\IntegrationTest\Issues\Issue72\Class1' => \DI\object()

--- a/tests/IntegrationTest/Issues/Issue72Test.php
+++ b/tests/IntegrationTest/Issues/Issue72Test.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest\Issues;
 

--- a/tests/IntegrationTest/Issues/Issue72Test.php
+++ b/tests/IntegrationTest/Issues/Issue72Test.php
@@ -6,7 +6,7 @@ use DI\ContainerBuilder;
 use DI\Test\IntegrationTest\Issues\Issue72\Class1;
 
 /**
- * Test that the manager prioritize correctly the different sources
+ * Test that the manager prioritize correctly the different sources.
  *
  * @see https://github.com/mnapoli/PHP-DI/issues/72
  *

--- a/tests/IntegrationTest/ProxyTest.php
+++ b/tests/IntegrationTest/ProxyTest.php
@@ -70,6 +70,7 @@ class ProxyTest extends \PHPUnit_Framework_TestCase
         $builder = new ContainerBuilder;
         $builder->useAutowiring(false);
         $builder->addDefinitions($definitions);
+
         return $builder->build();
     }
 }

--- a/tests/IntegrationTest/ProxyTest.php
+++ b/tests/IntegrationTest/ProxyTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\IntegrationTest;
 

--- a/tests/UnitTest/Annotation/Fixtures/Dependency.php
+++ b/tests/UnitTest/Annotation/Fixtures/Dependency.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Annotation\Fixtures;
 

--- a/tests/UnitTest/Annotation/Fixtures/InjectFixture.php
+++ b/tests/UnitTest/Annotation/Fixtures/InjectFixture.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Annotation\Fixtures;
 

--- a/tests/UnitTest/Annotation/Fixtures/Injectable1.php
+++ b/tests/UnitTest/Annotation/Fixtures/Injectable1.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Annotation\Fixtures;
 

--- a/tests/UnitTest/Annotation/Fixtures/Injectable2.php
+++ b/tests/UnitTest/Annotation/Fixtures/Injectable2.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Annotation\Fixtures;
 

--- a/tests/UnitTest/Annotation/Fixtures/Injectable3.php
+++ b/tests/UnitTest/Annotation/Fixtures/Injectable3.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Annotation\Fixtures;
 

--- a/tests/UnitTest/Annotation/Fixtures/MixedAnnotationsFixture.php
+++ b/tests/UnitTest/Annotation/Fixtures/MixedAnnotationsFixture.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Annotation\Fixtures;
 

--- a/tests/UnitTest/Annotation/Fixtures/NonImportedInjectFixture.php
+++ b/tests/UnitTest/Annotation/Fixtures/NonImportedInjectFixture.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Annotation\Fixtures;
 

--- a/tests/UnitTest/Annotation/InjectTest.php
+++ b/tests/UnitTest/Annotation/InjectTest.php
@@ -8,7 +8,7 @@ use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
 use ReflectionClass;
 
 /**
- * Inject annotation test class
+ * Inject annotation test class.
  *
  * @covers \DI\Annotation\Inject
  */
@@ -109,7 +109,7 @@ class InjectTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Inject annotation should work even if not imported
+     * Inject annotation should work even if not imported.
      */
     public function testNonImportedAnnotation()
     {
@@ -122,7 +122,7 @@ class InjectTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Inject annotation should work even if there are other weird annotations in the file
+     * Inject annotation should work even if there are other weird annotations in the file.
      */
     public function testMixedAnnotations()
     {

--- a/tests/UnitTest/Annotation/InjectTest.php
+++ b/tests/UnitTest/Annotation/InjectTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Annotation;
 

--- a/tests/UnitTest/Annotation/InjectableTest.php
+++ b/tests/UnitTest/Annotation/InjectableTest.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
 use ReflectionClass;
 
 /**
- * Injectable annotation test class
+ * Injectable annotation test class.
  *
  * @covers \DI\Annotation\Injectable
  */

--- a/tests/UnitTest/Annotation/InjectableTest.php
+++ b/tests/UnitTest/Annotation/InjectableTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Annotation;
 

--- a/tests/UnitTest/Cache/CacheTest.php
+++ b/tests/UnitTest/Cache/CacheTest.php
@@ -31,17 +31,16 @@ abstract class CacheTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($cache->contains('key'));
     }
 
-
     public function provideCrudValues()
     {
-        return array(
-            'array' => array(array('one', 2, 3.0)),
-            'string' => array('value'),
-            'integer' => array(1),
-            'float' => array(1.5),
-            'object' => array(new ArrayObject()),
-            'null' => array(null),
-        );
+        return [
+            'array'   => [['one', 2, 3.0]],
+            'string'  => ['value'],
+            'integer' => [1],
+            'float'   => [1.5],
+            'object'  => [new ArrayObject()],
+            'null'    => [null],
+        ];
     }
 
     public function testDeleteAll()
@@ -100,15 +99,15 @@ abstract class CacheTest extends \PHPUnit_Framework_TestCase
      */
     public function falseCastedValuesProvider()
     {
-        return array(
-            array(false),
-            array(null),
-            array(array()),
-            array('0'),
-            array(0),
-            array(0.0),
-            array('')
-        );
+        return [
+            [false],
+            [null],
+            [[]],
+            ['0'],
+            [0],
+            [0.0],
+            [''],
+        ];
     }
 
     /**
@@ -120,20 +119,20 @@ abstract class CacheTest extends \PHPUnit_Framework_TestCase
         $cache = $this->getCacheDriver();
         $cache->deleteAll();
         $obj = new \stdClass();
-        $obj->foo = "bar";
+        $obj->foo = 'bar';
         $obj2 = new \stdClass();
-        $obj2->bar = "foo";
+        $obj2->bar = 'foo';
         $obj2->obj = $obj;
         $obj->obj2 = $obj2;
-        $cache->save("obj", $obj);
+        $cache->save('obj', $obj);
 
-        $fetched = $cache->fetch("obj");
+        $fetched = $cache->fetch('obj');
 
-        $this->assertInstanceOf("stdClass", $obj);
-        $this->assertInstanceOf("stdClass", $obj->obj2);
-        $this->assertInstanceOf("stdClass", $obj->obj2->obj);
-        $this->assertEquals("bar", $fetched->foo);
-        $this->assertEquals("foo", $fetched->obj2->bar);
+        $this->assertInstanceOf('stdClass', $obj);
+        $this->assertInstanceOf('stdClass', $obj->obj2);
+        $this->assertInstanceOf('stdClass', $obj->obj2->obj);
+        $this->assertEquals('bar', $fetched->foo);
+        $this->assertEquals('foo', $fetched->obj2->bar);
     }
 
     /**

--- a/tests/UnitTest/ContainerBuilderTest.php
+++ b/tests/UnitTest/ContainerBuilderTest.php
@@ -3,8 +3,8 @@
 namespace DI\Test\UnitTest;
 
 use DI\ContainerBuilder;
-use DI\Definition\Source\DefinitionArray;
 use DI\Definition\Source\CachedDefinitionSource;
+use DI\Definition\Source\DefinitionArray;
 use DI\Definition\ValueDefinition;
 use DI\Test\UnitTest\Fixtures\FakeContainer;
 use EasyMock\EasyMock;

--- a/tests/UnitTest/ContainerBuilderTest.php
+++ b/tests/UnitTest/ContainerBuilderTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest;
 

--- a/tests/UnitTest/ContainerCallTest.php
+++ b/tests/UnitTest/ContainerCallTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest;
 

--- a/tests/UnitTest/ContainerGetTest.php
+++ b/tests/UnitTest/ContainerGetTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest;
 

--- a/tests/UnitTest/ContainerGetTest.php
+++ b/tests/UnitTest/ContainerGetTest.php
@@ -6,7 +6,7 @@ use DI\ContainerBuilder;
 use stdClass;
 
 /**
- * Test class for Container
+ * Test class for Container.
  *
  * @covers \DI\Container
  */
@@ -130,7 +130,7 @@ class ContainerGetTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Tests a class can be initialized with a parameter passed by reference
+     * Tests a class can be initialized with a parameter passed by reference.
      */
     public function testPassByReferenceParameter()
     {

--- a/tests/UnitTest/ContainerMakeTest.php
+++ b/tests/UnitTest/ContainerMakeTest.php
@@ -6,7 +6,7 @@ use DI\ContainerBuilder;
 use stdClass;
 
 /**
- * Test class for Container
+ * Test class for Container.
  *
  * @covers \DI\Container
  */
@@ -118,7 +118,7 @@ class ContainerMakeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Tests a dependency can be made when a dependency is passed by reference
+     * Tests a dependency can be made when a dependency is passed by reference.
      */
     public function testPassByReferenceParameter()
     {
@@ -127,14 +127,14 @@ class ContainerMakeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Tests the parameter can be provided by reference
+     * Tests the parameter can be provided by reference.
      */
     public function testProvidedPassByReferenceParameter()
     {
         $object = new stdClass();
         $container = ContainerBuilder::buildDevContainer();
         $fetched = $container->make('DI\Test\UnitTest\Fixtures\PassByReferenceDependency', [
-            'object' => &$object
+            'object' => &$object,
         ]);
         $this->assertEquals('bar', $object->foo);
     }

--- a/tests/UnitTest/ContainerMakeTest.php
+++ b/tests/UnitTest/ContainerMakeTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest;
 

--- a/tests/UnitTest/ContainerTest.php
+++ b/tests/UnitTest/ContainerTest.php
@@ -6,7 +6,7 @@ use DI\ContainerBuilder;
 use stdClass;
 
 /**
- * Test class for Container
+ * Test class for Container.
  *
  * @covers \DI\Container
  */
@@ -32,7 +32,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test that injecting an existing object returns the same reference to that object
+     * Test that injecting an existing object returns the same reference to that object.
      */
     public function testInjectOnMaintainsReferentialEquality()
     {
@@ -44,7 +44,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test that injection on null yields null
+     * Test that injection on null yields null.
      */
     public function testInjectNull()
     {
@@ -55,7 +55,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * We should be able to set a null value
+     * We should be able to set a null value.
      * @see https://github.com/mnapoli/PHP-DI/issues/79
      */
     public function testSetNullValue()
@@ -67,7 +67,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * The container auto-registers itself
+     * The container auto-registers itself.
      */
     public function testContainerIsRegistered()
     {
@@ -77,7 +77,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * The container auto-registers itself (with the factory interface)
+     * The container auto-registers itself (with the factory interface).
      */
     public function testFactoryInterfaceIsRegistered()
     {
@@ -87,7 +87,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * The container auto-registers itself (with the invoker interface)
+     * The container auto-registers itself (with the invoker interface).
      */
     public function testInvokerInterfaceIsRegistered()
     {

--- a/tests/UnitTest/ContainerTest.php
+++ b/tests/UnitTest/ContainerTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest;
 

--- a/tests/UnitTest/DebugTest.php
+++ b/tests/UnitTest/DebugTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest;
 

--- a/tests/UnitTest/Definition/AliasDefinitionTest.php
+++ b/tests/UnitTest/Definition/AliasDefinitionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition;
 

--- a/tests/UnitTest/Definition/ArrayDefinitionExtensionTest.php
+++ b/tests/UnitTest/Definition/ArrayDefinitionExtensionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition;
 

--- a/tests/UnitTest/Definition/ArrayDefinitionTest.php
+++ b/tests/UnitTest/Definition/ArrayDefinitionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition;
 

--- a/tests/UnitTest/Definition/DecoratorDefinitionTest.php
+++ b/tests/UnitTest/Definition/DecoratorDefinitionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition;
 

--- a/tests/UnitTest/Definition/Dumper/AliasDefinitionDumperTest.php
+++ b/tests/UnitTest/Definition/Dumper/AliasDefinitionDumperTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Dumper;
 

--- a/tests/UnitTest/Definition/Dumper/ArrayDefinitionDumperTest.php
+++ b/tests/UnitTest/Definition/Dumper/ArrayDefinitionDumperTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Dumper;
 

--- a/tests/UnitTest/Definition/Dumper/DecoratorDefinitionDumperTest.php
+++ b/tests/UnitTest/Definition/Dumper/DecoratorDefinitionDumperTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Dumper;
 

--- a/tests/UnitTest/Definition/Dumper/DefinitionDumperDispatcherTest.php
+++ b/tests/UnitTest/Definition/Dumper/DefinitionDumperDispatcherTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Dumper;
 

--- a/tests/UnitTest/Definition/Dumper/DefinitionDumperDispatcherTest.php
+++ b/tests/UnitTest/Definition/Dumper/DefinitionDumperDispatcherTest.php
@@ -4,17 +4,17 @@ namespace DI\Test\UnitTest\Definition\Dumper;
 
 use DI\Definition\AliasDefinition;
 use DI\Definition\DecoratorDefinition;
-use DI\Definition\Dumper\DecoratorDefinitionDumper;
-use DI\Definition\ObjectDefinition;
 use DI\Definition\Dumper\AliasDefinitionDumper;
-use DI\Definition\Dumper\ObjectDefinitionDumper;
+use DI\Definition\Dumper\DecoratorDefinitionDumper;
 use DI\Definition\Dumper\DefinitionDumperDispatcher;
-use DI\Definition\Dumper\FactoryDefinitionDumper;
-use DI\Definition\Dumper\ValueDefinitionDumper;
 use DI\Definition\Dumper\EnvironmentVariableDefinitionDumper;
-use DI\Definition\FactoryDefinition;
-use DI\Definition\ValueDefinition;
+use DI\Definition\Dumper\FactoryDefinitionDumper;
+use DI\Definition\Dumper\ObjectDefinitionDumper;
+use DI\Definition\Dumper\ValueDefinitionDumper;
 use DI\Definition\EnvironmentVariableDefinition;
+use DI\Definition\FactoryDefinition;
+use DI\Definition\ObjectDefinition;
+use DI\Definition\ValueDefinition;
 
 /**
  * @covers \DI\Definition\Dumper\DefinitionDumperDispatcher
@@ -36,7 +36,7 @@ class DefinitionDumperDispatcherTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue('foo'));
 
         $dumper = new DefinitionDumperDispatcher([
-            get_class($definition) => $subDumper
+            get_class($definition) => $subDumper,
         ]);
 
         $this->assertEquals('foo', $dumper->dump($definition));

--- a/tests/UnitTest/Definition/Dumper/EnvironmentVariableDefinitionDumperTest.php
+++ b/tests/UnitTest/Definition/Dumper/EnvironmentVariableDefinitionDumperTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Dumper;
 

--- a/tests/UnitTest/Definition/Dumper/FactoryDefinitionDumperTest.php
+++ b/tests/UnitTest/Definition/Dumper/FactoryDefinitionDumperTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Dumper;
 

--- a/tests/UnitTest/Definition/Dumper/ObjectDefinitionDumperTest.php
+++ b/tests/UnitTest/Definition/Dumper/ObjectDefinitionDumperTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Dumper;
 

--- a/tests/UnitTest/Definition/Dumper/ObjectDefinitionDumperTest.php
+++ b/tests/UnitTest/Definition/Dumper/ObjectDefinitionDumperTest.php
@@ -2,8 +2,8 @@
 
 namespace DI\Test\UnitTest\Definition\Dumper;
 
-use DI\Definition\ObjectDefinition;
 use DI\Definition\Dumper\ObjectDefinitionDumper;
+use DI\Definition\ObjectDefinition;
 use DI\Definition\ValueDefinition;
 use DI\Scope;
 

--- a/tests/UnitTest/Definition/Dumper/StringDefinitionDumperTest.php
+++ b/tests/UnitTest/Definition/Dumper/StringDefinitionDumperTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Dumper;
 

--- a/tests/UnitTest/Definition/Dumper/ValueDefinitionDumperTest.php
+++ b/tests/UnitTest/Definition/Dumper/ValueDefinitionDumperTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Dumper;
 

--- a/tests/UnitTest/Definition/EntryReferenceTest.php
+++ b/tests/UnitTest/Definition/EntryReferenceTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition;
 

--- a/tests/UnitTest/Definition/EnvironmentVariableDefinitionTest.php
+++ b/tests/UnitTest/Definition/EnvironmentVariableDefinitionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition;
 

--- a/tests/UnitTest/Definition/FactoryDefinitionTest.php
+++ b/tests/UnitTest/Definition/FactoryDefinitionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition;
 

--- a/tests/UnitTest/Definition/Helper/ArrayDefinitionExtensionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/ArrayDefinitionExtensionHelperTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Helper;
 

--- a/tests/UnitTest/Definition/Helper/EnvironmentVariableDefinitionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/EnvironmentVariableDefinitionHelperTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Helper;
 

--- a/tests/UnitTest/Definition/Helper/FactoryDefinitionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/FactoryDefinitionHelperTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Helper;
 

--- a/tests/UnitTest/Definition/Helper/Fixtures/Class1.php
+++ b/tests/UnitTest/Definition/Helper/Fixtures/Class1.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Helper\Fixtures;
 

--- a/tests/UnitTest/Definition/Helper/ObjectDefinitionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/ObjectDefinitionHelperTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Helper;
 

--- a/tests/UnitTest/Definition/Helper/ObjectDefinitionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/ObjectDefinitionHelperTest.php
@@ -2,9 +2,8 @@
 
 namespace DI\Test\UnitTest\Definition\Helper;
 
-use DI\Definition\ObjectDefinition\MethodInjection;
-use DI\Definition\Exception\DefinitionException;
 use DI\Definition\Helper\ObjectDefinitionHelper;
+use DI\Definition\ObjectDefinition\MethodInjection;
 use DI\Scope;
 
 /**
@@ -154,7 +153,7 @@ class ObjectDefinitionHelperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Check using the parameter name, not its index
+     * Check using the parameter name, not its index.
      */
     public function allows_to_override_a_parameter_injection_by_name()
     {
@@ -171,7 +170,7 @@ class ObjectDefinitionHelperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * If using methodParameter() for "__construct", then the constructor definition should be updated
+     * If using methodParameter() for "__construct", then the constructor definition should be updated.
      */
     public function should_update_constructor_definition_if_overriding_parameter_for_constructor()
     {

--- a/tests/UnitTest/Definition/Helper/StringDefinitionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/StringDefinitionHelperTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Helper;
 

--- a/tests/UnitTest/Definition/Helper/ValueDefinitionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/ValueDefinitionHelperTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Helper;
 

--- a/tests/UnitTest/Definition/InstanceDefinitionTest.php
+++ b/tests/UnitTest/Definition/InstanceDefinitionTest.php
@@ -2,7 +2,6 @@
 
 namespace DI\Test\UnitTest\Definition;
 
-use DI\Definition\ObjectDefinition;
 use DI\Definition\InstanceDefinition;
 use DI\Scope;
 use EasyMock\EasyMock;

--- a/tests/UnitTest/Definition/InstanceDefinitionTest.php
+++ b/tests/UnitTest/Definition/InstanceDefinitionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition;
 

--- a/tests/UnitTest/Definition/ObjectDefinition/MethodInjectionTest.php
+++ b/tests/UnitTest/Definition/ObjectDefinition/MethodInjectionTest.php
@@ -37,7 +37,7 @@ class MethodInjectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Check that a merge will preserve "null" injections
+     * Check that a merge will preserve "null" injections.
      */
     public function testMergeParametersPreservesNull()
     {

--- a/tests/UnitTest/Definition/ObjectDefinition/PropertyInjectionTest.php
+++ b/tests/UnitTest/Definition/ObjectDefinition/PropertyInjectionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\ObjectDefinition;
 

--- a/tests/UnitTest/Definition/ObjectDefinitionTest.php
+++ b/tests/UnitTest/Definition/ObjectDefinitionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition;
 

--- a/tests/UnitTest/Definition/Resolver/AliasResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/AliasResolverTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Resolver;
 

--- a/tests/UnitTest/Definition/Resolver/ArrayResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/ArrayResolverTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Resolver;
 

--- a/tests/UnitTest/Definition/Resolver/DecoratorResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/DecoratorResolverTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Resolver;
 

--- a/tests/UnitTest/Definition/Resolver/EnvironmentVariableResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/EnvironmentVariableResolverTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Resolver;
 

--- a/tests/UnitTest/Definition/Resolver/FactoryResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/FactoryResolverTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Resolver;
 

--- a/tests/UnitTest/Definition/Resolver/Fixture/FixtureAbstractClass.php
+++ b/tests/UnitTest/Definition/Resolver/Fixture/FixtureAbstractClass.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Resolver\Fixture;
 

--- a/tests/UnitTest/Definition/Resolver/Fixture/FixtureClass.php
+++ b/tests/UnitTest/Definition/Resolver/Fixture/FixtureClass.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Resolver\Fixture;
 

--- a/tests/UnitTest/Definition/Resolver/Fixture/FixtureInterface.php
+++ b/tests/UnitTest/Definition/Resolver/Fixture/FixtureInterface.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Resolver\Fixture;
 

--- a/tests/UnitTest/Definition/Resolver/Fixture/NoConstructor.php
+++ b/tests/UnitTest/Definition/Resolver/Fixture/NoConstructor.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Resolver\Fixture;
 

--- a/tests/UnitTest/Definition/Resolver/InstanceInjectorTest.php
+++ b/tests/UnitTest/Definition/Resolver/InstanceInjectorTest.php
@@ -2,10 +2,10 @@
 
 namespace DI\Test\UnitTest\Definition\Resolver;
 
+use DI\Definition\InstanceDefinition;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\ObjectDefinition\MethodInjection;
 use DI\Definition\ObjectDefinition\PropertyInjection;
-use DI\Definition\InstanceDefinition;
 use DI\Definition\Resolver\InstanceInjector;
 use DI\Definition\Resolver\ResolverDispatcher;
 use DI\Proxy\ProxyFactory;

--- a/tests/UnitTest/Definition/Resolver/InstanceInjectorTest.php
+++ b/tests/UnitTest/Definition/Resolver/InstanceInjectorTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Resolver;
 

--- a/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
+++ b/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
@@ -5,8 +5,8 @@ namespace DI\Test\UnitTest\Definition\Resolver;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\ObjectDefinition\MethodInjection;
 use DI\Definition\ObjectDefinition\PropertyInjection;
-use DI\Definition\Resolver\ObjectCreator;
 use DI\Definition\Resolver\DefinitionResolver;
+use DI\Definition\Resolver\ObjectCreator;
 use DI\Proxy\ProxyFactory;
 use EasyMock\EasyMock;
 use PHPUnit_Framework_MockObject_MockObject;
@@ -79,7 +79,7 @@ class ObjectCreatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Check that given parameters override the definition
+     * Check that given parameters override the definition.
      */
     public function testResolveWithParametersAndDefinition()
     {
@@ -93,7 +93,7 @@ class ObjectCreatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Check that useless parameters are ignored (no error)
+     * Check that useless parameters are ignored (no error).
      */
     public function testResolveWithUselessParameters()
     {
@@ -106,7 +106,7 @@ class ObjectCreatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Check that nested definitions are resolved in parameters
+     * Check that nested definitions are resolved in parameters.
      */
     public function testResolveWithNestedDefinitionInParameters()
     {
@@ -128,7 +128,7 @@ class ObjectCreatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Check that nested definitions are resolved in properties
+     * Check that nested definitions are resolved in properties.
      */
     public function testResolveWithNestedDefinitionInProperties()
     {
@@ -149,7 +149,7 @@ class ObjectCreatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Check that we can inject "null" into parameters and properties
+     * Check that we can inject "null" into parameters and properties.
      */
     public function testResolveNullInjections()
     {

--- a/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
+++ b/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Resolver;
 

--- a/tests/UnitTest/Definition/Resolver/ResolverDispatcherTest.php
+++ b/tests/UnitTest/Definition/Resolver/ResolverDispatcherTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Resolver;
 

--- a/tests/UnitTest/Definition/Resolver/StringResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/StringResolverTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Resolver;
 

--- a/tests/UnitTest/Definition/Resolver/ValueResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/ValueResolverTest.php
@@ -2,8 +2,8 @@
 
 namespace DI\Test\UnitTest\Definition\Resolver;
 
-use DI\Definition\ValueDefinition;
 use DI\Definition\Resolver\ValueResolver;
+use DI\Definition\ValueDefinition;
 
 /**
  * @covers \DI\Definition\Resolver\ValueResolver

--- a/tests/UnitTest/Definition/Resolver/ValueResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/ValueResolverTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Resolver;
 

--- a/tests/UnitTest/Definition/Source/AnnotationReaderTest.php
+++ b/tests/UnitTest/Definition/Source/AnnotationReaderTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Source;
 

--- a/tests/UnitTest/Definition/Source/AnnotationReaderTest.php
+++ b/tests/UnitTest/Definition/Source/AnnotationReaderTest.php
@@ -261,6 +261,7 @@ class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
                 return $methodInjection;
             }
         }
+
         return null;
     }
 }

--- a/tests/UnitTest/Definition/Source/AutowiringTest.php
+++ b/tests/UnitTest/Definition/Source/AutowiringTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Source;
 

--- a/tests/UnitTest/Definition/Source/CachedDefinitionSourceTest.php
+++ b/tests/UnitTest/Definition/Source/CachedDefinitionSourceTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Source;
 

--- a/tests/UnitTest/Definition/Source/CachedDefinitionSourceTest.php
+++ b/tests/UnitTest/Definition/Source/CachedDefinitionSourceTest.php
@@ -2,8 +2,8 @@
 
 namespace DI\Test\UnitTest\Definition\Source;
 
-use DI\Definition\Source\DefinitionArray;
 use DI\Definition\Source\CachedDefinitionSource;
+use DI\Definition\Source\DefinitionArray;
 use DI\Definition\ValueDefinition;
 use Doctrine\Common\Cache\Cache;
 use EasyMock\EasyMock;

--- a/tests/UnitTest/Definition/Source/DefinitionArrayTest.php
+++ b/tests/UnitTest/Definition/Source/DefinitionArrayTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Source;
 

--- a/tests/UnitTest/Definition/Source/DefinitionArrayTest.php
+++ b/tests/UnitTest/Definition/Source/DefinitionArrayTest.php
@@ -170,10 +170,10 @@ class DefinitionArrayTest extends \PHPUnit_Framework_TestCase
     public function testWildcards()
     {
         $source = new DefinitionArray([
-            'foo*' => 'bar',
-            'Namespaced\*Interface' => \DI\object('Namespaced\*'),
+            'foo*'                   => 'bar',
+            'Namespaced\*Interface'  => \DI\object('Namespaced\*'),
             'Namespaced2\*Interface' => \DI\object('Namespaced2\Foo'),
-            'Multiple\*\*\Matches' => \DI\object('Multiple\*\*\Implementation')
+            'Multiple\*\*\Matches'   => \DI\object('Multiple\*\*\Implementation'),
         ]);
 
         $definition = $source->getDefinition('foo1');
@@ -213,7 +213,7 @@ class DefinitionArrayTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * The wildcard should not match empty strings
+     * The wildcard should not match empty strings.
      */
     public function testWildcardShouldNotMatchEmptyString()
     {

--- a/tests/UnitTest/Definition/Source/DefinitionFileTest.php
+++ b/tests/UnitTest/Definition/Source/DefinitionFileTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Source;
 

--- a/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixture.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixture.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Source\Fixtures;
 

--- a/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixture.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixture.php
@@ -25,7 +25,7 @@ class AnnotationFixture
     protected $unannotatedProperty;
 
     /**
-     * Static property shouldn't be injected
+     * Static property shouldn't be injected.
      *
      * @Inject("foo")
      */
@@ -71,7 +71,7 @@ class AnnotationFixture
     }
 
     /**
-     * Indexed by name, param1 not specified:
+     * Indexed by name, param1 not specified:.
      * @Inject({"param2" = "bar"})
      */
     public function method5($param1, $param2)

--- a/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixture2.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixture2.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Source\Fixtures;
 

--- a/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixture3.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixture3.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Source\Fixtures;
 

--- a/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixture4.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixture4.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Source\Fixtures;
 

--- a/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixture5.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixture5.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Source\Fixtures;
 

--- a/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixtureChild.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixtureChild.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Source\Fixtures;
 

--- a/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixtureParent.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixtureParent.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Source\Fixtures;
 

--- a/tests/UnitTest/Definition/Source/Fixtures/AnnotationInjectableFixture.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AnnotationInjectableFixture.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Source\Fixtures;
 

--- a/tests/UnitTest/Definition/Source/Fixtures/AutowiringFixture.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AutowiringFixture.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Source\Fixtures;
 

--- a/tests/UnitTest/Definition/Source/Fixtures/AutowiringFixture.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AutowiringFixture.php
@@ -3,7 +3,7 @@
 namespace DI\Test\UnitTest\Definition\Source\Fixtures;
 
 /**
- * Fixture class for the Autowiring tests
+ * Fixture class for the Autowiring tests.
  */
 class AutowiringFixture
 {

--- a/tests/UnitTest/Definition/Source/Fixtures/AutowiringFixtureChild.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AutowiringFixtureChild.php
@@ -3,7 +3,7 @@
 namespace DI\Test\UnitTest\Definition\Source\Fixtures;
 
 /**
- * Fixture class for the Autowiring tests
+ * Fixture class for the Autowiring tests.
  */
 class AutowiringFixtureChild extends AutowiringFixture
 {

--- a/tests/UnitTest/Definition/Source/Fixtures/AutowiringFixtureChild.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AutowiringFixtureChild.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Source\Fixtures;
 

--- a/tests/UnitTest/Definition/Source/SourceChainTest.php
+++ b/tests/UnitTest/Definition/Source/SourceChainTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition\Source;
 

--- a/tests/UnitTest/Definition/Source/SourceChainTest.php
+++ b/tests/UnitTest/Definition/Source/SourceChainTest.php
@@ -2,10 +2,10 @@
 
 namespace DI\Test\UnitTest\Definition\Source;
 
-use DI\Definition\ObjectDefinition;
 use DI\Definition\Definition;
-use DI\Definition\Source\DefinitionArray;
+use DI\Definition\ObjectDefinition;
 use DI\Definition\Source\Autowiring;
+use DI\Definition\Source\DefinitionArray;
 use DI\Definition\Source\SourceChain;
 use DI\Definition\ValueDefinition;
 

--- a/tests/UnitTest/Definition/StringDefinitionTest.php
+++ b/tests/UnitTest/Definition/StringDefinitionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition;
 

--- a/tests/UnitTest/Definition/ValueDefinitionTest.php
+++ b/tests/UnitTest/Definition/ValueDefinitionTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Definition;
 

--- a/tests/UnitTest/Fixtures/Class1CircularDependencies.php
+++ b/tests/UnitTest/Fixtures/Class1CircularDependencies.php
@@ -3,8 +3,7 @@
 namespace DI\Test\UnitTest\Fixtures;
 
 /**
- * Fixture class for testing circular dependencies
- *
+ * Fixture class for testing circular dependencies.
  */
 class Class1CircularDependencies
 {

--- a/tests/UnitTest/Fixtures/Class1CircularDependencies.php
+++ b/tests/UnitTest/Fixtures/Class1CircularDependencies.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Fixtures;
 

--- a/tests/UnitTest/Fixtures/Class2CircularDependencies.php
+++ b/tests/UnitTest/Fixtures/Class2CircularDependencies.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Fixtures;
 

--- a/tests/UnitTest/Fixtures/Class2CircularDependencies.php
+++ b/tests/UnitTest/Fixtures/Class2CircularDependencies.php
@@ -3,8 +3,7 @@
 namespace DI\Test\UnitTest\Fixtures;
 
 /**
- * Fixture class for testing circular dependencies
- *
+ * Fixture class for testing circular dependencies.
  */
 class Class2CircularDependencies
 {

--- a/tests/UnitTest/Fixtures/FakeContainer.php
+++ b/tests/UnitTest/Fixtures/FakeContainer.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://mnapoli.github.com/PHP-DI/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Fixtures;
 

--- a/tests/UnitTest/Fixtures/InvalidScope.php
+++ b/tests/UnitTest/Fixtures/InvalidScope.php
@@ -5,7 +5,7 @@ namespace DI\Test\UnitTest\Fixtures;
 use DI\Annotation\Injectable;
 
 /**
- * Fixture class for testing Singleton scope
+ * Fixture class for testing Singleton scope.
  *
  * @Injectable(scope="foobar")
  */

--- a/tests/UnitTest/Fixtures/InvalidScope.php
+++ b/tests/UnitTest/Fixtures/InvalidScope.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Fixtures;
 

--- a/tests/UnitTest/Fixtures/NewInstanceWithoutConstructor.php
+++ b/tests/UnitTest/Fixtures/NewInstanceWithoutConstructor.php
@@ -5,17 +5,15 @@ namespace DI\Test\UnitTest\Fixtures;
 use Exception;
 
 /**
- * Fixture class for testing Container::newInstanceWithoutConstructor
+ * Fixture class for testing Container::newInstanceWithoutConstructor.
  */
 class NewInstanceWithoutConstructor
 {
-
     /**
-     * If the constructor is called, it will throw an exception
+     * If the constructor is called, it will throw an exception.
      */
     public function __construct()
     {
-        throw new Exception("The constructor is called");
+        throw new Exception('The constructor is called');
     }
-
 }

--- a/tests/UnitTest/Fixtures/NewInstanceWithoutConstructor.php
+++ b/tests/UnitTest/Fixtures/NewInstanceWithoutConstructor.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Fixtures;
 

--- a/tests/UnitTest/Fixtures/PassByReferenceDependency.php
+++ b/tests/UnitTest/Fixtures/PassByReferenceDependency.php
@@ -6,8 +6,8 @@ use stdClass;
 
 class PassByReferenceDependency
 {
-	public function __construct(stdClass &$object)
-	{
-		$object->foo = 'bar';
-	}
+    public function __construct(stdClass &$object)
+    {
+        $object->foo = 'bar';
+    }
 }

--- a/tests/UnitTest/Fixtures/Prototype.php
+++ b/tests/UnitTest/Fixtures/Prototype.php
@@ -5,11 +5,10 @@ namespace DI\Test\UnitTest\Fixtures;
 use DI\Annotation\Injectable;
 
 /**
- * Fixture class for testing Singleton scope
+ * Fixture class for testing Singleton scope.
  *
  * @Injectable(scope="prototype")
  */
 class Prototype
 {
-
 }

--- a/tests/UnitTest/Fixtures/Prototype.php
+++ b/tests/UnitTest/Fixtures/Prototype.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Fixtures;
 

--- a/tests/UnitTest/Fixtures/Singleton.php
+++ b/tests/UnitTest/Fixtures/Singleton.php
@@ -5,11 +5,10 @@ namespace DI\Test\UnitTest\Fixtures;
 use DI\Annotation\Injectable;
 
 /**
- * Fixture class for testing Singleton scope
+ * Fixture class for testing Singleton scope.
  *
  * @Injectable(scope="singleton")
  */
 class Singleton
 {
-
 }

--- a/tests/UnitTest/Fixtures/Singleton.php
+++ b/tests/UnitTest/Fixtures/Singleton.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest\Fixtures;
 

--- a/tests/UnitTest/FunctionsTest.php
+++ b/tests/UnitTest/FunctionsTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest;
 

--- a/tests/UnitTest/FunctionsTest.php
+++ b/tests/UnitTest/FunctionsTest.php
@@ -4,10 +4,10 @@ namespace DI\Test\UnitTest;
 
 use DI\Definition\ArrayDefinition;
 use DI\Definition\ArrayDefinitionExtension;
-use DI\Definition\ObjectDefinition;
 use DI\Definition\Helper\ArrayDefinitionExtensionHelper;
-use DI\Definition\Helper\ObjectDefinitionHelper;
 use DI\Definition\Helper\EnvironmentVariableDefinitionHelper;
+use DI\Definition\Helper\ObjectDefinitionHelper;
+use DI\Definition\ObjectDefinition;
 
 /**
  * Tests the helper functions.

--- a/tests/UnitTest/Proxy/ProxyFactoryTest.php
+++ b/tests/UnitTest/Proxy/ProxyFactoryTest.php
@@ -29,6 +29,7 @@ class ProxyFactoryTest extends \PHPUnit_Framework_TestCase
             $wrappedObject = $instance;
             $initializer = null; // turning off further lazy initialization
             $initialized = true;
+
             return true;
         };
         /** @var ClassToProxy $proxy */

--- a/tests/UnitTest/ScopeTest.php
+++ b/tests/UnitTest/ScopeTest.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * PHP-DI
- *
- * @link      http://php-di.org/
- * @copyright Matthieu Napoli (http://mnapoli.fr/)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
- */
 
 namespace DI\Test\UnitTest;
 


### PR DESCRIPTION
- remove file docblocks (those with the copyright and links): those were useless, I copied that from Symfony at the time but I don't really see the point
- enable [StyleCI](https://styleci.io/repos/3751713) to enforce correct code styling in new commits and pull requests (let's try it, if it's too cumbersome we'll disable it)
- apply StyleCI fixes to fix code style everywhere at once (#331 merged into this branch)