### PR TITLE
Implement PSR-11

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -2,6 +2,9 @@
 namespace PHPSTORM_META {
 
     $STATIC_METHOD_TYPES = [
+        \Psr\Container\ContainerInterface::get('') => [
+            "" == "@",
+        ],
         \Interop\Container\ContainerInterface::get('') => [
             "" == "@",
         ],

--- a/change-log.md
+++ b/change-log.md
@@ -1,5 +1,11 @@
 # Change log
 
+## 5.4.1
+
+- [PSR-11](http://www.php-fig.org/psr/) compliance
+
+Note that PHP-DI was already compliant with PSR-11 because it was implementing container-interop, and container-interop 1.2 extends PSR-11. This new version just makes it more explicit and will allow to drop container-interop support in the next major versions.
+
 ## 5.4
 
 Read the [news entry](news/20-php-di-5-4-released.md).

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     },
     "require": {
         "php": ">=5.5.0",
-        "container-interop/container-interop": "~1.0",
+        "container-interop/container-interop": "~1.2",
+        "psr/container": "~1.0",
         "php-di/invoker": "^1.3.2",
         "php-di/phpdoc-reader": "^2.0.1"
     },

--- a/doc/container.md
+++ b/doc/container.md
@@ -9,10 +9,10 @@ This documentation describes the API of the container object itself.
 
 ## get() & has()
 
-The container implements the [container-interop](https://github.com/container-interop/container-interop) standard. That means it implements [`Interop\Container\ContainerInterface`](https://github.com/container-interop/container-interop/blob/master/src/Interop/Container/ContainerInterface.php):
+The container implements the [PSR-11](http://www.php-fig.org/psr/) standard. That means it implements [`Psr\Container\ContainerInterface`](https://github.com/php-fig/container/blob/master/src/ContainerInterface.php):
 
 ```php
-namespace Interop\Container;
+namespace Psr\Container;
 
 interface ContainerInterface
 {

--- a/doc/ide-integration.md
+++ b/doc/ide-integration.md
@@ -33,14 +33,14 @@ This solution is simple and works great when your container is used rarely.
 
 ### Metadata file
 
-[PhpStorm will load metadata from a `.phpstorm.meta.php` file](https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Advanced+Metadata) if it exists at the root of your project. Here is an example that adds support for PHP-DI as well as [any container-interop container](https://github.com/container-interop/container-interop#compatible-projects):
+[PhpStorm will load metadata from a `.phpstorm.meta.php` file](https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Advanced+Metadata) if it exists at the root of your project. Here is an example that adds support for PHP-DI as well as [any PSR-11 container](http://www.php-fig.org/psr/):
 
 ```php
 <?php
 namespace PHPSTORM_META
 {
     $STATIC_METHOD_TYPES = [
-        \Interop\Container\ContainerInterface::get('') => [
+        \Psr\Container\ContainerInterface::get('') => [
             "" == "@",
         ],
         \DI\Container::get('') => [

--- a/doc/php-definitions.md
+++ b/doc/php-definitions.md
@@ -100,7 +100,7 @@ Factories are **PHP callables** that return the instance. They allow to define o
 Here is an example using a closure:
 
 ```php
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 return [
     'Foo' => function (ContainerInterface $c) {
@@ -130,7 +130,7 @@ return [
 ];
 ```
 
-This can also be done by injecting the container itself, as seen in the first example. When injecting the container, you should type-hint against the interface `Interop\Container\ContainerInterface` instead of the implementation `DI\Container`.
+This can also be done by injecting the container itself, as seen in the first example. When injecting the container, you should type-hint against the interface `Psr\Container\ContainerInterface` instead of the implementation `DI\Container`.
 
 Factories can be any PHP callable, so they can also be class methods:
 

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -15,7 +15,7 @@ use DI\Definition\Source\MutableDefinitionSource;
 use DI\Invoker\DefinitionParameterResolver;
 use DI\Proxy\ProxyFactory;
 use Exception;
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface as InteropContainerInterface;
 use InvalidArgumentException;
 use Invoker\Invoker;
 use Invoker\ParameterResolver\AssociativeArrayResolver;
@@ -23,13 +23,14 @@ use Invoker\ParameterResolver\Container\TypeHintContainerResolver;
 use Invoker\ParameterResolver\DefaultValueResolver;
 use Invoker\ParameterResolver\NumericArrayResolver;
 use Invoker\ParameterResolver\ResolverChain;
+use Psr\Container\ContainerInterface;
 
 /**
  * Dependency Injection Container.
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class Container implements ContainerInterface, FactoryInterface, \DI\InvokerInterface
+class Container implements ContainerInterface, InteropContainerInterface, FactoryInterface, \DI\InvokerInterface
 {
     /**
      * Map of entries with Singleton scope that are already resolved.

--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -11,7 +11,7 @@ use DI\Definition\Source\DefinitionSource;
 use DI\Definition\Source\SourceChain;
 use DI\Proxy\ProxyFactory;
 use Doctrine\Common\Cache\Cache;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use InvalidArgumentException;
 
 /**

--- a/src/DI/Definition/AliasDefinition.php
+++ b/src/DI/Definition/AliasDefinition.php
@@ -3,7 +3,7 @@
 namespace DI\Definition;
 
 use DI\Scope;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Defines an alias from an entry to another.

--- a/src/DI/Definition/Resolver/DecoratorResolver.php
+++ b/src/DI/Definition/Resolver/DecoratorResolver.php
@@ -5,7 +5,7 @@ namespace DI\Definition\Resolver;
 use DI\Definition\DecoratorDefinition;
 use DI\Definition\Definition;
 use DI\Definition\Exception\DefinitionException;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Resolves a decorator definition to a value.

--- a/src/DI/Definition/Resolver/FactoryResolver.php
+++ b/src/DI/Definition/Resolver/FactoryResolver.php
@@ -7,7 +7,7 @@ use DI\Definition\Exception\DefinitionException;
 use DI\Definition\FactoryDefinition;
 use DI\Definition\Helper\DefinitionHelper;
 use DI\Invoker\FactoryParameterResolver;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Invoker\Exception\NotCallableException;
 use Invoker\Exception\NotEnoughParametersException;
 use Invoker\Invoker;

--- a/src/DI/Definition/Resolver/InstanceInjector.php
+++ b/src/DI/Definition/Resolver/InstanceInjector.php
@@ -5,7 +5,7 @@ namespace DI\Definition\Resolver;
 use DI\Definition\Definition;
 use DI\Definition\InstanceDefinition;
 use DI\DependencyException;
-use Interop\Container\Exception\NotFoundException;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * Injects dependencies on an existing instance.
@@ -26,7 +26,7 @@ class InstanceInjector extends ObjectCreator
     {
         try {
             $this->injectMethodsAndProperties($definition->getInstance(), $definition->getObjectDefinition());
-        } catch (NotFoundException $e) {
+        } catch (NotFoundExceptionInterface $e) {
             $message = sprintf(
                 'Error while injecting dependencies into %s: %s',
                 get_class($definition->getInstance()),

--- a/src/DI/Definition/Resolver/ObjectCreator.php
+++ b/src/DI/Definition/Resolver/ObjectCreator.php
@@ -10,7 +10,7 @@ use DI\Definition\ObjectDefinition\PropertyInjection;
 use DI\DependencyException;
 use DI\Proxy\ProxyFactory;
 use Exception;
-use Interop\Container\Exception\NotFoundException;
+use Psr\Container\NotFoundExceptionInterface;
 use ProxyManager\Proxy\LazyLoadingInterface;
 use ReflectionClass;
 use ReflectionProperty;
@@ -141,7 +141,7 @@ class ObjectCreator implements DefinitionResolver
             }
 
             $this->injectMethodsAndProperties($object, $definition);
-        } catch (NotFoundException $e) {
+        } catch (NotFoundExceptionInterface $e) {
             throw new DependencyException(sprintf(
                 'Error while injecting dependencies into %s: %s',
                 $classReflection->getName(),

--- a/src/DI/Definition/Resolver/ResolverDispatcher.php
+++ b/src/DI/Definition/Resolver/ResolverDispatcher.php
@@ -5,7 +5,7 @@ namespace DI\Definition\Resolver;
 use DI\Definition\Definition;
 use DI\Definition\Exception\DefinitionException;
 use DI\Proxy\ProxyFactory;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Dispatches to more specific resolvers.

--- a/src/DI/Definition/Resolver/SelfResolver.php
+++ b/src/DI/Definition/Resolver/SelfResolver.php
@@ -4,7 +4,7 @@ namespace DI\Definition\Resolver;
 
 use DI\Definition\Definition;
 use DI\Definition\SelfResolvingDefinition;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Resolves self-resolving definitions.

--- a/src/DI/Definition/SelfResolvingDefinition.php
+++ b/src/DI/Definition/SelfResolvingDefinition.php
@@ -2,7 +2,7 @@
 
 namespace DI\Definition;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Describes a definition that can resolve itself.

--- a/src/DI/Definition/StringDefinition.php
+++ b/src/DI/Definition/StringDefinition.php
@@ -4,8 +4,8 @@ namespace DI\Definition;
 
 use DI\DependencyException;
 use DI\Scope;
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\NotFoundException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * Definition of a string composed of other strings.
@@ -67,7 +67,7 @@ class StringDefinition implements Definition, SelfResolvingDefinition
         $result = preg_replace_callback('#\{([^\{\}]+)\}#', function (array $matches) use ($container) {
             try {
                 return $container->get($matches[1]);
-            } catch (NotFoundException $e) {
+            } catch (NotFoundExceptionInterface $e) {
                 throw new DependencyException(sprintf(
                     "Error while parsing string expression for entry '%s': %s",
                     $this->getName(),

--- a/src/DI/Definition/ValueDefinition.php
+++ b/src/DI/Definition/ValueDefinition.php
@@ -3,7 +3,7 @@
 namespace DI\Definition;
 
 use DI\Scope;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Definition of a value for dependency injection.

--- a/src/DI/Invoker/FactoryParameterResolver.php
+++ b/src/DI/Invoker/FactoryParameterResolver.php
@@ -2,7 +2,7 @@
 
 namespace DI\Invoker;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Invoker\ParameterResolver\ParameterResolver;
 use ReflectionFunctionAbstract;
 
@@ -46,7 +46,8 @@ class FactoryParameterResolver implements ParameterResolver
                 continue;
             }
 
-            if ($parameterClass->name === 'Interop\Container\ContainerInterface') {
+            if ($parameterClass->name === 'Interop\Container\ContainerInterface'
+                || $parameterClass->name === 'Psr\Container\ContainerInterface') {
                 $resolvedParameters[$index] = $this->container;
             } elseif ($parameterClass->name === 'DI\Factory\RequestedEntry') {
                 // By convention the second parameter is the definition

--- a/tests/IntegrationTest/Definitions/DecoratorDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/DecoratorDefinitionTest.php
@@ -3,7 +3,7 @@
 namespace DI\Test\IntegrationTest\Definitions;
 
 use DI\ContainerBuilder;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Test decorator definitions.

--- a/tests/IntegrationTest/Definitions/FactoryDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/FactoryDefinitionTest.php
@@ -5,7 +5,7 @@ namespace DI\Test\IntegrationTest\Definitions;
 use DI\ContainerBuilder;
 use DI\Factory\RequestedEntry;
 use DI\Test\UnitTest\Definition\Resolver\Fixture\NoConstructor;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Test factory definitions.
@@ -165,6 +165,20 @@ class FactoryDefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('stdClass', $factory[0]);
         $this->assertInstanceOf(RequestedEntry::class, $factory[1]);
         $this->assertInstanceOf(ContainerInterface::class, $factory[2]);
+    }
+
+    public function test_interop_container_get_injected_in_arbitrary_position_via_typehint()
+    {
+        $container = $this->createContainer([
+            'factory' => function (\stdClass $stdClass, \Interop\Container\ContainerInterface $c) {
+                return [$stdClass, $c];
+            },
+        ]);
+
+        $factory = $container->get('factory');
+
+        $this->assertInstanceOf('stdClass', $factory[0]);
+        $this->assertInstanceOf(ContainerInterface::class, $factory[1]);
     }
 
     public function test_value_gets_injected_via_parameter()

--- a/tests/PerformanceTest/factory.php
+++ b/tests/PerformanceTest/factory.php
@@ -2,7 +2,7 @@
 
 use DI\ContainerBuilder;
 use DI\Scope;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 require_once __DIR__ . '/vendor/autoload.php';
 

--- a/tests/PerformanceTest/get/config.php
+++ b/tests/PerformanceTest/get/config.php
@@ -2,7 +2,7 @@
 
 use DI\Test\PerformanceTest\Get\A;
 use DI\Test\PerformanceTest\Get\B;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 return [
     'object'  => \DI\object('DI\Test\PerformanceTest\Get\GetFixture')

--- a/tests/UnitTest/ContainerBuilderTest.php
+++ b/tests/UnitTest/ContainerBuilderTest.php
@@ -9,7 +9,7 @@ use DI\Definition\ValueDefinition;
 use DI\Test\UnitTest\Fixtures\FakeContainer;
 use Doctrine\Common\Cache\Cache;
 use EasyMock\EasyMock;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * @covers \DI\ContainerBuilder

--- a/tests/UnitTest/Definition/AliasDefinitionTest.php
+++ b/tests/UnitTest/Definition/AliasDefinitionTest.php
@@ -6,7 +6,7 @@ use DI\Definition\AliasDefinition;
 use DI\Definition\CacheableDefinition;
 use DI\Scope;
 use EasyMock\EasyMock;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * @covers \DI\Definition\AliasDefinition

--- a/tests/UnitTest/Definition/Resolver/DecoratorResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/DecoratorResolverTest.php
@@ -7,7 +7,7 @@ use DI\Definition\Resolver\DecoratorResolver;
 use DI\Definition\Resolver\DefinitionResolver;
 use DI\Definition\ValueDefinition;
 use EasyMock\EasyMock;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use PHPUnit_Framework_MockObject_MockObject;
 
 /**

--- a/tests/UnitTest/Definition/Resolver/FactoryParameterResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/FactoryParameterResolverTest.php
@@ -7,7 +7,7 @@ use DI\Factory\RequestedEntry;
 use DI\Invoker\FactoryParameterResolver;
 use DI\Test\UnitTest\Definition\Resolver\Fixture\NoConstructor;
 use EasyMock\EasyMock;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * @covers \DI\Invoker\FactoryParameterResolver
@@ -36,6 +36,36 @@ class FactoryParameterResolverTest extends \PHPUnit_Framework_TestCase
         $this->container = $this->easyMock(ContainerInterface::class);
         $this->resolver = new FactoryParameterResolver($this->container);
         $this->requestedEntry = $this->easyMock(RequestedEntry::class);
+    }
+
+    /**
+     * @test
+     */
+    public function should_resolve_interop_container()
+    {
+        $callable = function (\Interop\Container\ContainerInterface $c) {
+        };
+        $reflection = new \ReflectionFunction($callable);
+
+        $parameters = $this->resolver->getParameters($reflection, [$this->container, $this->requestedEntry], []);
+
+        $this->assertCount(1, $parameters);
+        $this->assertSame($this->container, $parameters[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function should_resolve_psr11_container()
+    {
+        $callable = function (ContainerInterface $c) {
+        };
+        $reflection = new \ReflectionFunction($callable);
+
+        $parameters = $this->resolver->getParameters($reflection, [$this->container, $this->requestedEntry], []);
+
+        $this->assertCount(1, $parameters);
+        $this->assertSame($this->container, $parameters[0]);
     }
 
     /**

--- a/tests/UnitTest/Definition/Resolver/ResolverDispatcherTest.php
+++ b/tests/UnitTest/Definition/Resolver/ResolverDispatcherTest.php
@@ -8,7 +8,7 @@ use DI\Definition\StringDefinition;
 use DI\Definition\ValueDefinition;
 use DI\Proxy\ProxyFactory;
 use EasyMock\EasyMock;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * @covers \DI\Definition\Resolver\ResolverDispatcher

--- a/tests/UnitTest/Definition/Resolver/SelfResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/SelfResolverTest.php
@@ -5,7 +5,7 @@ namespace DI\Test\UnitTest\Definition\Resolver;
 use DI\Definition\Resolver\SelfResolver;
 use DI\Definition\ValueDefinition;
 use EasyMock\EasyMock;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * @covers \DI\Definition\Resolver\SelfResolver

--- a/tests/UnitTest/Definition/StringDefinitionTest.php
+++ b/tests/UnitTest/Definition/StringDefinitionTest.php
@@ -7,7 +7,7 @@ use DI\Definition\StringDefinition;
 use DI\NotFoundException;
 use DI\Scope;
 use EasyMock\EasyMock;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * @covers \DI\Definition\StringDefinition

--- a/tests/UnitTest/Definition/ValueDefinitionTest.php
+++ b/tests/UnitTest/Definition/ValueDefinitionTest.php
@@ -6,7 +6,7 @@ use DI\Definition\CacheableDefinition;
 use DI\Definition\ValueDefinition;
 use DI\Scope;
 use EasyMock\EasyMock;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * @covers \DI\Definition\ValueDefinition

--- a/tests/UnitTest/Fixtures/FakeContainer.php
+++ b/tests/UnitTest/Fixtures/FakeContainer.php
@@ -4,7 +4,7 @@ namespace DI\Test\UnitTest\Fixtures;
 
 use DI\Definition\Source\DefinitionSource;
 use DI\Proxy\ProxyFactory;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Fake container class that exposes all constructor parameters.

--- a/website/home_container.twig
+++ b/website/home_container.twig
@@ -11,7 +11,8 @@
         <div class="col-md-6">
             <h4>Get & Has</h4>
             <p>
-                PHP-DI is compliant with <a href="https://github.com/container-interop/container-interop">container-interop</a>:
+                PHP-DI is compliant with <a href="https://github.com/container-interop/container-interop">container-interop</a>
+                and <a href="http://www.php-fig.org/psr/">PSR-11</a>:
             </p>
             <pre><code class="php">$container->get($name);
 $container->has($name);</code></pre>


### PR DESCRIPTION
PHP-DI already implements PSR-11 through container-interop (which extends PSR-11 since version 1.2.0).

But this pull request makes it explicit and brings full support with autowiring (type-hinting `Psr\Container\ContainerInterface`).