### PR TITLE
Add Kernel class for consuming modules using Puli and PHP-DI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,9 @@
         "mnapoli/phpunit-easymock": "~0.2.0",
         "doctrine/cache": "~1.4",
         "doctrine/annotations": "~1.2",
-        "ocramius/proxy-manager": "~1.0"
+        "ocramius/proxy-manager": "~1.0",
+        "puli/repository": "^1.0@beta",
+        "puli/discovery": "^1.0@beta"
     },
     "replace": {
         "mnapoli/php-di": "*"

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
         "doctrine/cache": "~1.4",
         "doctrine/annotations": "~1.2",
         "ocramius/proxy-manager": "~1.0",
-        "puli/repository": "^1.0@beta",
-        "puli/discovery": "^1.0@beta"
+        "puli/repository": "1.0.0-beta8@beta",
+        "puli/discovery": "1.0.0-beta8@beta"
     },
     "replace": {
         "mnapoli/php-di": "*"

--- a/src/DI/Application/Kernel.php
+++ b/src/DI/Application/Kernel.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace DI\Application;
+
+use DI\Container;
+use DI\ContainerBuilder;
+use Doctrine\Common\Cache\Cache;
+use Puli\Discovery\Api\Binding\Binding;
+use Puli\Discovery\Api\Discovery;
+use Puli\Discovery\Binding\ResourceBinding;
+use Puli\Repository\Api\ResourceRepository;
+use Puli\Repository\Resource\FileResource;
+
+/**
+ * Application kernel.
+ *
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ */
+class Kernel
+{
+    /**
+     * Name of the binding for PHP-DI configuration files in Puli.
+     *
+     * @see http://docs.puli.io/en/latest/discovery/introduction.html
+     */
+    const PULI_BINDING_NAME = 'php-di/configuration';
+
+    /**
+     * Configure and create a container using all configuration files registered under
+     * the `php-di/configuration` binding type in Puli.
+     *
+     * @return Container
+     */
+    public function createContainer()
+    {
+        if (!defined('PULI_FACTORY_CLASS')) {
+            throw new \RuntimeException('Puli is not installed');
+        }
+
+        // Create Puli objects
+        $factoryClass = PULI_FACTORY_CLASS;
+        $factory = new $factoryClass();
+        /** @var ResourceRepository $repository */
+        $repository = $factory->createRepository();
+        /** @var Discovery $discovery */
+        $discovery = $factory->createDiscovery($repository);
+
+        $containerBuilder = new ContainerBuilder();
+
+        $cache = $this->getContainerCache();
+        if ($cache) {
+            $containerBuilder->setDefinitionCache($cache);
+        }
+
+        // Discover and load all configuration files registered under `php-di/configuration` in Puli
+        $bindings = $discovery->findBindings(self::PULI_BINDING_NAME);
+        $bindings = array_filter($bindings, function (Binding $binding) {
+            return $binding instanceof ResourceBinding;
+        });
+        /** @var ResourceBinding[] $bindings */
+        foreach ($bindings as $binding) {
+            foreach ($binding->getResources() as $resource) {
+                if (!$resource instanceof FileResource) {
+                    throw new \RuntimeException(sprintf('Cannot load "%s": only file resources are supported', $resource->getName()));
+                }
+                $containerBuilder->addDefinitions($resource->getFilesystemPath());
+            }
+        }
+
+        // Puli objects
+        $containerBuilder->addDefinitions([
+            'Puli\Repository\Api\ResourceRepository' => $repository,
+            'Puli\Discovery\Api\Discovery' => $discovery,
+        ]);
+
+        $this->configureContainerBuilder($containerBuilder);
+
+        return $containerBuilder->build();
+    }
+
+    /**
+     * Override this method to configure the cache to use for container definitions.
+     *
+     * @return Cache|null
+     */
+    protected function getContainerCache()
+    {
+        return null;
+    }
+
+    /**
+     * Override this method to customize the container builder before it is used.
+     */
+    protected function configureContainerBuilder(ContainerBuilder $containerBuilder)
+    {
+    }
+}

--- a/tests/IntegrationTest/Application/Fixture/PuliFactoryClass.php
+++ b/tests/IntegrationTest/Application/Fixture/PuliFactoryClass.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace DI\Test\IntegrationTest\Application\Fixture;
+
+use Puli\Discovery\InMemoryDiscovery;
+use Puli\Repository\InMemoryRepository;
+
+class PuliFactoryClass
+{
+    /**
+     * @var InMemoryRepository
+     */
+    public static $repository;
+
+    /**
+     * @var InMemoryDiscovery
+     */
+    public static $discovery;
+
+    public function createRepository()
+    {
+        return self::$repository;
+    }
+
+    public function createDiscovery()
+    {
+        return self::$discovery;
+    }
+}

--- a/tests/IntegrationTest/Application/Fixture/config.php
+++ b/tests/IntegrationTest/Application/Fixture/config.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'foo' => 'bar',
+];

