### PR TITLE
PSR16 cache key char restriction

### DIFF
--- a/src/DI/Definition/Source/CachedDefinitionSource.php
+++ b/src/DI/Definition/Source/CachedDefinitionSource.php
@@ -17,7 +17,7 @@ class CachedDefinitionSource implements DefinitionSource
      * Prefix for cache key, to avoid conflicts with other systems using the same cache.
      * @var string
      */
-    const CACHE_PREFIX = 'DI\\Definition\\';
+    const CACHE_PREFIX = 'DI_Definition_';
 
     /**
      * @var DefinitionSource


### PR DESCRIPTION
Changed back slash to underscore to comply with PSR16 cache key restrictions

> Key - A string of at least one character that uniquely identifies a cached item. Implementing libraries MUST support keys consisting of the characters A-Z, a-z, 0-9, _, and . in any order in UTF-8 encoding and a length of up to 64 characters. Implementing libraries MAY support additional characters and encodings or longer lengths, but must support at least that minimum. Libraries are responsible for their own escaping of key strings as appropriate, but MUST be able to return the original unmodified key string. The following characters are reserved for future extensions and MUST NOT be supported by implementing libraries: {}()/\\@:

Fixes #473 