### PR TITLE
Use variadic args in constructor

### DIFF
--- a/src/DI/Definition/Resolver/ObjectCreator.php
+++ b/src/DI/Definition/Resolver/ObjectCreator.php
@@ -146,27 +146,7 @@ class ObjectCreator implements DefinitionResolver
                 $parameters
             );
 
-            // Optimization trick
-            switch (count($args)) {
-                case 0:
-                    $object = new $classname;
-                    break;
-                case 1:
-                    $object = new $classname($args[0]);
-                    break;
-                case 2:
-                    $object = new $classname($args[0], $args[1]);
-                    break;
-                case 3:
-                    $object = new $classname($args[0], $args[1], $args[2]);
-                    break;
-                case 4:
-                    $object = new $classname($args[0], $args[1], $args[2], $args[3]);
-                    break;
-                default:
-                    $object = $classReflection->newInstanceArgs($args);
-                    break;
-            }
+            $object = new $classname(...$args);
 
             $this->injectMethodsAndProperties($object, $definition);
         } catch (NotFoundException $e) {


### PR DESCRIPTION
Though this could be optimised without the extra verbosity. Crude benchmarks below:

### Reflection
Code
```php
class Foo { public function __construct($a, $b, $c, $d) {}  }
$foo = Foo::class;
$args = [1,2,3,4];
$reflect = new ReflectionClass($foo);
for ($i = 0; $i < 10000000; $i++) {
    $reflect->newInstanceArgs($args);
}
```
Time
```bash
$ time php reflect.php 
real	0m 3.42s
user	0m 3.41s
sys	0m 0.00s
```

### Current
Code
```php
class Foo { public function __construct($a, $b, $c, $d) {}  }
$foo = Foo::class;
$args = [1,2,3,4];
for ($i = 0; $i < 10000000; $i++) {
    new $foo($args[0], $args[1], $args[2], $args[3]);
}
```
Time
```bash
$ time php current.php 
real	0m 2.85s
user	0m 2.84s
sys	0m 0.00s
```

### Variadic
Code
```php
class Foo { public function __construct($a, $b, $c, $d) {}  }
$foo = Foo::class;
$args = [1,2,3,4];
for ($i = 0; $i < 10000000; $i++) {
    new $foo(...$args);
}
```
Time
```bash
$ time php variadic.php 
real	0m 2.48s
user	0m 2.48s
sys	0m 0.00s
```