--- a/tests/IntegrationTest/Application/KernelTest.php
+++ b/tests/IntegrationTest/Application/KernelTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace DI\Test\IntegrationTest\Application;
+
+use DI\Application\Kernel;
+use DI\Test\IntegrationTest\Application\Fixture\PuliFactoryClass;
+use Puli\Discovery\Api\Type\BindingType;
+use Puli\Discovery\Binding\ResourceBinding;
+use Puli\Discovery\InMemoryDiscovery;
+use Puli\Repository\InMemoryRepository;
+use Puli\Repository\Resource\FileResource;
+
+/**
+ * @covers \DI\Application\Kernel
+ */
+class KernelTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        if (!defined('PULI_FACTORY_CLASS')) {
+            define('PULI_FACTORY_CLASS', 'DI\Test\IntegrationTest\Application\Fixture\PuliFactoryClass');
+        }
+
+        PuliFactoryClass::$repository = new InMemoryRepository();
+        PuliFactoryClass::$discovery = new InMemoryDiscovery();
+    }
+
+    /**
+     * @test
+     */
+    public function creates_a_container()
+    {
+        $this->assertInstanceOf('DI\Container', (new Kernel)->createContainer());
+    }
+
+    /**
+     * @test
+     */
+    public function registers_puli_repository()
+    {
+        $container = (new Kernel)->createContainer();
+        $this->assertInstanceOf('Puli\Repository\Api\ResourceRepository', $container->get('Puli\Repository\Api\ResourceRepository'));
+    }
+
+    /**
+     * @test
+     */
+    public function registers_puli_discovery()
+    {
+        $container = (new Kernel)->createContainer();
+        $this->assertInstanceOf('Puli\Discovery\Api\Discovery', $container->get('Puli\Discovery\Api\Discovery'));
+    }
+
+    /**
+     * @test
+     */
+    public function registers_module_configuration_files()
+    {
+        $this->createPuliResource('/blog/config.php', __DIR__ . '/Fixture/config.php');
+        $this->bindPuliResource('/blog/config.php', Kernel::PULI_BINDING_NAME);
+
+        $container = (new Kernel)->createContainer();
+        $this->assertEquals('bar', $container->get('foo'));
+    }
+
+    private function createPuliResource($path, $file)
+    {
+        PuliFactoryClass::$repository->add($path, new FileResource($file));
+    }
+
+    private function bindPuliResource($path, $bindingName)
+    {
+        PuliFactoryClass::$discovery->addBindingType(new BindingType($bindingName));
+
+        $binding = new ResourceBinding($path, $bindingName);
+        $binding->setRepository(PuliFactoryClass::$repository);
+        PuliFactoryClass::$discovery->addBinding($binding);
+    }
+}


### PR DESCRIPTION
**Experimental**

This PR adds a new `Kernel` base class that can be used to create modular applications easily. Is is based on PHP-DI's module features + Puli.

## Usage example

### Module "Twig"

In project `twig-module`:

```bash
composer require php-di/php-di
# map the package's res/ folder to the /twig Puli path
puli map /twig res/
```

Provide a config file for Twig:

```php
// res/config/config.php
return [
    'twig' => function () {
        // ...
    }
];
```

Register the file as a PHP-DI config file:

```bash
puli bind /twig/config/config.php php-di/configuration
```

### In your application

Install PHP-DI and the Twig module:

```bash
composer require php-di/php-di acme/twig-module
```

Create your container using the kernel:

```php
// index.php
$app = new Kernel();
$container = $app->createContainer();
```

The Twig module was automatically discovered through Puli, so Twig is configured:

```php
$twig = $container->get('twig');
...
```