### PR TITLE
s/Github/GitHub/g

### DIFF
--- a/doc/frameworks/silex.md
+++ b/doc/frameworks/silex.md
@@ -111,4 +111,4 @@ $app->post('/', function (Twig_Environment $twig) {
 
 ## More
 
-Read more on the [Silex-Bridge project on Github](https://github.com/PHP-DI/Silex-Bridge).
+Read more on the [Silex-Bridge project on GitHub](https://github.com/PHP-DI/Silex-Bridge).

--- a/doc/frameworks/symfony2.md
+++ b/doc/frameworks/symfony2.md
@@ -184,4 +184,4 @@ Full details are here: [FOSRestBundle#743](https://github.com/FriendsOfSymfony/F
 
 ## More
 
-Read more on the [Symfony2-Bridge project on Github](https://github.com/PHP-DI/Symfony2-Bridge).
+Read more on the [Symfony2-Bridge project on GitHub](https://github.com/PHP-DI/Symfony2-Bridge).

--- a/doc/frameworks/zf1.md
+++ b/doc/frameworks/zf1.md
@@ -163,4 +163,4 @@ Obviously, the `setUp()` and `appBootstrap()` methods could go in a base abstrac
 
 ## More
 
-Read more on the [ZF1-Bridge project on Github](https://github.com/PHP-DI/ZF1-Bridge).
+Read more on the [ZF1-Bridge project on GitHub](https://github.com/PHP-DI/ZF1-Bridge).

--- a/doc/frameworks/zf2.md
+++ b/doc/frameworks/zf2.md
@@ -135,4 +135,4 @@ return [
 
 ## More
 
-Read more on the [ZF2-Bridge project on Github](https://github.com/PHP-DI/ZF2-Bridge).
+Read more on the [ZF2-Bridge project on GitHub](https://github.com/PHP-DI/ZF2-Bridge).


### PR DESCRIPTION
Well, there were fewer occurances with lower case "h" than I thought, only in the framework integration docs... it was a bit late last night, I think ;)

I wasn't sure whether to replace it in the class name `GithubProfile` in the `doc/container.md`, too. What do you think?