### PR TITLE
Cache refactoring for performance improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
       env: dependencies=lowest
 
 before_script:
+  - phpenv config-add travis.php.ini
   - if [[ $(phpenv version-name) == '7.1' ]]; then composer require satooshi/php-coveralls:dev-master -n ; fi
   - if [[ $(phpenv version-name) != '7.1' ]]; then composer install -n ; fi
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable -n; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ php:
   - 7.1
   - nightly
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 matrix:
   fast_finish: true
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,10 @@
         "php-di/phpdoc-reader": "^2.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0",
-        "mnapoli/phpunit-easymock": "~0.2.0",
-        "doctrine/annotations": "~1.2",
-        "ocramius/proxy-manager": "~2.0.2"
+        "phpunit/phpunit": "^5.7.0",
+        "mnapoli/phpunit-easymock": "^0.2.3",
+        "doctrine/annotations": "^1.2.0",
+        "ocramius/proxy-manager": "^2.0.2"
     },
     "replace": {
         "mnapoli/php-di": "*"

--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -202,6 +202,20 @@ class ContainerBuilder
     /**
      * Enables the use of a cache for the definitions.
      *
+     * @return $this
+     */
+    public function cacheDefinitions(bool $useCache = true) : ContainerBuilder
+    {
+        $this->ensureNotLocked();
+
+        $this->cache = $useCache;
+
+        return $this;
+    }
+
+    /**
+     * Enables the use of a cache for the definitions.
+     *
      * @param CacheInterface $cache Cache backend to use
      * @return $this
      */

--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -133,7 +133,10 @@ class ContainerBuilder
         $chain = new SourceChain($sources);
 
         if ($this->cache) {
-            $source = new CachedDefinitionSource($chain, $this->cache);
+            if (!CachedDefinitionSource::isSupported()) {
+                throw new \Exception('APCu is not enabled, PHP-DI cannot use it as a cache');
+            }
+            $source = new CachedDefinitionSource($chain);
             $chain->setRootDefinitionSource($source);
         } else {
             $source = $chain;

--- a/src/DI/Definition/Source/CachedDefinitionSource.php
+++ b/src/DI/Definition/Source/CachedDefinitionSource.php
@@ -14,85 +14,53 @@ use Psr\SimpleCache\CacheInterface;
 class CachedDefinitionSource implements DefinitionSource
 {
     /**
-     * Prefix for cache key, to avoid conflicts with other systems using the same cache.
      * @var string
      */
-    const CACHE_PREFIX = 'DI.Definition.';
+    const CACHE_KEY = 'php-di.definitions';
 
     /**
      * @var DefinitionSource
      */
-    private $source;
+    private $cachedSource;
 
     /**
-     * @var CacheInterface
+     * Definitions loaded from the cache (or null if not loaded yet).
+     *
+     * @var Definition[]|null
      */
-    private $cache;
+    private $cachedDefinitions;
 
-    public function __construct(DefinitionSource $source, CacheInterface $cache)
+    public function __construct(DefinitionSource $cachedSource)
     {
-        $this->source = $source;
-        $this->cache = $cache;
+        $this->cachedSource = $cachedSource;
     }
 
     public function getDefinition(string $name)
     {
+        if ($this->cachedDefinitions === null) {
+            $this->cachedDefinitions = apcu_fetch(self::CACHE_KEY) ?: [];
+        }
+
         // Look in cache
-        $definition = $this->fetchFromCache($name);
+        $definition = $this->cachedDefinitions[$name] ?? false;
 
         if ($definition === false) {
-            $definition = $this->source->getDefinition($name);
+            $definition = $this->cachedSource->getDefinition($name);
 
-            // Save to cache
+            // Update the cache
             if ($definition === null || ($definition instanceof CacheableDefinition)) {
-                $this->saveToCache($name, $definition);
+                $this->cachedDefinitions[$name] = $definition;
+                apcu_store(self::CACHE_KEY, $this->cachedDefinitions);
             }
         }
 
         return $definition;
     }
 
-    public function getCache() : CacheInterface
+    public static function isSupported() : bool
     {
-        return $this->cache;
-    }
-
-    /**
-     * Fetches a definition from the cache.
-     *
-     * @param string $name Entry name
-     * @return Definition|null|bool The cached definition, null or false if the value is not already cached
-     */
-    private function fetchFromCache(string $name)
-    {
-        $data = $this->cache->get($this->getCacheKey($name), false);
-
-        if ($data !== false) {
-            return $data;
-        }
-
-        return false;
-    }
-
-    /**
-     * Saves a definition to the cache.
-     *
-     * @param string $name Entry name
-     */
-    private function saveToCache(string $name, Definition $definition = null)
-    {
-        $this->cache->set($this->getCacheKey($name), $definition);
-    }
-
-    /**
-     * Get normalized cache key.
-     *
-     * @param string $name
-     *
-     * @return string
-     */
-    private function getCacheKey(string $name) : string
-    {
-        return self::CACHE_PREFIX . str_replace(['{', '}', '(', ')', '/', '\\', '@', ':'], '.', $name);
+        return function_exists('apcu_fetch')
+            && ini_get('apc.enabled')
+            && !('cli' === PHP_SAPI && !ini_get('apc.enable_cli'));
     }
 }

--- a/src/DI/Definition/Source/CachedDefinitionSource.php
+++ b/src/DI/Definition/Source/CachedDefinitionSource.php
@@ -4,7 +4,6 @@ namespace DI\Definition\Source;
 
 use DI\Definition\CacheableDefinition;
 use DI\Definition\Definition;
-use Psr\SimpleCache\CacheInterface;
 
 /**
  * Caches another definition source.

--- a/tests/IntegrationTest/CacheTest.php
+++ b/tests/IntegrationTest/CacheTest.php
@@ -4,6 +4,7 @@ namespace DI\Test\IntegrationTest;
 
 use DI\Cache\ArrayCache;
 use DI\ContainerBuilder;
+use DI\Definition\Source\CachedDefinitionSource;
 
 /**
  * Test caching.
@@ -12,6 +13,17 @@ use DI\ContainerBuilder;
  */
 class CacheTest extends \PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        parent::setUp();
+
+        if (!CachedDefinitionSource::isSupported()) {
+            $this->markTestSkipped('APCu extension is required');
+        }
+
+        apcu_clear_cache();
+    }
+
     /**
      * @test
      */

--- a/tests/UnitTest/ContainerBuilderTest.php
+++ b/tests/UnitTest/ContainerBuilderTest.php
@@ -38,23 +38,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function should_allow_to_configure_a_cache()
-    {
-        $cache = $this->easyMock(CacheInterface::class);
-
-        $builder = new ContainerBuilder(FakeContainer::class);
-        $builder->setDefinitionCache($cache);
-
-        /** @var FakeContainer $container */
-        $container = $builder->build();
-
-        $this->assertTrue($container->definitionSource instanceof CachedDefinitionSource);
-        $this->assertSame($cache, $container->definitionSource->getCache());
-    }
-
-    /**
-     * @test
-     */
     public function the_container_should_not_be_wrapped_by_default()
     {
         $builder = new ContainerBuilder(FakeContainer::class);

--- a/tests/UnitTest/Definition/Source/CachedDefinitionSourceTest.php
+++ b/tests/UnitTest/Definition/Source/CachedDefinitionSourceTest.php
@@ -2,6 +2,7 @@
 
 namespace DI\Test\UnitTest\Definition\Source;
 
+use DI\Definition\AliasDefinition;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\Source\CachedDefinitionSource;
 use DI\Definition\Source\DefinitionArray;
@@ -28,16 +29,18 @@ class CachedDefinitionSourceTest extends \PHPUnit_Framework_TestCase
      */
     public function should_get_from_cache()
     {
+        $definition = new AliasDefinition('foo', 'bar');
+
         $source = $this->createMock(DefinitionSource::class);
         $source
             ->expects($this->once()) // The sub-source should be called ONLY ONCE
             ->method('getDefinition')
-            ->willReturn('bar');
+            ->willReturn($definition);
 
         $source = new CachedDefinitionSource($source);
 
-        self::assertEquals('bar', $source->getDefinition('foo'));
-        self::assertEquals('bar', $source->getDefinition('foo'));
+        self::assertEquals($definition, $source->getDefinition('foo'));
+        self::assertEquals($definition, $source->getDefinition('foo'));
     }
 
     /**

--- a/tests/UnitTest/Definition/Source/CachedDefinitionSourceTest.php
+++ b/tests/UnitTest/Definition/Source/CachedDefinitionSourceTest.php
@@ -6,15 +6,12 @@ use DI\Definition\ObjectDefinition;
 use DI\Definition\Source\CachedDefinitionSource;
 use DI\Definition\Source\DefinitionArray;
 use DI\Definition\Source\DefinitionSource;
-use EasyMock\EasyMock;
 
 /**
  * @covers \DI\Definition\Source\CachedDefinitionSource
  */
 class CachedDefinitionSourceTest extends \PHPUnit_Framework_TestCase
 {
-    use EasyMock;
-
     public function setUp()
     {
         parent::setUp();

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -1,0 +1,3 @@
+extension="apcu.so"
+# Enable APC on the CLI to run all tests
+apc.enable_cli=1


### PR DESCRIPTION
🎉   yuuuuge performance improvements incoming :)

Fixes #477 This pull request refactors the whole cache system.

## Changes

Before:

- every (cacheable) definition is cached as a separate entry
- each definition is `get` on demand
- each definition is `set` when not found
- all PSR-16 caches are supported
- APCu is recommended because given the number of get/set to the cache, all other caches are too slow

After:

- only APCu is supported: that allows a much more optimized code, less errors from users, and a more "plug and play" solution (just enable the cache, nothing to configure)
- all definitions are cached under a single cache entry
- all the definitions are `get` at once: huge gain
- each definition is `set` when not found (not optimisation here)

Things to look out for: cache stampede.

## Performance comparison

### Benchmark `get-cache.php`

Before:

- no cache used: 224ms
- APCu cache used: 181ms
- gain thanks to the cache: **19%**
- [profiling](https://blackfire.io/profiles/compare/702a492a-f462-4aed-b210-8ab7ecf2d1eb/graph)

After:

- no cache used: 225ms
- APCu cache used: 146ms
- gain thanks to the cache: **35%**
- [profiling](https://blackfire.io/profiles/compare/29367b6a-b2c5-4e4b-8d98-aec20a1c8feb/graph)

When you use the cache there is a **19% improvement** (181 -> 146ms). [Profiling](https://blackfire.io/profiles/compare/cf181d0a-7629-4d21-aee6-ed78550573f4/graph)

## TODO

- [x] POC
- [x] ~~optimize APCu calls to avoid many `set` in the same `Container::get()` call~~ Not interesting
- [ ] test with 3rd party DI container benchmarks
- [ ] update the `ContainerBuilder`
- [ ] configurable cache key prefix
- [ ] the cache key should contain a hash of all sources? auto-refresh?
- [ ] decide what to do with `ArrayCache`
- [ ] update documentation
- [ ] changelog