### PR TITLE
Improve the documentation sidebar by highlighting the active item

### DIFF
--- a/couscous.yml
+++ b/couscous.yml
@@ -37,13 +37,13 @@ menu:
         definition:
             section: Definitions
             items:
-                introduction:
+                definition-introduction:
                     text: Introduction
                     url: doc/definition.html
                 autowiring:
                     text: Autowiring
                     url: doc/autowiring.html
-                php:
+                php-definitions:
                     text: PHP definitions
                     url: doc/php-definitions.html
                 annotations:
@@ -55,7 +55,7 @@ menu:
         frameworks:
             section: Frameworks
             items:
-                symfony2:
+                symfony:
                     text: Symfony 2
                     url: doc/frameworks/symfony2.html
                 silex:
@@ -100,10 +100,10 @@ menu:
         migration:
             section: Migration guides
             items:
-                4:
+                v4:
                     text: From PHP-DI 3.x to 4.0
                     url: doc/migration/4.0.html
-                5:
+                v5:
                     text: From PHP-DI 4.x to 5.0
                     url: doc/migration/5.0.html
         internals:

--- a/doc/annotations.md
+++ b/doc/annotations.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: annotations
 ---
 
 # Annotations

--- a/doc/autowiring.md
+++ b/doc/autowiring.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: autowiring
 ---
 
 # Autowiring

--- a/doc/best-practices.md
+++ b/doc/best-practices.md
@@ -1,6 +1,7 @@
 ---
 layout: documentation
 tab: best-practices
+current_menu: best-practices
 ---
 
 # Best practices

--- a/doc/container-configuration.md
+++ b/doc/container-configuration.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: container-configuration
 ---
 
 # Configuring the container

--- a/doc/container.md
+++ b/doc/container.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: container
 ---
 
 # Using the container

--- a/doc/definition-overriding.md
+++ b/doc/definition-overriding.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: definition-overriding
 ---
 
 # Definition extensions and overriding

--- a/doc/definition.md
+++ b/doc/definition.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: definition-introduction
 ---
 
 # Definitions

--- a/doc/environments.md
+++ b/doc/environments.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: environments
 ---
 
 # Injections depending on the environment

--- a/doc/frameworks/silex.md
+++ b/doc/frameworks/silex.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: silex
 ---
 
 # PHP-DI in Silex

--- a/doc/frameworks/silly.md
+++ b/doc/frameworks/silly.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: silly
 ---
 
 # PHP-DI in Silly

--- a/doc/frameworks/slim.md
+++ b/doc/frameworks/slim.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: slim
 ---
 
 # PHP-DI in Slim 3

--- a/doc/frameworks/symfony2.md
+++ b/doc/frameworks/symfony2.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: symfony
 ---
 
 # PHP-DI in Symfony 2

--- a/doc/frameworks/zf1.md
+++ b/doc/frameworks/zf1.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: zf1
 ---
 
 # PHP-DI in Zend Framework 1

--- a/doc/frameworks/zf2.md
+++ b/doc/frameworks/zf2.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: zf2
 ---
 
 # PHP-DI in Zend Framework 2

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -1,6 +1,7 @@
 ---
 layout: documentation
 title: Getting started
+current_menu: getting-started
 ---
 
 # Getting started with PHP-DI

--- a/doc/how-it-works.md
+++ b/doc/how-it-works.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: how-it-works
 ---
 
 # How PHP-DI works

--- a/doc/ide-integration.md
+++ b/doc/ide-integration.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: ide-integration
 ---
 
 # IDE integration

--- a/doc/inject-on-instance.md
+++ b/doc/inject-on-instance.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: inject-on-instance
 ---
 
 # Inject on an existing instance

--- a/doc/lazy-injection.md
+++ b/doc/lazy-injection.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: lazy-injection
 ---
 
 # Lazy injection

--- a/doc/migration/4.0.md
+++ b/doc/migration/4.0.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: v4
 ---
 
 # Migrating from PHP-DI 3.x to 4.0

--- a/doc/migration/5.0.md
+++ b/doc/migration/5.0.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: v5
 ---
 
 # Migrating from PHP-DI 4.x to 5.0

--- a/doc/performances.md
+++ b/doc/performances.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: performances
 ---
 
 # Performances

--- a/doc/php-definitions.md
+++ b/doc/php-definitions.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: php-definitions
 ---
 
 # PHP definitions

--- a/doc/scopes.md
+++ b/doc/scopes.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: scopes
 ---
 
 # Scopes

--- a/doc/understanding-di.md
+++ b/doc/understanding-di.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+current_menu: understanding-di
 ---
 
 # Understanding Dependency Injection

--- a/website/less/main.less
+++ b/website/less/main.less
@@ -168,6 +168,10 @@ article {
                         @media (min-width: @screen-md-min) {
                             font-size: 14px;
                         }
+                        &.active a {
+                            color: @link-hover-color;
+                            text-decoration: underline;
+                        }
                     }
                 }
             }

--- a/website/less/variables.less
+++ b/website/less/variables.less
@@ -8,3 +8,4 @@
 
 
 @link-color: darken(@brand-primary, 5%);
+@link-hover-color: #9D5A08;


### PR DESCRIPTION
Example:

![capture d ecran 2016-05-06 a 22 58 48](https://cloud.githubusercontent.com/assets/720328/15086001/25cba030-13de-11e6-892e-a5dbd60cc707.png)

This is also necessary to integrate Algolia's documentation search.
