### PR TITLE
Replace Doctrine Cache with PSR-16

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -2,6 +2,8 @@
 
 ## 6.0
 
+This is the complete change log. You can also read the [migration guide](doc/migration/6.0.md) for upgrading.
+
 Improvements:
 
 - [#294](https://github.com/PHP-DI/PHP-DI/issues/294), [#349](https://github.com/PHP-DI/PHP-DI/issues/349), [#449](https://github.com/PHP-DI/PHP-DI/pull/449): `DI\object()` has been replaced by more specific and less ambiguous helpers:
@@ -9,13 +11,17 @@ Improvements:
     - `DI\autowire()` autowires an object and allows to override specific constructor and method parameters
 - The container can now be built without parameters: `new Container()`
 - [#242](https://github.com/PHP-DI/PHP-DI/issues/242) Error in case a definition is not indexed by a string
+- [#376](https://github.com/PHP-DI/PHP-DI/issues/376) [PSR-16](https://github.com/php-fig/simple-cache) support for the cache system (which replaces Doctrine's Cache)
 
 BC breaks:
 
 - PHP 7 or greater is required
 - `DI\object()` has been removed, use `DI\create()` or `DI\autowire()` instead
 - The deprecated `DI\link()` helper was removed, used `DI\get()` instead
+- The cache system has been moved from Doctrine Cache to PSR-16 (the simple cache standard)
 - The exception `DI\Definition\Exception\DefinitionException` was renamed to `DI\Definition\Exception\InvalidDefinition`
+
+Be also aware that internal classes or interfaces may have changed.
 
 ## 5.4.1
 

--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,13 @@
         "php": ">=7.0.0",
         "container-interop/container-interop": "~1.2",
         "psr/container": "~1.0",
+        "psr/simple-cache": "^1.0",
         "php-di/invoker": "^1.3.2",
         "php-di/phpdoc-reader": "^2.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0",
         "mnapoli/phpunit-easymock": "~0.2.0",
-        "doctrine/cache": "~1.4",
         "doctrine/annotations": "~1.2",
         "ocramius/proxy-manager": "~2.0.2"
     },
@@ -44,7 +44,6 @@
         "psr/container-implementation": "^1.0"
     },
     "suggest": {
-        "doctrine/cache": "Install it if you want to use the cache (version ~1.4)",
         "doctrine/annotations": "Install it if you want to use annotations (version ~1.2)",
         "ocramius/proxy-manager": "Install it if you want to use lazy injection (version ~2.0)"
     }

--- a/doc/container-configuration.md
+++ b/doc/container-configuration.md
@@ -7,15 +7,15 @@ current_menu: container-configuration
 
 ## Development environment
 
-PHP-DI's container is preconfigured for "plug'n'play", i.e. development environment. You can start using it simply like so:
+PHP-DI's container is preconfigured for "plug and play", i.e. development environment. You can start using it simply like so:
 
 ```php
 $container = ContainerBuilder::buildDevContainer();
-// same as
+// or even simpler
 $container = new Container();
 ```
 
-By default, PHP-DI will have [Autowiring](definition.md) enabled (annotations are disabled by default).
+By default, PHP-DI will have [Autowiring](definition.md) enabled ([annotations](annotations.md) are disabled by default).
 
 ## Production environment
 
@@ -23,7 +23,7 @@ In production environment, you will of course favor speed:
 
 ```php
 $builder = new \DI\ContainerBuilder();
-$builder->setDefinitionCache(new Doctrine\Common\Cache\ApcCache());
+$builder->setDefinitionCache(/* a cache */);
 $builder->writeProxiesToFile(true, 'tmp/proxies');
 
 $container = $builder->build();

--- a/doc/migration/6.0.md
+++ b/doc/migration/6.0.md
@@ -37,6 +37,27 @@ If you have multiple configuration files, for example if you have built a module
 
 The `DI\link()` function helper was deprecated in 5.0. It is now completely removed. Use `DI\get()` instead.
 
+## Caching
+
+PHP-DI 5 was using the Doctrine Cache library for caching definitions. Since then, PSR-6 and PSR-16 have standardized caching in PHP.
+
+PHP-DI 6 now uses PSR-16 (the simple cache standard) instead of Doctrine. The migration should be easy:
+
+- you can replace completely doctrine/cache with another PHP library, like the [symfony/cache](http://symfony.com/doc/current/components/cache.html) component
+
+    ```php
+    $cache = new Symfony\Component\Cache\Simple\ApcuCache();
+    $containerBuilder->setDefinitionCache($cache);
+    ```
+
+- or else you can use the `Symfony\Component\Cache\Adapter\DoctrineAdapter` class from the [symfony/cache](http://symfony.com/doc/current/components/cache.html) component to keep using the Doctrine cache while also making it compatible with PSR-16
+
+    ```php
+    $doctrineCache = /* your current Doctrine cache */
+    $cache = new Symfony\Component\Cache\Adapter\DoctrineAdapter($doctrineCache);
+    $containerBuilder->setDefinitionCache($cache);
+    ```
+
 ## Internal changes
 
 If you were overriding or extending some internal classes of PHP-DI, be aware that they may have changed.

--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -11,9 +11,9 @@ use DI\Definition\Source\NoAutowiring;
 use DI\Definition\Source\ReflectionBasedAutowiring;
 use DI\Definition\Source\SourceChain;
 use DI\Proxy\ProxyFactory;
-use Doctrine\Common\Cache\Cache;
 use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
+use Psr\SimpleCache\CacheInterface;
 
 /**
  * Helper to create and configure a Container.
@@ -52,7 +52,7 @@ class ContainerBuilder
     private $ignorePhpDocErrors = false;
 
     /**
-     * @var Cache
+     * @var CacheInterface
      */
     private $cache;
 
@@ -204,10 +204,10 @@ class ContainerBuilder
     /**
      * Enables the use of a cache for the definitions.
      *
-     * @param Cache $cache Cache backend to use
+     * @param CacheInterface $cache Cache backend to use
      * @return ContainerBuilder
      */
-    public function setDefinitionCache(Cache $cache)
+    public function setDefinitionCache(CacheInterface $cache)
     {
         $this->ensureNotLocked();
 

--- a/src/DI/Definition/Source/CachedDefinitionSource.php
+++ b/src/DI/Definition/Source/CachedDefinitionSource.php
@@ -4,7 +4,7 @@ namespace DI\Definition\Source;
 
 use DI\Definition\CacheableDefinition;
 use DI\Definition\Definition;
-use Doctrine\Common\Cache\Cache;
+use Psr\SimpleCache\CacheInterface;
 
 /**
  * Caches another definition source.
@@ -25,11 +25,11 @@ class CachedDefinitionSource implements DefinitionSource
     private $source;
 
     /**
-     * @var Cache
+     * @var CacheInterface
      */
     private $cache;
 
-    public function __construct(DefinitionSource $source, Cache $cache)
+    public function __construct(DefinitionSource $source, CacheInterface $cache)
     {
         $this->source = $source;
         $this->cache = $cache;
@@ -55,10 +55,7 @@ class CachedDefinitionSource implements DefinitionSource
         return $definition;
     }
 
-    /**
-     * @return Cache
-     */
-    public function getCache()
+    public function getCache() : CacheInterface
     {
         return $this->cache;
     }
@@ -73,7 +70,7 @@ class CachedDefinitionSource implements DefinitionSource
     {
         $cacheKey = self::CACHE_PREFIX . $name;
 
-        $data = $this->cache->fetch($cacheKey);
+        $data = $this->cache->get($cacheKey, false);
 
         if ($data !== false) {
             return $data;
@@ -92,6 +89,6 @@ class CachedDefinitionSource implements DefinitionSource
     {
         $cacheKey = self::CACHE_PREFIX . $name;
 
-        $this->cache->save($cacheKey, $definition);
+        $this->cache->set($cacheKey, $definition);
     }
 }

--- a/tests/IntegrationTest/CacheTest.php
+++ b/tests/IntegrationTest/CacheTest.php
@@ -2,8 +2,8 @@
 
 namespace DI\Test\IntegrationTest;
 
+use DI\Cache\ArrayCache;
 use DI\ContainerBuilder;
-use Doctrine\Common\Cache\ArrayCache;
 
 /**
  * Test caching.

--- a/tests/PerformanceTest/call.php
+++ b/tests/PerformanceTest/call.php
@@ -1,7 +1,7 @@
 <?php
 
+use DI\Cache\ArrayCache;
 use DI\ContainerBuilder;
-use Doctrine\Common\Cache\ArrayCache;
 
 require_once __DIR__ . '/vendor/autoload.php';
 

--- a/tests/PerformanceTest/get-object.php
+++ b/tests/PerformanceTest/get-object.php
@@ -1,7 +1,7 @@
 <?php
 
+use DI\Cache\ArrayCache;
 use DI\ContainerBuilder;
-use Doctrine\Common\Cache\ArrayCache;
 
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/get-object/GetFixture.php';

--- a/tests/UnitTest/Cache/ArrayCacheTest.php
+++ b/tests/UnitTest/Cache/ArrayCacheTest.php
@@ -3,14 +3,15 @@
 namespace DI\Test\UnitTest\Cache;
 
 use DI\Cache\ArrayCache;
+use Psr\SimpleCache\CacheInterface;
 
 /**
  * Copy of Doctrine's test.
  */
 class ArrayCacheTest extends CacheTest
 {
-    protected function getCacheDriver()
+    protected function getCacheDriver() : CacheInterface
     {
-        return new ArrayCache();
+        return new ArrayCache;
     }
 }

--- a/tests/UnitTest/ContainerBuilderTest.php
+++ b/tests/UnitTest/ContainerBuilderTest.php
@@ -8,9 +8,9 @@ use DI\Definition\Source\CachedDefinitionSource;
 use DI\Definition\Source\DefinitionArray;
 use DI\Definition\ValueDefinition;
 use DI\Test\UnitTest\Fixtures\FakeContainer;
-use Doctrine\Common\Cache\Cache;
 use EasyMock\EasyMock;
 use Psr\Container\ContainerInterface;
+use Psr\SimpleCache\CacheInterface;
 
 /**
  * @covers \DI\ContainerBuilder
@@ -40,7 +40,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function should_allow_to_configure_a_cache()
     {
-        $cache = $this->easyMock(Cache::class);
+        $cache = $this->easyMock(CacheInterface::class);
 
         $builder = new ContainerBuilder(FakeContainer::class);
         $builder->setDefinitionCache($cache);
@@ -181,7 +181,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $result = $builder->writeProxiesToFile(false);
         $this->assertSame($builder, $result);
 
-        $mockCache = $this->easyMock(Cache::class);
+        $mockCache = $this->easyMock(CacheInterface::class);
         $result = $builder->setDefinitionCache($mockCache);
         $this->assertSame($builder, $result);
 

--- a/tests/UnitTest/Definition/Source/CachedDefinitionSourceTest.php
+++ b/tests/UnitTest/Definition/Source/CachedDefinitionSourceTest.php
@@ -5,8 +5,8 @@ namespace DI\Test\UnitTest\Definition\Source;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\Source\CachedDefinitionSource;
 use DI\Definition\Source\DefinitionArray;
-use Doctrine\Common\Cache\Cache;
 use EasyMock\EasyMock;
+use Psr\SimpleCache\CacheInterface;
 
 /**
  * @covers \DI\Definition\Source\CachedDefinitionSource
@@ -20,9 +20,9 @@ class CachedDefinitionSourceTest extends \PHPUnit_Framework_TestCase
      */
     public function should_get_from_cache()
     {
-        /** @var Cache $cache */
-        $cache = $this->easySpy(Cache::class, [
-            'fetch' => 'foo',
+        /** @var CacheInterface $cache */
+        $cache = $this->easySpy(CacheInterface::class, [
+            'get' => 'foo',
         ]);
 
         $source = new CachedDefinitionSource(new DefinitionArray(), $cache);
@@ -35,8 +35,8 @@ class CachedDefinitionSourceTest extends \PHPUnit_Framework_TestCase
      */
     public function should_save_to_cache_and_return()
     {
-        $cache = $this->easySpy(Cache::class, [
-            'fetch' => false,
+        $cache = $this->easySpy(CacheInterface::class, [
+            'get' => false,
         ]);
 
         $cachedSource = new DefinitionArray([
@@ -47,7 +47,7 @@ class CachedDefinitionSourceTest extends \PHPUnit_Framework_TestCase
 
         $expectedDefinition = new ObjectDefinition('foo');
         $cache->expects($this->once())
-            ->method('save')
+            ->method('set')
             ->with($this->isType('string'), $expectedDefinition);
 
         $this->assertEquals($expectedDefinition, $source->getDefinition('foo'));
@@ -58,14 +58,14 @@ class CachedDefinitionSourceTest extends \PHPUnit_Framework_TestCase
      */
     public function should_save_null_to_cache_and_return_null()
     {
-        $cache = $this->easySpy(Cache::class, [
-            'fetch' => false,
+        $cache = $this->easySpy(CacheInterface::class, [
+            'get' => false,
         ]);
 
         $source = new CachedDefinitionSource(new DefinitionArray(), $cache);
 
         $cache->expects($this->once())
-            ->method('save')
+            ->method('set')
             ->with($this->isType('string'), null);
         $this->assertNull($source->getDefinition('foo'));
     }


### PR DESCRIPTION
Fix #376 

The cache system has been moved from Doctrine Cache to PSR-16 (the simple cache standard).

Symfony Cache is recommended. Only the 3.3 version will support PSR-16, and it is not released yet. However 3.3 will be released in May and I think PHP-DI 6 will be released at the same time so it's fine IMO. Also it's a standard, people can use any implementation.

TODO:

- [x] Migration guide