### PR TITLE
add convenience method to get method injections for single method

### DIFF
--- a/src/DI/Definition/ObjectDefinition.php
+++ b/src/DI/Definition/ObjectDefinition.php
@@ -149,7 +149,8 @@ class ObjectDefinition implements Definition, CacheableDefinition, HasSubDefinit
         $this->propertyInjections[$propertyInjection->getPropertyName()] = $propertyInjection;
     }
 
-    public function getMethodInjectionsForMethod($methodName){
+    public function getMethodInjectionsForMethod($methodName)
+    {
         return isset($this->methodInjections[$methodName]) ? $this->methodInjections[$methodName] : [];
     }
 

--- a/src/DI/Definition/ObjectDefinition.php
+++ b/src/DI/Definition/ObjectDefinition.php
@@ -149,6 +149,10 @@ class ObjectDefinition implements Definition, CacheableDefinition, HasSubDefinit
         $this->propertyInjections[$propertyInjection->getPropertyName()] = $propertyInjection;
     }
 
+    public function getMethodInjectionsForMethod($methodName){
+        return isset($this->methodInjections[$methodName]) ? $this->methodInjections[$methodName] : [];
+    }
+
     /**
      * @return MethodInjection[] Method injections
      */

--- a/tests/UnitTest/Definition/ObjectDefinitionTest.php
+++ b/tests/UnitTest/Definition/ObjectDefinitionTest.php
@@ -39,6 +39,15 @@ class ObjectDefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($definition->getConstructorInjection());
         $this->assertEmpty($definition->getPropertyInjections());
         $this->assertEmpty($definition->getMethodInjections());
+        $this->assertEmpty($definition->getMethodInjectionsForMethod('nonExistent'));
+    }
+
+    public function test_get_method_injections_for_method()
+    {
+        $definition = new ObjectDefinition('foo');
+        $definition->addMethodInjection(new MethodInjection('barMethod'));
+
+        $this->assertEquals([new MethodInjection('barMethod')], $definition->getMethodInjectionsForMethod('barMethod'));
     }
 
     public function should_be_cacheable()


### PR DESCRIPTION
I added a getter to retrieve the MethodInjections for a single method from the ObjectDefinition. After all, this functionality is available for the properties in the ObjectDefinition. 