### PR TITLE
Return proper type AutowireDefinitionHelper in PHPDoc

### DIFF
--- a/src/DI/Definition/Helper/AutowireDefinitionHelper.php
+++ b/src/DI/Definition/Helper/AutowireDefinitionHelper.php
@@ -24,7 +24,7 @@ class AutowireDefinitionHelper extends CreateDefinitionHelper
      * @param string $parameter Parameter for which the value will be given.
      * @param mixed  $value     Value to give to this parameter.
      *
-     * @return CreateDefinitionHelper
+     * @return AutowireDefinitionHelper
      */
     public function constructorParameter($parameter, $value)
     {
@@ -48,7 +48,7 @@ class AutowireDefinitionHelper extends CreateDefinitionHelper
      * @param string $parameter Name or index of the parameter for which the value will be given.
      * @param mixed  $value     Value to give to this parameter.
      *
-     * @return CreateDefinitionHelper
+     * @return AutowireDefinitionHelper
      */
     public function methodParameter($method, $parameter, $value)
     {


### PR DESCRIPTION
Maybe even consider `@return $this`?

Currently PHPStorm does not 'accept' this:
- `autoware()->lazy()->constructorParameter()`. 

This is because `lazy()` PHPDoc suggests a CreateDefinitionHelper is returned which does not have method `constructorParameter()`...

<img width="373" alt="screen shot 2017-04-18 at 20 09 40" src="https://cloud.githubusercontent.com/assets/776405/25146106/0a989a88-2473-11e7-98ed-2d9a64d7d653.png">
