### PR TITLE
Compile factories, including closures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "psr/container": "^1.0",
         "php-di/invoker": "^2.0",
         "php-di/phpdoc-reader": "^2.0.1",
-        "roave/better-reflection": "^1.2",
+        "jeremeamia/superclosure": "^2.0",
         "nikic/php-parser": "^2.0|^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "php": ">=7.0.0",
         "psr/container": "^1.0",
         "php-di/invoker": "^2.0",
-        "php-di/phpdoc-reader": "^2.0.1"
+        "php-di/phpdoc-reader": "^2.0.1",
+        "roave/better-reflection": "^1.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7",
@@ -44,5 +45,10 @@
     "suggest": {
         "doctrine/annotations": "Install it if you want to use annotations (version ~1.2)",
         "ocramius/proxy-manager": "Install it if you want to use lazy injection (version ~2.0)"
+    },
+    "config": {
+        "platform": {
+            "php": "7.0"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "psr/container": "^1.0",
         "php-di/invoker": "^2.0",
         "php-di/phpdoc-reader": "^2.0.1",
-        "roave/better-reflection": "^1.2.0"
+        "roave/better-reflection": "^1.2",
+        "nikic/php-parser": "^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7",

--- a/composer.json
+++ b/composer.json
@@ -45,10 +45,5 @@
     "suggest": {
         "doctrine/annotations": "Install it if you want to use annotations (version ~1.2)",
         "ocramius/proxy-manager": "Install it if you want to use lazy injection (version ~2.0)"
-    },
-    "config": {
-        "platform": {
-            "php": "7.0"
-        }
     }
 }

--- a/doc/performances.md
+++ b/doc/performances.md
@@ -82,11 +82,17 @@ Currently PHP-DI does not traverse directories to find autowired or annotated cl
 
 Please note that the following definitions are not compiled (yet):
 
-- [factory definitions](php-definitions.md#factories)
 - [decorator definitions](php-definitions.md#decoration)
 - [wildcard definitions](php-definitions.md#wildcards)
 
 Those definitions will still work perfectly, they will simply not get a performance boost when using a compiled container.
+
+On the other hand factory definitions (either defined with closures or with class factories) are supported in the compiled container. However please note that if you are using closures as factories:
+
+- you should not use `$this` inside closures
+- you should not import variables inside the closure using the `use` keyword, like in `function () use ($foo) { ...`
+
+These limitations exist because the code of each closure is copied into the compiled container. It is safe to say that you should probably not do these things even if you do not compile the container.
 
 ### How it works
 

--- a/doc/php-definitions.md
+++ b/doc/php-definitions.md
@@ -99,7 +99,7 @@ However **this is not recommended** as that object will be created *for every PH
 
 ### Factories
 
-Factories are **PHP callables** that return the instance. They allow to define objects *lazily*, i.e. they will be created only when actually used.
+Factories are **PHP callables** that return the instance. They allow to define objects *lazily*, i.e. each object will be created only when actually needed.
 
 Here is an example using a closure:
 
@@ -197,7 +197,7 @@ Please note:
 
 - `factory([FooFactory::class, 'build'])`: if `build()` is a **static** method then the object will not be created: `FooFactory::build()` will be called statically (as one would expect)
 - you can set any container entry name in the array, e.g. `DI\factory(['foo_bar_baz', 'build'])` (or alternatively: `DI\factory('foo_bar_baz::build')`), allowing you to configure `foo_bar_baz` and its dependencies like any other object
-- as a factory can be any PHP callable, you can use invokable objects, too: `DI\factory(InvocableFooFactory::class)` (or alternatively: `DI\factory('invocable_foo_factory')`, if it's defined in the container)
+- as a factory can be any PHP callable, you can use invokable objects, too: `DI\factory(InvokableFooFactory::class)` (or alternatively: `DI\factory('invokable_foo_factory')`, if it's defined in the container)
 
 #### Retrieving the name of the requested entry
 

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -154,8 +154,8 @@ PHP;
                 $value = $definition->getCallable();
 
                 // Custom error message to help debugging
-                $isInvokableClassName = is_string($value) && class_exists($value) && method_exists($value, '__invoke');
-                if ($isInvokableClassName && !$this->autowiringEnabled) {
+                $isInvokableClass = is_string($value) && class_exists($value) && method_exists($value, '__invoke');
+                if ($isInvokableClass && !$this->autowiringEnabled) {
                     throw new InvalidDefinition(sprintf(
                         'Entry "%s" cannot be compiled. Invokable classes cannot be automatically resolved if autowiring is disabled on the container, you need to enable autowiring or define the entry manually.',
                         $entryName

--- a/src/Compiler/RequestedEntryHolder.php
+++ b/src/Compiler/RequestedEntryHolder.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Compiler;
+
+use DI\Factory\RequestedEntry;
+
+/**
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ */
+class RequestedEntryHolder implements RequestedEntry
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName() : string
+    {
+        return $this->name;
+    }
+}

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -144,8 +144,12 @@ class ContainerBuilder
         $containerClass = $this->containerClass;
 
         if ($this->compileToFile) {
-            $autowiringEnabled = $this->useAutowiring || $this->useAnnotations;
-            $containerClass = (new Compiler)->compile($source, $this->compileToFile, $autowiringEnabled);
+            $containerClass = (new Compiler)->compile(
+                $source,
+                $this->compileToFile,
+                $this->useAutowiring || $this->useAnnotations
+            );
+
             // Only load the file if it hasn't been already loaded
             // (the container can be created multiple times in the same process)
             if (!class_exists($containerClass, false)) {

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -144,7 +144,8 @@ class ContainerBuilder
         $containerClass = $this->containerClass;
 
         if ($this->compileToFile) {
-            $containerClass = (new Compiler)->compile($source, $this->compileToFile);
+            $autowiringEnabled = $this->useAutowiring || $this->useAnnotations;
+            $containerClass = (new Compiler)->compile($source, $this->compileToFile, $autowiringEnabled);
             // Only load the file if it hasn't been already loaded
             // (the container can be created multiple times in the same process)
             if (!class_exists($containerClass, false)) {

--- a/tests/IntegrationTest/CompiledContainerTest.php
+++ b/tests/IntegrationTest/CompiledContainerTest.php
@@ -6,7 +6,6 @@ namespace DI\Test\IntegrationTest;
 
 use DI\ContainerBuilder;
 use function DI\create;
-use function DI\factory;
 
 /**
  * Tests specific to the compiled container.
@@ -67,24 +66,6 @@ class CompiledContainerTest extends BaseContainerTest
         $builder = new ContainerBuilder;
         $builder->addDefinitions([
             'foo' => create($class),
-        ]);
-        $builder->compile(self::generateCompilationFileName());
-        $builder->build();
-    }
-
-    /**
-     * @test
-     * @expectedException \DI\Definition\Exception\InvalidDefinition
-     * @expectedExceptionMessage Entry "stdClass" cannot be compiled: A factory definition was found but factories cannot be compiled
-     */
-    public function factories_nested_in_other_definitions_cannot_be_compiled()
-    {
-        $builder = new ContainerBuilder;
-        $builder->addDefinitions([
-            \stdClass::class => create()
-                ->property('foo', factory(function () {
-                    return 'hello';
-                })),
         ]);
         $builder->compile(self::generateCompilationFileName());
         $builder->build();
@@ -155,4 +136,11 @@ class CompiledContainerTest extends BaseContainerTest
 
         $container->set('foo', create(ContainerSetTest\Dummy::class));
     }
+}
+
+namespace DI\Test\IntegrationTest\CompiledContainerTest;
+
+class Property
+{
+    public $foo;
 }

--- a/tests/IntegrationTest/Definitions/FactoryDefinition/config.inc
+++ b/tests/IntegrationTest/Definitions/FactoryDefinition/config.inc
@@ -1,0 +1,7 @@
+<?php
+
+// This is a separated file so that StyleCI doesn't detect it as PHP and doesn't try to reformat it
+
+return [
+    'factory' => function () { return 'foo'; }, 'factory2' => function () { return 'bar'; },
+];

--- a/tests/IntegrationTest/Definitions/NestedDefinitionsTest.php
+++ b/tests/IntegrationTest/Definitions/NestedDefinitionsTest.php
@@ -25,12 +25,16 @@ class NestedDefinitionsTest extends BaseContainerTest
             'link' => \DI\env('PHP_DI_DO_NOT_DEFINE_THIS', \DI\get('foo')),
             'object' => \DI\env('PHP_DI_DO_NOT_DEFINE_THIS', \DI\create('stdClass')),
             'objectInArray' => \DI\env('PHP_DI_DO_NOT_DEFINE_THIS', [\DI\create('stdClass')]),
+            'factory' => \DI\env('PHP_DI_DO_NOT_DEFINE_THIS', \DI\factory(function () {
+                return 'hello';
+            })),
         ]);
         $container = $builder->build();
 
         $this->assertEquals('bar', $container->get('link'));
         $this->assertEquals(new \stdClass, $container->get('object'));
         $this->assertEquals([new \stdClass], $container->get('objectInArray'));
+        $this->assertEquals('hello', $container->get('factory'));
     }
 
     /**
@@ -60,7 +64,9 @@ class NestedDefinitionsTest extends BaseContainerTest
             AllKindsOfInjections::class => create()
                 ->constructor(create('stdClass'))
                 ->property('property', create('stdClass'))
-                ->method('method', create('stdClass')),
+                ->method('method', \DI\factory(function () {
+                    return new \stdClass;
+                })),
         ]);
         $container = $builder->build();
 
@@ -86,7 +92,9 @@ class NestedDefinitionsTest extends BaseContainerTest
                     create('stdClass'),
                 ])
                 ->method('method', [
-                    create('stdClass'),
+                    \DI\factory(function () {
+                        return new \stdClass;
+                    }),
                 ]),
         ]);
         $container = $builder->build();
@@ -108,7 +116,9 @@ class NestedDefinitionsTest extends BaseContainerTest
             AllKindsOfInjections::class => autowire()
                 ->constructorParameter('constructorParameter', create('stdClass'))
                 ->property('property', create('stdClass'))
-                ->methodParameter('method', 'methodParameter', create('stdClass')),
+                ->methodParameter('method', 'methodParameter', \DI\factory(function () {
+                    return new \stdClass;
+                })),
         ]);
         $container = $builder->build();
 
@@ -134,7 +144,9 @@ class NestedDefinitionsTest extends BaseContainerTest
                     create('stdClass'),
                 ])
                 ->methodParameter('method', 'methodParameter', [
-                    create('stdClass'),
+                    \DI\factory(function () {
+                        return new \stdClass;
+                    }),
                 ]),
         ]);
         $container = $builder->build();
@@ -163,6 +175,9 @@ class NestedDefinitionsTest extends BaseContainerTest
                 'array' => [
                     'object' => create('stdClass'),
                 ],
+                'factory' => \DI\factory(function () {
+                    return 'hello';
+                }),
             ],
         ]);
 
@@ -177,6 +192,7 @@ class NestedDefinitionsTest extends BaseContainerTest
             'array' => [
                 'object' => new \stdClass,
             ],
+            'factory' => 'hello',
         ];
 
         $this->assertEquals($expected, $container->get('array'));

--- a/tests/PerformanceTest/composer.json
+++ b/tests/PerformanceTest/composer.json
@@ -12,6 +12,7 @@
         "psr/container": "^1.0",
         "php-di/invoker": "^2.0",
         "php-di/phpdoc-reader": "^2.0.1",
-        "doctrine/annotations": "~1.2"
+        "doctrine/annotations": "~1.2",
+        "roave/better-reflection": "^1.2.0"
     }
 }

--- a/tests/PerformanceTest/factory.php
+++ b/tests/PerformanceTest/factory.php
@@ -6,8 +6,12 @@ use DI\ContainerBuilder;
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-class Foo {}
-class Bar {}
+class Foo
+{
+}
+class Bar
+{
+}
 
 $builder = new ContainerBuilder();
 $builder->useAutowiring(false);


### PR DESCRIPTION
Factory definitions are now dumped into the compiled container!

This follows #494 where all definitions but factories, decorators and wildcards were compiled. Decorators and wildcards are still not compiled.

Compiling factories means also compiling closures. That was actually much more doable than I thought, I've used [Roave/BetterReflection](https://github.com/Roave/BetterReflection) (thanks @asgrim and @ocramius!)

The main downside of the whole pull request is the number of dependencies that BetterReflection brings:

  - Installing symfony/polyfill-util (v1.4.0) Loading from cache
  - Installing symfony/polyfill-php56 (v1.4.0) Loading from cache
  - Installing nikic/php-parser (v2.1.1) Loading from cache
  - Installing jeremeamia/superclosure (2.3.0) Loading from cache
  - Installing zendframework/zend-eventmanager (3.1.0) Loading from cache
  - Installing zendframework/zend-code (3.1.0) Loading from cache
  - Installing phpdocumentor/reflection-common (1.0) Loading from cache
  - Installing phpdocumentor/type-resolver (0.2.1) Loading from cache
  - Installing phpdocumentor/reflection-docblock (2.0.5) Loading from cache
  - Installing roave/better-reflection (1.2.0) Loading from cache

Maybe we could get on with superclosure only. Or else make compiling closures optional (only compile them if BetterReflection is installed…). Also I've seen that there is a v2.0 of BetterReflection in development [but it requires 7.1](https://github.com/Roave/BetterReflection#changes-in-br-20), I have no idea for how long the v1 will be supported (e.g. will it support PHP 7.2). PHP-DI could upgrade to 7.1 at the end of this year but that's not for sure yet.

Performance improvements: -20% on the factory.php benchmark, [profile](https://blackfire.io/profiles/compare/6692ca3e-521a-49df-96c6-1bf9833c8209/graph), which is very good for a micro-benchmark IMO. I'll test all that in larger scenarios for the complete 6.0 release but it's safe to say this PR is an improvement.

There are also a lot of micro/not-so-micro optimisations possible here in the future, especially because there are a lot of parameter-guessing done at runtime (you can inject dependencies into the factories and PHP-DI figures it out with type-hints). https://github.com/PHP-DI/Invoker could be compiled in the future (optionally), and simpler scenarios (classic closures) could be much more optimized than that. Work for later! :)

Because of closures, some scenarios are explicitly not supported:

- you should not use `$this` inside closures
- you should not import variables inside the closure using the `use` keyword, like in `function () use ($foo) { ...`
- you should not define multiple closures on the same line

But those scenarios don't make sense in container factories written in array config so that's good!