### PR TITLE
Handle collisions between identical parent and child private properties

### DIFF
--- a/src/DI/Definition/ObjectDefinition.php
+++ b/src/DI/Definition/ObjectDefinition.php
@@ -132,21 +132,18 @@ class ObjectDefinition implements Definition, CacheableDefinition, HasSubDefinit
         return $this->propertyInjections;
     }
 
-    /**
-     * @param string $propertyName
-     * @return PropertyInjection
-     */
-    public function getPropertyInjection($propertyName)
-    {
-        return isset($this->propertyInjections[$propertyName]) ? $this->propertyInjections[$propertyName] : null;
-    }
-
-    /**
-     * @param PropertyInjection $propertyInjection
-     */
     public function addPropertyInjection(PropertyInjection $propertyInjection)
     {
-        $this->propertyInjections[$propertyInjection->getPropertyName()] = $propertyInjection;
+        $className = $propertyInjection->getClassName();
+        if ($className) {
+            // Index with the class name to avoid collisions between parent and
+            // child private properties with the same name
+            $key = $className . '::' . $propertyInjection->getPropertyName();
+        } else {
+            $key = $propertyInjection->getPropertyName();
+        }
+
+        $this->propertyInjections[$key] = $propertyInjection;
     }
 
     /**
@@ -281,8 +278,8 @@ class ObjectDefinition implements Definition, CacheableDefinition, HasSubDefinit
 
     private function mergePropertyInjections(ObjectDefinition $definition)
     {
-        foreach ($definition->getPropertyInjections() as $propertyName => $propertyInjection) {
-            if (! array_key_exists($propertyName, $this->propertyInjections)) {
+        foreach ($definition->propertyInjections as $propertyName => $propertyInjection) {
+            if (! isset($this->propertyInjections[$propertyName])) {
                 // Add
                 $this->propertyInjections[$propertyName] = $propertyInjection;
             }

--- a/tests/IntegrationTest/Annotations/AnnotationsTest.php
+++ b/tests/IntegrationTest/Annotations/AnnotationsTest.php
@@ -26,6 +26,8 @@ class AnnotationsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Inject in parent properties (public, protected and private).
+     *
      * @test
      */
     public function inject_in_parent_properties()
@@ -43,6 +45,23 @@ class AnnotationsTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($object->public instanceof A);
         $this->assertTrue($object->getProtected() instanceof A);
         $this->assertTrue($object->getPrivate() instanceof A);
+    }
+
+    /**
+     * Inject in private parent properties even if they have the same name of child properties.
+     *
+     * @test
+     */
+    public function inject_in_private_parent_properties_with_same_name()
+    {
+        $container = $this->createContainer();
+
+        /** @var Child $object */
+        $object = $container->get('DI\Test\IntegrationTest\Annotations\Child');
+        $this->assertTrue($object->public instanceof A);
+        $this->assertTrue($object->getProtected() instanceof A);
+        $this->assertTrue($object->getPrivate() instanceof A);
+        $this->assertTrue($object->getChildPrivate() instanceof A);
     }
 
     /**

--- a/tests/IntegrationTest/Annotations/Child.php
+++ b/tests/IntegrationTest/Annotations/Child.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace DI\Test\IntegrationTest\Annotations;
+
+use DI\Annotation\Inject;
+
+class Child extends B
+{
+    /**
+     * @Inject
+     * @var A
+     */
+    private $private;
+
+    public function getChildPrivate()
+    {
+        return $this->private;
+    }
+}

--- a/tests/UnitTest/Definition/Source/AnnotationReaderTest.php
+++ b/tests/UnitTest/Definition/Source/AnnotationReaderTest.php
@@ -37,7 +37,7 @@ class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
         $source = new AnnotationReader();
         $definition = $source->getDefinition('DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixture');
 
-        $this->assertNull($definition->getPropertyInjection('unannotatedProperty'));
+        $this->assertNotHasPropertyInjection($definition, 'unannotatedProperty');
     }
 
     public function testStaticProperty()
@@ -45,7 +45,7 @@ class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
         $source = new AnnotationReader();
         $definition = $source->getDefinition('DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixture');
 
-        $this->assertNull($definition->getPropertyInjection('staticProperty'));
+        $this->assertNotHasPropertyInjection($definition, 'staticProperty');
     }
 
     /**
@@ -235,9 +235,9 @@ class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
         $source = new AnnotationReader();
         $definition = $source->getDefinition('DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixtureChild');
 
-        $this->assertNotNull($definition->getPropertyInjection('propertyChild'));
+        $this->assertHasPropertyInjection($definition, 'propertyChild');
         $this->assertNotNull($this->getMethodInjection($definition, 'methodChild'));
-        $this->assertNotNull($definition->getPropertyInjection('propertyParent'));
+        $this->assertHasPropertyInjection($definition, 'propertyParent');
         $this->assertNotNull($this->getMethodInjection($definition, 'methodParent'));
     }
 
@@ -250,7 +250,7 @@ class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
     {
         $source = new AnnotationReader();
         $definition = $source->getDefinition('DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixtureChild');
-        $this->assertNotNull($definition->getPropertyInjection('propertyParentPrivate'));
+        $this->assertHasPropertyInjection($definition, 'propertyParentPrivate');
     }
 
     private function getMethodInjection(ObjectDefinition $definition, $name)
@@ -263,5 +263,26 @@ class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
         }
 
         return null;
+    }
+
+    private function assertHasPropertyInjection(ObjectDefinition $definition, $propertyName)
+    {
+        $propertyInjections = $definition->getPropertyInjections();
+        foreach ($propertyInjections as $propertyInjection) {
+            if ($propertyInjection->getPropertyName() === $propertyName) {
+                return;
+            }
+        }
+        $this->fail('No property injection found for ' . $propertyName);
+    }
+
+    private function assertNotHasPropertyInjection(ObjectDefinition $definition, $propertyName)
+    {
+        $propertyInjections = $definition->getPropertyInjections();
+        foreach ($propertyInjections as $propertyInjection) {
+            if ($propertyInjection->getPropertyName() === $propertyName) {
+                $this->fail('No property injection found for ' . $propertyName);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix #366 

Add support for situations like this:

```php
class A
{
    /**
     * @Inject
     * @var ProductRepository
     */
    private $repository;
}

class B extends A
{
    /**
     * @Inject
     * @var ProductRepository
     */
    private $repository;
}
```

I also took the opportunity to remove `ObjectDefinition::getPropertyInjection()` which was only used by tests.