### PR TITLE
Register the container against the PSR ContainerInterface.

### DIFF
--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -89,6 +89,7 @@ class Container implements ContainerInterface, InteropContainerInterface, Factor
         $this->singletonEntries[self::class] = $this;
         $this->singletonEntries[FactoryInterface::class] = $this;
         $this->singletonEntries[InvokerInterface::class] = $this;
+        $this->singletonEntries[ContainerInterface::class] = $this;
     }
 
     /**

--- a/tests/UnitTest/ContainerTest.php
+++ b/tests/UnitTest/ContainerTest.php
@@ -6,6 +6,7 @@ use DI\Container;
 use DI\ContainerBuilder;
 use DI\FactoryInterface;
 use DI\InvokerInterface;
+use Psr\Container\ContainerInterface;
 use stdClass;
 
 /**
@@ -97,6 +98,16 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $container = ContainerBuilder::buildDevContainer();
 
         $this->assertSame($container, $container->get(InvokerInterface::class));
+    }
+
+    /**
+     * The container auto-registers itself (with the container interface).
+     */
+    public function testContainerInterfaceIsRegistered()
+    {
+        $container = ContainerBuilder::buildDevContainer();
+
+        $this->assertSame($container, $container->get(ContainerInterface::class));
     }
 
     /**


### PR DESCRIPTION
The container previously used to register itself against `DI\ContainerInterface` (which was subsequently removed). 

Now that PSR-11 has been accepted, it would be useful to be able retrieve the container from the PSR `ContainerInterface`.