### PR TITLE
Allow injection of any container object as factory parameter via type hinting

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -5,6 +5,7 @@
 Improvements:
 
 - [#272](https://github.com/PHP-DI/PHP-DI/issues/272): Support 'Class::method' syntax for callables
+- [#333](https://github.com/PHP-DI/PHP-DI/pull/333): Allow injection of any container object as factory parameter via type hinting
 
 Bugfixes:
 

--- a/doc/php-definitions.md
+++ b/doc/php-definitions.md
@@ -109,17 +109,18 @@ return [
 ];
 ```
 
-The only parameter of a factory is the container (which can be used to retrieve other entries). You are encouraged to type-hint against the interface `Interop\Container\ContainerInterface` instead of the implementation `DI\Container`: that can be necessary in scenarios where you are using multiple containers (for example if using the PHP-DI + Symfony integration).
+Instances of other classes can be injected through parameters via type-hinting (as long as they are registered within the container or autowiring is enabled).
+
+The container, as seen above, can be injected and then used to retrieve other entries, like values, that can't be automatically injected via type -hinting. You are encouraged to type-hint against the interface `Interop\Container\ContainerInterface` instead of the implementation `DI\Container` in this case: that can be necessary in scenarios where you are using multiple containers (for example if using the PHP-DI + Symfony integration).
 
 You can also use a factory class - as an example, let's assume you have a simple factory class like this:
 
 ```php
 class FooFactory
 {
-    // note: $container can be omitted if not needed
-    public function create($container)
+    public function create(Bar $bar)
     {
-        return new Foo();
+        return new Foo($bar);
     }
 }
 ```
@@ -135,7 +136,7 @@ return [
 
 But the factory will be created on every request (`new FooFactory`) even if not used. Additionally with this method it's harder to pass dependencies in the factory.
 
-The recommended solution is let the container create the factory:
+The recommended solution is to let the container create the factory:
 
 ```php
 return [
@@ -155,7 +156,8 @@ This configuration is equivalent to the following code:
 
 ```php
 $factory = $container->get(FooFactory::class);
-return $factory->create();
+$bar = $container->get(Bar::class);
+return $factory->create($bar);
 ```
 
 Please note:

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -88,6 +88,7 @@ class Container implements ContainerInterface, FactoryInterface, \DI\InvokerInte
         $this->singletonEntries['DI\Container'] = $this;
         $this->singletonEntries['DI\FactoryInterface'] = $this;
         $this->singletonEntries['DI\InvokerInterface'] = $this;
+        $this->singletonEntries['Interop\Container\ContainerInterface'] = $this->wrapperContainer;
     }
 
     /**

--- a/tests/IntegrationTest/Definitions/FactoryDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/FactoryDefinitionTest.php
@@ -3,6 +3,7 @@
 namespace DI\Test\IntegrationTest\Definitions;
 
 use DI\ContainerBuilder;
+use Interop\Container\ContainerInterface;
 
 /**
  * Test factory definitions.
@@ -86,6 +87,46 @@ class FactoryDefinitionTest extends \PHPUnit_Framework_TestCase
         $factory = $container->get('factory');
 
         $this->assertSame('bar', $factory);
+    }
+
+    public function test_container_gets_injected_as_first_argument_without_typehint()
+    {
+        $container = $this->createContainer([
+            'factory' => function ($c) {
+                return $c;
+            },
+        ]);
+
+        $factory = $container->get('factory');
+
+        $this->assertInstanceOf('Interop\Container\ContainerInterface', $factory);
+    }
+
+    public function test_arbitrary_object_gets_injected_via_typehint()
+    {
+        $container = $this->createContainer([
+            'factory' => function (\stdClass $stdClass) {
+                return $stdClass;
+            },
+        ]);
+
+        $factory = $container->get('factory');
+
+        $this->assertInstanceOf('stdClass', $factory);
+    }
+
+    public function test_container_gets_injected_in_arbitrary_position_via_typehint()
+    {
+        $container = $this->createContainer([
+            'factory' => function (\stdClass $stdClass, ContainerInterface $c) {
+                return [$stdClass, $c];
+            },
+        ]);
+
+        $factory = $container->get('factory');
+
+        $this->assertInstanceOf('stdClass', $factory[0]);
+        $this->assertInstanceOf('Interop\Container\ContainerInterface', $factory[1]);
     }
 
     /**


### PR DESCRIPTION
With this PR it's possible to inject any container object into a factory via type hinting (see #197).

This means that instead of fetching the needed objects from the container inside your factory like this
```php
factory(function(ContainerInterface $c) {
  return new Thing($c->get(Service::class));
});
```
you can now let the container inject your dependencies as arguments to your factory directly
```php
factory(function(Service $s) {
  return new Thing($s);
});
```
-
This works with multiple arguments, too, of course. And it's backwards compatible, so if you don't type hint the *first* parameter, an instance of the `ContainerInterface` will be injected (but that's not recommended anyway).

-
There was a discussion about "angular style DI" in #197 and #239 but as I wasn't sure what's the best way to define this type of dependencies this feature was left out here.

-
I did a quick benchmark (my first one using blackfire) with the provided `blackfire run --samples=100 php factory.php` which showed a performance decrease of about 10% but I'm not sure how reliable this is for real world situations. Maybe you have better ways for benchmarking this?

-
Todo:
- [x] documentation
- [x] changelog