### PR TITLE
Format debug dump entries

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -321,7 +321,7 @@ class Container implements ContainerInterface, FactoryInterface, \DI\InvokerInte
         }
 
         if (is_string($entry)) {
-            return sprintf('Value (\'%s\')', $entry );
+            return sprintf('Value (\'%s\')', $entry);
         }
 
         if (is_bool($entry)) {

--- a/src/Container.php
+++ b/src/Container.php
@@ -299,12 +299,36 @@ class Container implements ContainerInterface, FactoryInterface, \DI\InvokerInte
         }
 
         if (array_key_exists($name, $this->resolvedEntries)) {
-            $entry = $this->resolvedEntries[$name];
-
-            return is_object($entry) ? get_class($entry) : gettype($entry);
+            return $this->getEntryType($this->resolvedEntries[$name]);
         }
 
         throw new NotFoundException("No entry or class found for '$name'");
+    }
+
+    /**
+     * Get formatted entry type.
+     *
+     * @param mixed $entry
+     */
+    private function getEntryType($entry): string
+    {
+        if (is_object($entry)) {
+            return sprintf("Object (\n    class = %s\n)", get_class($entry));
+        }
+
+        if (is_array($entry)) {
+            return preg_replace(['/^array \(/', '/\)$/'], ['[', ']'], var_export($entry, true));
+        }
+
+        if (is_string($entry)) {
+            return sprintf('Value (\'%s\')', $entry );
+        }
+
+        if (is_bool($entry)) {
+            return sprintf('Value (%s)', $entry === true ? 'true' : 'false');
+        }
+
+        return sprintf('Value (%s)', is_scalar($entry) ? $entry : ucfirst(gettype($entry)));
     }
 
     /**

--- a/tests/IntegrationTest/ContainerDebugTest.php
+++ b/tests/IntegrationTest/ContainerDebugTest.php
@@ -109,7 +109,7 @@ class ContainerDebugTest extends BaseContainerTest
         $this->assertEquals('Value (100)', $container->debugEntry('entry_int'));
         $this->assertEquals('Value (false)', $container->debugEntry('entry_bool'));
         $this->assertEquals("Value ('string')", $container->debugEntry('entry_str'));
-        $this->assertEquals("Value (NULL)", $container->debugEntry('entry_null'));
+        $this->assertEquals('Value (NULL)', $container->debugEntry('entry_null'));
         $this->assertEquals('Value (Resource)', $container->debugEntry('entry_resource'));
         $this->assertEquals('Factory', $container->debugEntry('entry_callback'));
     }

--- a/tests/IntegrationTest/ContainerDebugTest.php
+++ b/tests/IntegrationTest/ContainerDebugTest.php
@@ -38,27 +38,42 @@ class ContainerDebugTest extends BaseContainerTest
         $builder = new ContainerBuilder();
 
         $builder->addDefinitions([
-            'value' => \DI\value('foo'),
             'create' => \DI\create(Container::class),
             'autowire' => \DI\autowire(Container::class),
             'factory' => \DI\factory(function () {
                 return true;
             }),
+            'callback' => function () {
+                return true;
+            },
             'decorator' => \DI\decorate(function () {
                 return true;
             }),
             'alias' => \DI\get('value'),
             'environment' => \DI\env('foo'),
-            'array' => \DI\add(['foo']),
+            'array' => \DI\add(['foo', 'bar']),
             'string' => \DI\string('foo'),
+            'float' => \DI\value(1.5),
+            'bool' => \DI\value(true),
+            'str' => \DI\value('string'),
+            'null' => \DI\value(null),
         ]);
 
         /** @var \DI\Container $container */
         $container = $builder->build();
 
-        $container->set('entry', 'value');
-        $container->set('object', new \stdClass());
+        $container->set('entry_object', new \stdClass());
+        $container->set('entry_array', ['foo', 'bar']);
+        $container->set('entry_int', 100);
+        $container->set('entry_bool', false);
+        $container->set('entry_str', 'string');
+        $container->set('entry_null', null);
+        $container->set('entry_resource', fopen(__FILE__, 'rb'));
+        $container->set('entry_callback', function () {
+            return true;
+        });
 
+        // Default definitions
         $this->assertRegExp('/^Object \(\n {4}class = DI\\\Container\n/', $container->debugEntry('DI\Container'));
         $this->assertRegExp(
             '/^Object \(\n {4}class = #NOT INSTANTIABLE# DI\\\FactoryInterface\n/',
@@ -73,17 +88,29 @@ class ContainerDebugTest extends BaseContainerTest
             $container->debugEntry('Psr\Container\ContainerInterface')
         );
 
-        $this->assertEquals("Value ('foo')", $container->debugEntry('value'));
+        // Container definitions
         $this->assertRegExp('/^Object \(\n {4}class = DI\\\Container\n/', $container->debugEntry('create'));
         $this->assertRegExp('/^Object \(\n {4}class = DI\\\Container\n/', $container->debugEntry('autowire'));
         $this->assertEquals('Factory', $container->debugEntry('factory'));
+        $this->assertEquals('Factory', $container->debugEntry('callback'));
         $this->assertEquals('Decorate(decorator)', $container->debugEntry('decorator'));
         $this->assertEquals('get(value)', $container->debugEntry('alias'));
         $this->assertRegExp('/^Environment variable \(\n {4}variable = foo\n/', $container->debugEntry('environment'));
-        $this->assertEquals("[\n    0 => 'foo',\n]", $container->debugEntry('array'));
+        $this->assertEquals("[\n    0 => 'foo',\n    1 => 'bar',\n]", $container->debugEntry('array'));
         $this->assertEquals('foo', $container->debugEntry('string'));
+        $this->assertEquals('Value (1.5)', $container->debugEntry('float'));
+        $this->assertEquals('Value (true)', $container->debugEntry('bool'));
+        $this->assertEquals("Value ('string')", $container->debugEntry('str'));
+        $this->assertEquals('Value (NULL)', $container->debugEntry('null'));
 
-        $this->assertEquals('string', $container->debugEntry('entry'));
-        $this->assertEquals('stdClass', $container->debugEntry('object'));
+        // Container entries
+        $this->assertEquals("Object (\n    class = stdClass\n)", $container->debugEntry('entry_object'));
+        $this->assertEquals("[\n    0 => 'foo',\n    1 => 'bar',\n]", $container->debugEntry('array'));
+        $this->assertEquals('Value (100)', $container->debugEntry('entry_int'));
+        $this->assertEquals('Value (false)', $container->debugEntry('entry_bool'));
+        $this->assertEquals("Value ('string')", $container->debugEntry('entry_str'));
+        $this->assertEquals("Value (NULL)", $container->debugEntry('entry_null'));
+        $this->assertEquals('Value (Resource)', $container->debugEntry('entry_resource'));
+        $this->assertEquals('Factory', $container->debugEntry('entry_callback'));
     }
 }


### PR DESCRIPTION
While definition's debug dump is well formatted, container entries debug dump is quite not that useful by just showing the type

I've tried to match entries format to definition formats as close as possible. This PR still needs a review to see if more types needs to be added or better formatting can be achieved, but you can get the idea