### PR TITLE
[WIP] Recursively resolve array definitions

### DIFF
--- a/src/DI/Definition/Resolver/ArrayResolver.php
+++ b/src/DI/Definition/Resolver/ArrayResolver.php
@@ -43,11 +43,11 @@ class ArrayResolver implements DefinitionResolver
         $values = $definition->getValues();
 
         // Resolve nested definitions
-        foreach ($values as $key => $value) {
+        array_walk_recursive($values, function (&$value, $key) use ($definition) {
             if ($value instanceof DefinitionHelper) {
-                $values[$key] = $this->resolveDefinition($value, $definition, $key);
+                $value = $this->resolveDefinition($value, $definition, $key);
             }
-        }
+        });
 
         return $values;
     }

--- a/tests/IntegrationTest/Definitions/ArrayDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/ArrayDefinitionTest.php
@@ -72,6 +72,25 @@ class ArrayDefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new \stdClass, $array[1]);
     }
 
+    public function test_nested_array_with_nested_definitions()
+    {
+        $builder = new ContainerBuilder();
+        $builder->addDefinitions([
+            'array' => [
+                'array' => [
+                    \DI\env('PHP_DI_DO_NOT_DEFINE_THIS', 'env'),
+                    \DI\create('stdClass'),
+                ],
+            ],
+        ]);
+        $container = $builder->build();
+
+        $array = $container->get('array');
+
+        $this->assertEquals('env', $array['array'][0]);
+        $this->assertEquals(new \stdClass, $array['array'][1]);
+    }
+
     /**
      * An array entry is a singleton.
      */


### PR DESCRIPTION
Hello,

I was using PHP-DI and noticed that array definitions are only resolved at the first level of the array.  For example:

```php
return [
    's3.config' => [
        'version'                  => 'latest',
        'region'                   => DI\env('S3_REGION'), // this resolves
        'bucket'                   => 'stuff',
        'credentials'              => [
            'key'    => DI\env('S3_KEY'),
            'secret' => DI\env('S3_SECRET'),  // these don't
        ],
    ],
    // ...
];
```

To make this work I changed the ArrayResolver to recurse and added a test.

It looks like `ArrayDefinition::__toString` would need to change too if this added.  I'm not too sure of what the format should be.