### PR TITLE
Allow to build the container without parameters

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -2,6 +2,10 @@
 
 ## 6.0
 
+Improvements:
+
+- The container can now be built without parameters: `new Container()`
+
 BC breaks:
 
 - The deprecated `DI\link()` helper was removed, used `DI\get()` instead

--- a/doc/container-configuration.md
+++ b/doc/container-configuration.md
@@ -11,6 +11,8 @@ PHP-DI's container is preconfigured for "plug'n'play", i.e. development environm
 
 ```php
 $container = ContainerBuilder::buildDevContainer();
+// same as
+$container = new Container();
 ```
 
 By default, PHP-DI will have [Autowiring](definition.md) enabled (annotations are disabled by default).

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -61,13 +61,13 @@ As we can see, the `UserManager` takes the `Mailer` as a constructor parameter: 
 
 ### 2. Create the container
 
-You can create a container instance preconfigured for development very easily:
+You can create a container instance pre-configured for development very easily:
 
 ```php
-$container = DI\ContainerBuilder::buildDevContainer();
+$container = new Container();
 ```
 
-If you want to register definition files (explained below) or tweak some options, you can use the container builder:
+If you want to register definition files (explained in [PHP definitions](php-definitions.md)) or tweak some options, you can use the [container builder](container-configuration.md):
 
 ```php
 $builder = new DI\ContainerBuilder();

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -9,9 +9,12 @@ use DI\Definition\InstanceDefinition;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\Resolver\DefinitionResolver;
 use DI\Definition\Resolver\ResolverDispatcher;
+use DI\Definition\Source\Autowiring;
 use DI\Definition\Source\CachedDefinitionSource;
+use DI\Definition\Source\DefinitionArray;
 use DI\Definition\Source\DefinitionSource;
 use DI\Definition\Source\MutableDefinitionSource;
+use DI\Definition\Source\SourceChain;
 use DI\Invoker\DefinitionParameterResolver;
 use DI\Proxy\ProxyFactory;
 use Exception;
@@ -66,22 +69,24 @@ class Container implements ContainerInterface, FactoryInterface, \DI\InvokerInte
     private $wrapperContainer;
 
     /**
-     * Use the ContainerBuilder to ease constructing the Container.
+     * Use `$container = new Container()` if you want a container with the default configuration.
+     *
+     * If you want to customize the container's behavior, you are discouraged to create and pass the
+     * dependencies yourself, the ContainerBuilder class is here to help you instead.
      *
      * @see ContainerBuilder
      *
-     * @param DefinitionSource   $definitionSource
-     * @param ProxyFactory       $proxyFactory
      * @param ContainerInterface $wrapperContainer If the container is wrapped by another container.
      */
     public function __construct(
-        DefinitionSource $definitionSource,
-        ProxyFactory $proxyFactory,
+        DefinitionSource $definitionSource = null,
+        ProxyFactory $proxyFactory = null,
         ContainerInterface $wrapperContainer = null
     ) {
         $this->wrapperContainer = $wrapperContainer ?: $this;
 
-        $this->definitionSource = $definitionSource;
+        $this->definitionSource = $definitionSource ?: $this->createDefaultDefinitionSource();
+        $proxyFactory = $proxyFactory ?: new ProxyFactory(false);
         $this->definitionResolver = new ResolverDispatcher($this->wrapperContainer, $proxyFactory);
 
         // Auto-register the container
@@ -330,5 +335,16 @@ class Container implements ContainerInterface, FactoryInterface, \DI\InvokerInte
         }
 
         return $this->invoker;
+    }
+
+    /**
+     * @return DefinitionSource
+     */
+    private function createDefaultDefinitionSource()
+    {
+        $source = new SourceChain([new Autowiring]);
+        $source->setMutableDefinitionSource(new DefinitionArray);
+
+        return $source;
     }
 }

--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -91,9 +91,7 @@ class ContainerBuilder
      */
     public static function buildDevContainer()
     {
-        $builder = new self();
-
-        return $builder->build();
+        return new Container;
     }
 
     /**

--- a/src/DI/Proxy/ProxyFactory.php
+++ b/src/DI/Proxy/ProxyFactory.php
@@ -37,7 +37,7 @@ class ProxyFactory
      */
     private $proxyManager;
 
-    public function __construct($writeProxiesToFile, $proxyDirectory = null)
+    public function __construct($writeProxiesToFile = false, $proxyDirectory = null)
     {
         $this->writeProxiesToFile = $writeProxiesToFile;
         $this->proxyDirectory = $proxyDirectory;

--- a/tests/UnitTest/ContainerBuilderTest.php
+++ b/tests/UnitTest/ContainerBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace DI\Test\UnitTest;
 
+use DI\Container;
 use DI\ContainerBuilder;
 use DI\Definition\Source\CachedDefinitionSource;
 use DI\Definition\Source\DefinitionArray;
@@ -200,5 +201,13 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $builder->build();
 
         $builder->addDefinitions([]);
+    }
+
+    /**
+     * @test
+     */
+    public function dev_container_configuration_should_be_identical_to_creating_a_new_container_from_defaults()
+    {
+        self::assertEquals(new Container, ContainerBuilder::buildDevContainer());
     }
 }

--- a/tests/UnitTest/ContainerTest.php
+++ b/tests/UnitTest/ContainerTest.php
@@ -113,4 +113,12 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('hello', $container->get('foo'));
     }
+
+    /**
+     * @test
+     */
+    public function canBeBuiltWithoutParameters()
+    {
+        self::assertInstanceOf(Container::class, new Container); // Should not be an error
+    }
 }


### PR DESCRIPTION
All parameters in the constructor are now optional. We can build the container like this:

```php
$container = new Container();
```

This is the same as `ContainerBuilder::buildDevContainer()`, but simpler. Also, it's about time we get back that constructor :)