### PR TITLE
Add link to the ZF2 bridge repo to the docs

### DIFF
--- a/doc/frameworks/zf2.md
+++ b/doc/frameworks/zf2.md
@@ -132,3 +132,7 @@ return [
     ]
 ];
 ```
+
+## More
+
+Read more on the [ZF2-Bridge project on Github](https://github.com/PHP-DI/ZF2-Bridge).


### PR DESCRIPTION
I just noticed that there is no link to the ZF2 bridge repo in the docs. For the other framework bridges there is one, so I added it for ZF2, too.