### PR TITLE
Make autowiring and annotations work for `DI\object()` inside arrays

### DIFF
--- a/src/DI/Definition/ArrayDefinition.php
+++ b/src/DI/Definition/ArrayDefinition.php
@@ -3,6 +3,7 @@
 namespace DI\Definition;
 
 use DI\Definition\Helper\DefinitionHelper;
+use DI\Definition\Helper\ObjectDefinitionHelper;
 use DI\Scope;
 
 /**
@@ -56,6 +57,22 @@ class ArrayDefinition implements Definition
     public function getValues()
     {
         return $this->values;
+    }
+
+    /**
+     * @return array
+     */
+    public function getValuesWithSubDefinition()
+    {
+        return array_values(
+            array_filter(
+                $this->values,
+                function ($value) {
+                    return ($value instanceof ObjectDefinitionHelper)
+                    && ($value->getDefinition('') instanceof HasSubDefinition);
+                }
+            )
+        );
     }
 
     public function __toString()

--- a/src/DI/Definition/Helper/ObjectDefinitionHelper.php
+++ b/src/DI/Definition/Helper/ObjectDefinitionHelper.php
@@ -48,6 +48,11 @@ class ObjectDefinitionHelper implements DefinitionHelper
     private $methods = [];
 
     /**
+     * @var ObjectDefinition\
+     */
+    private $definition;
+
+    /**
      * Helper for defining an object.
      *
      * @param string|null $className Class name of the object.
@@ -56,6 +61,18 @@ class ObjectDefinitionHelper implements DefinitionHelper
     public function __construct($className = null)
     {
         $this->className = $className;
+    }
+
+    /**
+     * @param ObjectDefinition $definition
+     *
+     * @return $this
+     */
+    public function setDefinition(ObjectDefinition $definition)
+    {
+        $this->definition = $definition;
+
+        return $this;
     }
 
     /**
@@ -206,6 +223,10 @@ class ObjectDefinitionHelper implements DefinitionHelper
      */
     public function getDefinition($entryName)
     {
+        if ($this->definition !== null) {
+            return $this->definition;
+        }
+
         $definition = new ObjectDefinition($entryName, $this->className);
 
         if ($this->lazy !== null) {

--- a/src/DI/Definition/Source/SourceChain.php
+++ b/src/DI/Definition/Source/SourceChain.php
@@ -2,8 +2,10 @@
 
 namespace DI\Definition\Source;
 
+use DI\Definition\ArrayDefinition;
 use DI\Definition\Definition;
 use DI\Definition\HasSubDefinition;
+use DI\Definition\Helper\ObjectDefinitionHelper;
 
 /**
  * Manages a chain of other definition sources.
@@ -53,6 +55,17 @@ class SourceChain implements DefinitionSource, MutableDefinitionSource
             if ($definition) {
                 if ($definition instanceof HasSubDefinition) {
                     $this->resolveSubDefinition($definition, $i);
+                }
+                if ($definition instanceof ArrayDefinition) {
+                    foreach ($definition->getValues() as $definitionHelper) {
+                        if ($definitionHelper instanceof ObjectDefinitionHelper) {
+                            $subDefinition = $definitionHelper->getDefinition('');
+                            if ($subDefinition instanceof HasSubDefinition) {
+                                $this->resolveSubDefinition($subDefinition, $i);
+                            }
+                            $definitionHelper->setDefinition($subDefinition);
+                        }
+                    }
                 }
 
                 return $definition;

--- a/src/DI/Definition/Source/SourceChain.php
+++ b/src/DI/Definition/Source/SourceChain.php
@@ -5,6 +5,7 @@ namespace DI\Definition\Source;
 use DI\Definition\ArrayDefinition;
 use DI\Definition\Definition;
 use DI\Definition\HasSubDefinition;
+use DI\Definition\Helper\DefinitionHelper;
 use DI\Definition\Helper\ObjectDefinitionHelper;
 
 /**
@@ -57,14 +58,11 @@ class SourceChain implements DefinitionSource, MutableDefinitionSource
                     $this->resolveSubDefinition($definition, $i);
                 }
                 if ($definition instanceof ArrayDefinition) {
-                    foreach ($definition->getValues() as $definitionHelper) {
-                        if ($definitionHelper instanceof ObjectDefinitionHelper) {
-                            $subDefinition = $definitionHelper->getDefinition('');
-                            if ($subDefinition instanceof HasSubDefinition) {
-                                $this->resolveSubDefinition($subDefinition, $i);
-                            }
-                            $definitionHelper->setDefinition($subDefinition);
-                        }
+                    /** @var ObjectDefinitionHelper $definitionHelper */
+                    foreach ($definition->getValuesWithSubDefinition() as $definitionHelper) {
+                        $subDefinition = $definitionHelper->getDefinition('');
+                        $this->resolveSubDefinition($subDefinition, $i);
+                        $definitionHelper->setDefinition($subDefinition);
                     }
                 }
 

--- a/tests/IntegrationTest/Definitions/ArrayDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/ArrayDefinitionTest.php
@@ -4,6 +4,9 @@ namespace DI\Test\IntegrationTest\Definitions;
 
 use DI\ContainerBuilder;
 use DI\Scope;
+use DI\Test\IntegrationTest\Definitions\ObjectDefinition\A;
+use DI\Test\IntegrationTest\Definitions\ObjectDefinition\B;
+use DI\Test\IntegrationTest\Definitions\ObjectDefinition\C;
 
 /**
  * Test array definitions.
@@ -160,4 +163,24 @@ class ArrayDefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $array);
         $this->assertEquals('value 1', $array[0]);
     }
+
+    public function test_autowiring_inside_arrays()
+    {
+        $builder = new ContainerBuilder();
+        $builder->addDefinitions([
+            'values' => [
+                \DI\object(A::class),
+                \DI\object(C::class)
+            ]
+        ]);
+        $container = $builder->build();
+
+        $array = $container->get('values');
+
+        $this->assertCount(2, $array);
+        $this->assertInstanceOf(A::class, $array[0]);
+        $this->assertInstanceOf(C::class, $array[1]);
+        $this->assertInstanceOf(B::class, $array[1]->a->b);
+    }
 }
+

--- a/tests/IntegrationTest/Definitions/ObjectDefinition/A.php
+++ b/tests/IntegrationTest/Definitions/ObjectDefinition/A.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace DI\Test\IntegrationTest\Definitions\ObjectDefinition;
+
+
+class A
+{
+    public $b;
+
+    public function __construct(B $b)
+    {
+        $this->b = $b;
+    }
+}

--- a/tests/IntegrationTest/Definitions/ObjectDefinition/B.php
+++ b/tests/IntegrationTest/Definitions/ObjectDefinition/B.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace DI\Test\IntegrationTest\Definitions\ObjectDefinition;
+
+
+class B
+{
+
+}

--- a/tests/IntegrationTest/Definitions/ObjectDefinition/C.php
+++ b/tests/IntegrationTest/Definitions/ObjectDefinition/C.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace DI\Test\IntegrationTest\Definitions\ObjectDefinition;
+
+
+class C
+{
+    public $a;
+
+    public function __construct(A $a)
+    {
+        $this->a = $a;
+    }
+}

--- a/tests/UnitTest/Definition/ArrayDefinitionTest.php
+++ b/tests/UnitTest/Definition/ArrayDefinitionTest.php
@@ -4,6 +4,7 @@ namespace DI\Test\UnitTest\Definition;
 
 use DI\Definition\ArrayDefinition;
 use DI\Definition\CacheableDefinition;
+use DI\Definition\HasSubDefinition;
 use DI\Scope;
 
 /**
@@ -84,5 +85,19 @@ class ArrayDefinitionTest extends \PHPUnit_Framework_TestCase
     ),
 ]';
         $this->assertEquals($str, (string) $definition);
+    }
+
+    public function test_get_values_with_sub_definitions()
+    {
+        $definition = new ArrayDefinition('foo', [
+            'bar',
+            \DI\object(\stdClass::class),
+            [],
+            1
+        ]);
+        $array = $definition->getValuesWithSubDefinition();
+
+        $this->assertCount(1, $array);
+        $this->assertInstanceOf(HasSubDefinition::class, $array[0]->getDefinition(''));
     }
 }

--- a/tests/UnitTest/Definition/ArrayDefinitionTest.php
+++ b/tests/UnitTest/Definition/ArrayDefinitionTest.php
@@ -87,7 +87,7 @@ class ArrayDefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($str, (string) $definition);
     }
 
-    public function test_get_values_with_sub_definitions()
+    public function test_get_values_with_sub_definition()
     {
         $definition = new ArrayDefinition('foo', [
             'bar',


### PR DESCRIPTION
quick fix for #343 
