### PR TITLE
Fix #377 in 4.x branch

### DIFF
--- a/src/DI/Definition/Resolver/ClassDefinitionResolver.php
+++ b/src/DI/Definition/Resolver/ClassDefinitionResolver.php
@@ -143,7 +143,7 @@ class ClassDefinitionResolver implements DefinitionResolver
         /** @noinspection PhpUnusedParameterInspection */
         $proxy = $this->proxyFactory->createProxy(
             $definition->getClassName(),
-            function (& $wrappedObject, $proxy, $method, $parameters, & $initializer) use ($resolver, $definition, $parameters) {
+            function (& $wrappedObject, $proxy, $method, $params, & $initializer) use ($resolver, $definition, $parameters) {
                 $wrappedObject = $resolver->createInstance($definition, $parameters);
                 $initializer = null; // turning off further lazy initialization
                 return true;


### PR DESCRIPTION
It looks like the fix for #377, specifically 6c7bea58ea1fecb6c6a839d4ffc6631c90880544, [was intended to be included](https://github.com/PHP-DI/PHP-DI/compare/4.4.8...4.4.9#diff-4cf511cb0042f3783162a77a4b08dca9R116) in php-di/php-di 4.4.9. However, that release was [mis-tagged against master](https://github.com/PHP-DI/PHP-DI/releases/tag/4.4.9); 4.4.10 was [used to address that](https://github.com/PHP-DI/PHP-DI/releases/tag/4.4.10), but [does not include](https://github.com/PHP-DI/PHP-DI/commits/4.4.10) 6c7bea58ea1fecb6c6a839d4ffc6631c90880544. This is corroborated by inspecting [this line](https://github.com/PHP-DI/PHP-DI/blob/4.4.10/src/DI/Definition/Resolver/ClassDefinitionResolver.php#L146).

Please merge this fix to the 4.x branch and tag it as 4.4.11. This will allow the 4.x branch to work under PHP 7.1. While I would like to use php-di/php-di 5 or 6 in my project, mnapoli/silly#40 is currently preventing me from doing so. Thanks in advance.