### PR TITLE
Fix #522: Compile does not work on Windows

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -107,7 +107,7 @@ class Compiler
     private function compileDefinition(string $entryName, Definition $definition) : string
     {
         // Generate a unique method name
-        $methodName = uniqid('get');
+        $methodName = str_replace('.', '', uniqid('get', true));
         $this->entryToMethodMapping[$entryName] = $methodName;
 
         switch (true) {


### PR DESCRIPTION
The uniqid('get') function may generate duplicates on Windows
Then add more_entropy parameter