### PR TITLE
Require PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,25 +3,23 @@ language: php
 sudo: false
 
 php:
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
   - hhvm
 
 matrix:
   include:
-    - php: 5.5
+    - php: 7.0
       env: dependencies=lowest
 
 before_script:
-  - if [[ $(phpenv version-name) == '5.6' ]]; then composer require satooshi/php-coveralls:dev-master -n ; fi
-  - if [[ $(phpenv version-name) != '5.6' ]]; then composer install -n ; fi
+  - if [[ $(phpenv version-name) == '7.1' ]]; then composer require satooshi/php-coveralls:dev-master -n ; fi
+  - if [[ $(phpenv version-name) != '7.1' ]]; then composer install -n ; fi
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable -n; fi;
 
 script:
-  - if [[ $(phpenv version-name) == '5.6' ]]; then vendor/bin/phpunit --coverage-clover clover.xml ; fi
-  - if [[ $(phpenv version-name) != '5.6' ]]; then vendor/bin/phpunit ; fi
+  - if [[ $(phpenv version-name) == '7.1' ]]; then vendor/bin/phpunit --coverage-clover clover.xml ; fi
+  - if [[ $(phpenv version-name) != '7.1' ]]; then vendor/bin/phpunit ; fi
 
 after_script:
-  - if [[ $(phpenv version-name) == '5.6' ]]; then php vendor/bin/coveralls -v ; fi
+  - if [[ $(phpenv version-name) == '7.1' ]]; then php vendor/bin/coveralls -v ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 php:
   - 7.0
   - 7.1
-  - hhvm
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,12 @@ sudo: false
 php:
   - 7.0
   - 7.1
+  - nightly
 
 matrix:
+  fast_finish: true
+  allow_failures:
+    - php: nightly
   include:
     - php: 7.0
       env: dependencies=lowest

--- a/change-log.md
+++ b/change-log.md
@@ -4,6 +4,7 @@
 
 BC breaks:
 
+- PHP 7 or greater is required
 - The deprecated `DI\link()` helper was removed, used `DI\get()` instead
 
 ## 5.4

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
         "test": "phpunit"
     },
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=7.0.0",
         "container-interop/container-interop": "~1.0",
         "php-di/invoker": "^1.3.2",
         "php-di/phpdoc-reader": "^2.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5",
+        "phpunit/phpunit": "~5.0",
         "mnapoli/phpunit-easymock": "~0.2.0",
         "doctrine/cache": "~1.4",
         "doctrine/annotations": "~1.2",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "mnapoli/phpunit-easymock": "~0.2.0",
         "doctrine/cache": "~1.4",
         "doctrine/annotations": "~1.2",
-        "ocramius/proxy-manager": "~1.0|~2.0"
+        "ocramius/proxy-manager": "~2.0.2"
     },
     "replace": {
         "mnapoli/php-di": "*"
@@ -44,6 +44,6 @@
     "suggest": {
         "doctrine/cache": "Install it if you want to use the cache (version ~1.4)",
         "doctrine/annotations": "Install it if you want to use annotations (version ~1.2)",
-        "ocramius/proxy-manager": "Install it if you want to use lazy injection (version ~1.0 or ~2.0)"
+        "ocramius/proxy-manager": "Install it if you want to use lazy injection (version ~2.0)"
     }
 }

--- a/doc/lazy-injection.md
+++ b/doc/lazy-injection.md
@@ -86,7 +86,7 @@ Lazy injection requires the [Ocramius/ProxyManager](https://github.com/Ocramius/
 {
     "require": {
         "php-di/php-di": "*",
-        "ocramius/proxy-manager": "~1.0|~2.0"
+        "ocramius/proxy-manager": "~2.0"
     }
 }
 ```

--- a/doc/migration/6.0.md
+++ b/doc/migration/6.0.md
@@ -13,6 +13,8 @@ This guide will help you migrate from a 5.x version to 6.0. It will only explain
 
 PHP-DI requires PHP 7 or greater, it is no longer compatible with PHP 5.
 
+As a consequence if you require `ocramius/proxy-manager` in your project (to benefit from [lazy injection](../lazy-injection.md)), you must require v2.0 (not 1.0, which is not compatible with PHP 7).
+
 ## Definitions
 
 ### DI\link()

--- a/doc/migration/6.0.md
+++ b/doc/migration/6.0.md
@@ -9,6 +9,10 @@ PHP-DI 6.0 is a new major version that comes with backward compatibility breaks.
 
 This guide will help you migrate from a 5.x version to 6.0. It will only explain backward compatibility breaks, it will not present the new features (read the release notes or the blog post for that).
 
+## PHP version
+
+PHP-DI requires PHP 7 or greater, it is no longer compatible with PHP 5.
+
 ## Definitions
 
 ### DI\link()

--- a/src/DI/Proxy/ProxyFactory.php
+++ b/src/DI/Proxy/ProxyFactory.php
@@ -66,7 +66,7 @@ class ProxyFactory
         }
 
         if (! class_exists(Configuration::class)) {
-            throw new \RuntimeException('The ocramius/proxy-manager library is not installed. Lazy injection requires that library to be installed with Composer in order to work. Run "composer require ocramius/proxy-manager:~1.0".');
+            throw new \RuntimeException('The ocramius/proxy-manager library is not installed. Lazy injection requires that library to be installed with Composer in order to work. Run "composer require ocramius/proxy-manager:~2.0".');
         }
 
         $config = new Configuration();


### PR DESCRIPTION
Require PHP 7 or greater for PHP-DI 6.

Is that too much of a jump?