### PR TITLE
FQN are no good as cache keys for PSR-16

### DIFF
--- a/src/DI/Definition/Source/CachedDefinitionSource.php
+++ b/src/DI/Definition/Source/CachedDefinitionSource.php
@@ -93,6 +93,6 @@ class CachedDefinitionSource implements DefinitionSource
      */
     private function getCacheKey(string $name) : string
     {
-        return self::CACHE_PREFIX . str_replace('\\', '.', $name);
+        return self::CACHE_PREFIX . str_replace(['{', '}', '(', ')', '/', '\\', '@', ':'], '.', $name);
     }
 }

--- a/src/DI/Definition/Source/CachedDefinitionSource.php
+++ b/src/DI/Definition/Source/CachedDefinitionSource.php
@@ -17,7 +17,7 @@ class CachedDefinitionSource implements DefinitionSource
      * Prefix for cache key, to avoid conflicts with other systems using the same cache.
      * @var string
      */
-    const CACHE_PREFIX = 'DI_Definition_';
+    const CACHE_PREFIX = 'DI.Definition.';
 
     /**
      * @var DefinitionSource
@@ -65,9 +65,7 @@ class CachedDefinitionSource implements DefinitionSource
      */
     private function fetchFromCache(string $name)
     {
-        $cacheKey = self::CACHE_PREFIX . $name;
-
-        $data = $this->cache->get($cacheKey, false);
+        $data = $this->cache->get($this->getCacheKey($name), false);
 
         if ($data !== false) {
             return $data;
@@ -83,8 +81,18 @@ class CachedDefinitionSource implements DefinitionSource
      */
     private function saveToCache(string $name, Definition $definition = null)
     {
-        $cacheKey = self::CACHE_PREFIX . $name;
+        $this->cache->set($this->getCacheKey($name), $definition);
+    }
 
-        $this->cache->set($cacheKey, $definition);
+    /**
+     * Get normalized cache key.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    private function getCacheKey(string $name) : string
+    {
+        return self::CACHE_PREFIX . str_replace('\\', '.', $name);
     }
 }

--- a/tests/UnitTest/Definition/Source/CachedDefinitionSourceTest.php
+++ b/tests/UnitTest/Definition/Source/CachedDefinitionSourceTest.php
@@ -30,7 +30,10 @@ class CachedDefinitionSourceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $source->getDefinition('foo'));
     }
 
-    public function testCacheKey()
+    /**
+     * @dataProvider cacheKeyProvider
+     */
+    public function testCacheKey($rawName, $cacheName)
     {
         $cache = $this->easySpy(CacheInterface::class);
 
@@ -38,14 +41,24 @@ class CachedDefinitionSourceTest extends \PHPUnit_Framework_TestCase
 
         $cache->expects($this->once())
             ->method('get')
-            ->with(CachedDefinitionSource::CACHE_PREFIX . 'foo.bar.baz')
+            ->with(CachedDefinitionSource::CACHE_PREFIX . $cacheName)
             ->will($this->returnValue(false));
 
         $cache->expects($this->once())
             ->method('set')
-            ->with(CachedDefinitionSource::CACHE_PREFIX . 'foo.bar.baz');
+            ->with(CachedDefinitionSource::CACHE_PREFIX . $cacheName);
 
-        $source->getDefinition('foo\\bar\\baz');
+        $source->getDefinition($rawName);
+    }
+
+    public function cacheKeyProvider()
+    {
+        return [
+            ['foo{bar}baz', 'foo.bar.baz'],
+            ['foo(bar)baz', 'foo.bar.baz'],
+            ['foo/bar\baz', 'foo.bar.baz'],
+            ['foo@bar:baz', 'foo.bar.baz'],
+        ];
     }
 
     /**

--- a/tests/UnitTest/Definition/Source/CachedDefinitionSourceTest.php
+++ b/tests/UnitTest/Definition/Source/CachedDefinitionSourceTest.php
@@ -30,6 +30,24 @@ class CachedDefinitionSourceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $source->getDefinition('foo'));
     }
 
+    public function testCacheKey()
+    {
+        $cache = $this->easySpy(CacheInterface::class);
+
+        $source = new CachedDefinitionSource(new DefinitionArray(), $cache);
+
+        $cache->expects($this->once())
+            ->method('get')
+            ->with(CachedDefinitionSource::CACHE_PREFIX . 'foo.bar.baz')
+            ->will($this->returnValue(false));
+
+        $cache->expects($this->once())
+            ->method('set')
+            ->with(CachedDefinitionSource::CACHE_PREFIX . 'foo.bar.baz');
+
+        $source->getDefinition('foo\\bar\\baz');
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
Following on #474 

When using FQN as definitions these are conflicting with PSR-16 cache key restriction:

```php
$containerBuilder->setDefinitionCache(new PSR_16_cache_implementation());
$containerBuilder->addDefinitions([
    LoggerInterface::class => function (): LoggerInterface {
        return (new Logger())
            ->pushProcessor(new MemoryUsageProcessor())
            ->pushProcessor(new MemoryPeakUsageProcessor())
            ->pushHandler(new ErrorLogHandler(ErrorLogHandler::OPERATING_SYSTEM, Logger::DEBUG));
    },
]);

$container = $containerBuilder->build();
$container->get(LoggerInterface::class);
```

Produces the error

> Invalid key: "DI_Definition_Psr\Log\LoggerInterface". The key contains one or more characters reserved for future extension: {}()/\\@:

In order to fix this cache key is constructed by changing back slashes to dots, but perhaps dot is not the proper character to use as separator and a less common char should be used instead, such like #, %, * or ~