### PR TITLE
Update autowiring.md (link to PHP manual)

### DIFF
--- a/doc/autowiring.md
+++ b/doc/autowiring.md
@@ -26,7 +26,7 @@ class UserRegistrationService
 }
 ```
 
-When PHP-DI needs to create the `UserRegistrationService`, it detects that the constructor takes a `UserRepository` object (using the [type hinting](http://www.php.net/manual/en/language.oop5.typehinting.php)).
+When PHP-DI needs to create the `UserRegistrationService`, it detects that the constructor takes a `UserRepository` object (using the [type hinting](http://www.php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration)).
 
 **Without any configuration**, PHP-DI will create a `UserRepository` instance (if it wasn't already created) and pass it as a constructor parameter. The equivalent raw PHP code would be:
 


### PR DESCRIPTION
The external link about type hinting had its resource moved to the proposed new URL.