### PR TITLE
Standardize resolution of nested definitions everywhere

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -16,6 +16,9 @@ Improvements:
 
 Fixes:
 
+- [#499](https://github.com/PHP-DI/PHP-DI/issues/499) & [#488](https://github.com/PHP-DI/PHP-DI/issues/488) Standardize resolution of nested definitions everywhere.
+    In PHP-DI 5, definitions could be nested in some places (e.g. use a get() in an object definition, etc.). However it did not behave everywhere the same, for example it didn't work for sub-definitions in arrays.
+    Now in PHP-DI 6 all nested definitions will all be recognized and resolved correctly everywhere. Since #494 (compiled container) performance will not be affected so we can implement a more robust behavior.
 - [#343](https://github.com/PHP-DI/PHP-DI/issues/343) Autowiring and Annotations do not work for `object()` inside arrays: it now works with the new `create()` and `autowire()` helpers
 
 BC breaks:

--- a/src/DI/Definition/Resolver/EnvironmentVariableResolver.php
+++ b/src/DI/Definition/Resolver/EnvironmentVariableResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Definition\Resolver;
 
+use DI\Definition\ArrayDefinition;
 use DI\Definition\Definition;
 use DI\Definition\EnvironmentVariableDefinition;
 use DI\Definition\Exception\InvalidDefinition;
@@ -58,7 +59,14 @@ class EnvironmentVariableResolver implements DefinitionResolver
 
         // Nested definition
         if ($value instanceof DefinitionHelper) {
-            return $this->definitionResolver->resolve($value->getDefinition(''));
+            // As per ObjectCreator::injectProperty, use '' for an anonymous sub-definition
+            $value = $value->getDefinition('');
+        } elseif (is_array($value)) {
+            // Cast arrays into array definitions to allow resolution of nested definitions
+            $value = new ArrayDefinition('', $value);
+        }
+        if ($value instanceof Definition) {
+            return $this->definitionResolver->resolve($value);
         }
 
         return $value;

--- a/src/DI/Definition/Resolver/FactoryResolver.php
+++ b/src/DI/Definition/Resolver/FactoryResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Definition\Resolver;
 
+use DI\Definition\ArrayDefinition;
 use DI\Definition\Definition;
 use DI\Definition\Exception\InvalidDefinition;
 use DI\Definition\FactoryDefinition;
@@ -115,6 +116,9 @@ class FactoryResolver implements DefinitionResolver
             if ($value instanceof DefinitionHelper) {
                 // As per ObjectCreator::injectProperty, use '' for an anonymous sub-definition
                 $value = $value->getDefinition('');
+            } elseif (is_array($value)) {
+                // Cast arrays into array definitions to allow resolution of nested definitions
+                $value = new ArrayDefinition('', $value);
             }
             if (!$value instanceof Definition) {
                 $resolved[$key] = $value;

--- a/src/DI/Definition/Resolver/ObjectCreator.php
+++ b/src/DI/Definition/Resolver/ObjectCreator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Definition\Resolver;
 
+use DI\Definition\ArrayDefinition;
 use DI\Definition\Definition;
 use DI\Definition\Exception\InvalidDefinition;
 use DI\Definition\Helper\DefinitionHelper;
@@ -194,11 +195,14 @@ class ObjectCreator implements DefinitionResolver
         $value = $propertyInjection->getValue();
 
         if ($value instanceof DefinitionHelper) {
-            /** @var Definition $nestedDefinition */
-            $nestedDefinition = $value->getDefinition('');
-
+            $value = $value->getDefinition('');
+        } elseif (is_array($value)) {
+            // Cast arrays into array definitions to allow resolution of nested definitions
+            $value = new ArrayDefinition('', $value);
+        }
+        if ($value instanceof Definition) {
             try {
-                $value = $this->definitionResolver->resolve($nestedDefinition);
+                $value = $this->definitionResolver->resolve($value);
             } catch (DependencyException $e) {
                 throw $e;
             } catch (Exception $e) {

--- a/src/DI/Definition/Resolver/ParameterResolver.php
+++ b/src/DI/Definition/Resolver/ParameterResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DI\Definition\Resolver;
 
+use DI\Definition\ArrayDefinition;
+use DI\Definition\Definition;
 use DI\Definition\Exception\InvalidDefinition;
 use DI\Definition\Helper\DefinitionHelper;
 use DI\Definition\ObjectDefinition\MethodInjection;
@@ -70,13 +72,17 @@ class ParameterResolver
             }
 
             if ($value instanceof DefinitionHelper) {
-                $nestedDefinition = $value->getDefinition('');
-
+                $value = $value->getDefinition('');
+            } elseif (is_array($value)) {
+                // Cast arrays into array definitions to allow resolution of nested definitions
+                $value = new ArrayDefinition('', $value);
+            }
+            if ($value instanceof Definition) {
                 // If the container cannot produce the entry, we can use the default parameter value
-                if ($parameter->isOptional() && ! $this->definitionResolver->isResolvable($nestedDefinition)) {
+                if ($parameter->isOptional() && ! $this->definitionResolver->isResolvable($value)) {
                     $value = $this->getParameterDefaultValue($parameter, $method);
                 } else {
-                    $value = $this->definitionResolver->resolve($nestedDefinition);
+                    $value = $this->definitionResolver->resolve($value);
                 }
             }
 

--- a/tests/IntegrationTest/CompiledContainerTest.php
+++ b/tests/IntegrationTest/CompiledContainerTest.php
@@ -129,26 +129,6 @@ class CompiledContainerTest extends BaseContainerTest
 
     /**
      * @test
-     * @expectedException \DI\Definition\Exception\InvalidDefinition
-     * @expectedExceptionMessage Entry "stdClass" cannot be compiled: An object was found but objects cannot be compiled
-     */
-    public function object_nested_in_array_in_other_definitions_cannot_be_compiled()
-    {
-        $builder = new ContainerBuilder;
-        $builder->addDefinitions([
-            \stdClass::class => create()
-                ->property('foo', [
-                    [
-                        new \stdClass,
-                    ],
-                ]),
-        ]);
-        $builder->compile(self::generateCompilationFileName());
-        $builder->build();
-    }
-
-    /**
-     * @test
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The file in which to compile the container must have a name that is a valid class name: foo-bar is not a valid PHP class name
      */

--- a/tests/IntegrationTest/Definitions/AutowireDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/AutowireDefinitionTest.php
@@ -230,20 +230,6 @@ class AutowireDefinitionTest extends BaseContainerTest
         self::assertEquals('bar', $object->bar);
         self::assertTrue($object->isProxyInitialized());
     }
-
-    /**
-     * @dataProvider provideContainer
-     */
-    public function test_autowire_in_array(ContainerBuilder $builder)
-    {
-        $container = $builder->addDefinitions([
-            'foo' => [
-                'bar' => autowire(Class1::class),
-            ],
-        ])->build();
-
-        self::assertInstanceOf(Class1::class, $container->get('foo')['bar']);
-    }
 }
 
 namespace DI\Test\IntegrationTest\Definitions\AutowireDefinitionTest;
@@ -317,4 +303,21 @@ class ConstructorInjection
 
 class LazyService
 {
+}
+
+class AllKindsOfInjections
+{
+    public $property;
+    public $constructorParameter;
+    public $methodParameter;
+
+    public function __construct($constructorParameter)
+    {
+        $this->constructorParameter = $constructorParameter;
+    }
+
+    public function method($methodParameter)
+    {
+        $this->methodParameter = $methodParameter;
+    }
 }


### PR DESCRIPTION
Fix #498 and #488

In PHP-DI 5, definitions could be nested in some places (e.g. use a `get()` in an object definition, etc.). However it did not behave everywhere the same, for example it didn't work for sub-definitions in arrays.

Now in PHP-DI 6 all nested definitions will all be recognized and resolved correctly everywhere. Since #494 (compiled container) performance will not be affected so we can implement a more robust behavior.