### PR TITLE
Fix handling of PHP 7 Throwables during resolving

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -351,10 +351,8 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
         // Resolve the definition
         try {
             $value = $this->definitionResolver->resolve($definition, $parameters);
-        } catch (Exception $exception) {
+        } finally {
             unset($this->entriesBeingResolved[$entryName]);
-
-            throw $exception;
         }
 
         unset($this->entriesBeingResolved[$entryName]);


### PR DESCRIPTION
In PHP 7, it is possible to throw something that doesn't inherit the Exception class. The most common example is that type-checking now causes a TypeError to be thrown. PHP-DI did not catch this type of error, and leaves the entry dangling as "being resolved". If the service is requested again after this happens, a "Circular dependency detected while trying to resolve entry" exception is thrown by Container even though there is no circular dependency.

The solution uses a finally block instead of catch(Exception) to ensure all possible Throwables are handled properly. This also removes the need to re-throw the exception.

Minimal test case for this behavior:

```
class Foo
{
  public function __construct(bool $foo)
  {
  }
}
$builder = new DI\ContainerBuilder();
$builder->addDefinitions([
  Foo::class => DI\factory(function() {
    return new Foo(""); // Cause a TypeError to be thrown
  });
]);
$container = $builder->build();
try {
  $container->get(Foo::class);
} catch (Throwable $e) {
  // TypeError was caught by us but not Container
}
$container->get(Foo::class); // This will cause a circular dependency exception
```
