### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/tests/IntegrationTest/FunctionsTest.php
+++ b/tests/IntegrationTest/FunctionsTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace DI\Test\IntegrationTest;
 
-class FunctionsTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class FunctionsTest extends TestCase
 {
     /**
      * @test

--- a/tests/UnitTest/Annotation/InjectTest.php
+++ b/tests/UnitTest/Annotation/InjectTest.php
@@ -10,6 +10,7 @@ use DI\Test\UnitTest\Annotation\Fixtures\InjectFixture;
 use DI\Test\UnitTest\Annotation\Fixtures\MixedAnnotationsFixture;
 use DI\Test\UnitTest\Annotation\Fixtures\NonImportedInjectFixture;
 use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 /**
@@ -17,7 +18,7 @@ use ReflectionClass;
  *
  * @covers \DI\Annotation\Inject
  */
-class InjectTest extends \PHPUnit_Framework_TestCase
+class InjectTest extends TestCase
 {
     /**
      * @var DoctrineAnnotationReader

--- a/tests/UnitTest/Annotation/InjectableTest.php
+++ b/tests/UnitTest/Annotation/InjectableTest.php
@@ -9,6 +9,7 @@ use DI\Definition\Source\AnnotationBasedAutowiring;
 use DI\Test\UnitTest\Annotation\Fixtures\Injectable1;
 use DI\Test\UnitTest\Annotation\Fixtures\Injectable2;
 use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 /**
@@ -16,7 +17,7 @@ use ReflectionClass;
  *
  * @covers \DI\Annotation\Injectable
  */
-class InjectableTest extends \PHPUnit_Framework_TestCase
+class InjectableTest extends TestCase
 {
     /**
      * @var DoctrineAnnotationReader

--- a/tests/UnitTest/ContainerBuilderTest.php
+++ b/tests/UnitTest/ContainerBuilderTest.php
@@ -12,12 +12,13 @@ use DI\Definition\ValueDefinition;
 use DI\Test\IntegrationTest\BaseContainerTest;
 use DI\Test\UnitTest\Fixtures\FakeContainer;
 use EasyMock\EasyMock;
+use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
 /**
  * @covers \DI\ContainerBuilder
  */
-class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
+class ContainerBuilderTest extends TestCase
 {
     use EasyMock;
 

--- a/tests/UnitTest/ContainerGetTest.php
+++ b/tests/UnitTest/ContainerGetTest.php
@@ -6,6 +6,7 @@ namespace DI\Test\UnitTest;
 
 use DI\ContainerBuilder;
 use DI\Test\UnitTest\Fixtures\PassByReferenceDependency;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
@@ -13,7 +14,7 @@ use stdClass;
  *
  * @covers \DI\Container
  */
-class ContainerGetTest extends \PHPUnit_Framework_TestCase
+class ContainerGetTest extends TestCase
 {
     public function testSetGet()
     {

--- a/tests/UnitTest/ContainerTest.php
+++ b/tests/UnitTest/ContainerTest.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace DI\Test\UnitTest;
 
 use DI\Container;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for DI\Container.
  */
-class ContainerTest extends \PHPUnit_Framework_TestCase
+class ContainerTest extends TestCase
 {
     /**
      * @test

--- a/tests/UnitTest/Definition/ArrayDefinitionExtensionTest.php
+++ b/tests/UnitTest/Definition/ArrayDefinitionExtensionTest.php
@@ -7,11 +7,12 @@ namespace DI\Test\UnitTest\Definition;
 use DI\Definition\ArrayDefinition;
 use DI\Definition\ArrayDefinitionExtension;
 use DI\Definition\ValueDefinition;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Definition\ArrayDefinitionExtension
  */
-class ArrayDefinitionExtensionTest extends \PHPUnit_Framework_TestCase
+class ArrayDefinitionExtensionTest extends TestCase
 {
     /**
      * @test

--- a/tests/UnitTest/Definition/ArrayDefinitionTest.php
+++ b/tests/UnitTest/Definition/ArrayDefinitionTest.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace DI\Test\UnitTest\Definition;
 
 use DI\Definition\ArrayDefinition;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Definition\ArrayDefinition
  */
-class ArrayDefinitionTest extends \PHPUnit_Framework_TestCase
+class ArrayDefinitionTest extends TestCase
 {
     /**
      * @test

--- a/tests/UnitTest/Definition/DecoratorDefinitionTest.php
+++ b/tests/UnitTest/Definition/DecoratorDefinitionTest.php
@@ -7,11 +7,12 @@ namespace DI\Test\UnitTest\Definition;
 use DI\Definition\DecoratorDefinition;
 use DI\Definition\ExtendsPreviousDefinition;
 use DI\Definition\ValueDefinition;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Definition\DecoratorDefinition
  */
-class DecoratorDefinitionTest extends \PHPUnit_Framework_TestCase
+class DecoratorDefinitionTest extends TestCase
 {
     public function test_getters()
     {

--- a/tests/UnitTest/Definition/Dumper/ObjectDefinitionDumperTest.php
+++ b/tests/UnitTest/Definition/Dumper/ObjectDefinitionDumperTest.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace DI\Test\UnitTest\Definition\Dumper;
 
 use DI\Definition\Dumper\ObjectDefinitionDumper;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Definition\Dumper\ObjectDefinitionDumper
  */
-class ObjectDefinitionDumperTest extends \PHPUnit_Framework_TestCase
+class ObjectDefinitionDumperTest extends TestCase
 {
     public function testAll()
     {

--- a/tests/UnitTest/Definition/EnvironmentVariableDefinitionTest.php
+++ b/tests/UnitTest/Definition/EnvironmentVariableDefinitionTest.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace DI\Test\UnitTest\Definition;
 
 use DI\Definition\EnvironmentVariableDefinition;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Definition\EnvironmentVariableDefinition
  */
-class EnvironmentVariableDefinitionTest extends \PHPUnit_Framework_TestCase
+class EnvironmentVariableDefinitionTest extends TestCase
 {
     public function test_getters()
     {

--- a/tests/UnitTest/Definition/FactoryDefinitionTest.php
+++ b/tests/UnitTest/Definition/FactoryDefinitionTest.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace DI\Test\UnitTest\Definition;
 
 use DI\Definition\FactoryDefinition;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Definition\FactoryDefinition
  */
-class FactoryDefinitionTest extends \PHPUnit_Framework_TestCase
+class FactoryDefinitionTest extends TestCase
 {
     public function test_getters()
     {

--- a/tests/UnitTest/Definition/Helper/AutowireDefinitionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/AutowireDefinitionHelperTest.php
@@ -8,11 +8,12 @@ use DI\Definition\Exception\InvalidDefinition;
 use DI\Definition\Helper\AutowireDefinitionHelper;
 use DI\Definition\ObjectDefinition\MethodInjection;
 use DI\Test\UnitTest\Definition\Helper\Fixtures\Class1;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Definition\Helper\AutowireDefinitionHelper
  */
-class AutowireDefinitionHelperTest extends \PHPUnit_Framework_TestCase
+class AutowireDefinitionHelperTest extends TestCase
 {
     /**
      * @test

--- a/tests/UnitTest/Definition/Helper/CreateDefinitionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/CreateDefinitionHelperTest.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace DI\Test\UnitTest\Definition\Helper;
 
 use DI\Definition\Helper\CreateDefinitionHelper;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Definition\Helper\CreateDefinitionHelper
  */
-class CreateDefinitionHelperTest extends \PHPUnit_Framework_TestCase
+class CreateDefinitionHelperTest extends TestCase
 {
     /**
      * @test

--- a/tests/UnitTest/Definition/Helper/FactoryDefinitionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/FactoryDefinitionHelperTest.php
@@ -7,11 +7,12 @@ namespace DI\Test\UnitTest\Definition\Helper;
 use DI\Definition\DecoratorDefinition;
 use DI\Definition\FactoryDefinition;
 use DI\Definition\Helper\FactoryDefinitionHelper;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Definition\Helper\FactoryDefinitionHelper
  */
-class FactoryDefinitionHelperTest extends \PHPUnit_Framework_TestCase
+class FactoryDefinitionHelperTest extends TestCase
 {
     /**
      * @test

--- a/tests/UnitTest/Definition/InstanceDefinitionTest.php
+++ b/tests/UnitTest/Definition/InstanceDefinitionTest.php
@@ -7,11 +7,12 @@ namespace DI\Test\UnitTest\Definition;
 use DI\Definition\InstanceDefinition;
 use DI\Definition\ObjectDefinition;
 use EasyMock\EasyMock;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Definition\InstanceDefinition
  */
-class InstanceDefinitionTest extends \PHPUnit_Framework_TestCase
+class InstanceDefinitionTest extends TestCase
 {
     use EasyMock;
 

--- a/tests/UnitTest/Definition/ObjectDefinition/MethodInjectionTest.php
+++ b/tests/UnitTest/Definition/ObjectDefinition/MethodInjectionTest.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace DI\Test\UnitTest\Definition\ObjectDefinition;
 
 use DI\Definition\ObjectDefinition\MethodInjection;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Definition\ObjectDefinition\MethodInjection
  */
-class MethodInjectionTest extends \PHPUnit_Framework_TestCase
+class MethodInjectionTest extends TestCase
 {
     public function testBasicMethods()
     {

--- a/tests/UnitTest/Definition/ObjectDefinition/PropertyInjectionTest.php
+++ b/tests/UnitTest/Definition/ObjectDefinition/PropertyInjectionTest.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace DI\Test\UnitTest\Definition\ObjectDefinition;
 
 use DI\Definition\ObjectDefinition\PropertyInjection;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Definition\ObjectDefinition\PropertyInjection
  */
-class PropertyInjectionTest extends \PHPUnit_Framework_TestCase
+class PropertyInjectionTest extends TestCase
 {
     public function testGetters()
     {

--- a/tests/UnitTest/Definition/ObjectDefinitionTest.php
+++ b/tests/UnitTest/Definition/ObjectDefinitionTest.php
@@ -8,11 +8,12 @@ use DI\Definition\ObjectDefinition;
 use DI\Definition\ObjectDefinition\MethodInjection;
 use DI\Definition\ObjectDefinition\PropertyInjection;
 use DI\Test\UnitTest\Definition\Fixture\NonInstantiableClass;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Definition\ObjectDefinition
  */
-class ObjectDefinitionTest extends \PHPUnit_Framework_TestCase
+class ObjectDefinitionTest extends TestCase
 {
     public function test_getters_setters()
     {

--- a/tests/UnitTest/Definition/ReferenceTest.php
+++ b/tests/UnitTest/Definition/ReferenceTest.php
@@ -6,12 +6,13 @@ namespace DI\Test\UnitTest\Definition;
 
 use DI\Definition\Reference;
 use EasyMock\EasyMock;
+use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
 /**
  * @covers \DI\Definition\Reference
  */
-class ReferenceTest extends \PHPUnit_Framework_TestCase
+class ReferenceTest extends TestCase
 {
     use EasyMock;
 

--- a/tests/UnitTest/Definition/Resolver/ArrayResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/ArrayResolverTest.php
@@ -10,12 +10,13 @@ use DI\Definition\ObjectDefinition;
 use DI\Definition\Resolver\ArrayResolver;
 use DI\Definition\Resolver\DefinitionResolver;
 use EasyMock\EasyMock;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 
 /**
  * @covers \DI\Definition\Resolver\ArrayResolver
  */
-class ArrayResolverTest extends \PHPUnit_Framework_TestCase
+class ArrayResolverTest extends TestCase
 {
     use EasyMock;
 

--- a/tests/UnitTest/Definition/Resolver/DecoratorResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/DecoratorResolverTest.php
@@ -9,13 +9,14 @@ use DI\Definition\Resolver\DecoratorResolver;
 use DI\Definition\Resolver\DefinitionResolver;
 use DI\Definition\ValueDefinition;
 use EasyMock\EasyMock;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 use Psr\Container\ContainerInterface;
 
 /**
  * @covers \DI\Definition\Resolver\DecoratorResolver
  */
-class DecoratorResolverTest extends \PHPUnit_Framework_TestCase
+class DecoratorResolverTest extends TestCase
 {
     use EasyMock;
 

--- a/tests/UnitTest/Definition/Resolver/EnvironmentVariableResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/EnvironmentVariableResolverTest.php
@@ -9,12 +9,13 @@ use DI\Definition\EnvironmentVariableDefinition;
 use DI\Definition\Resolver\DefinitionResolver;
 use DI\Definition\Resolver\EnvironmentVariableResolver;
 use EasyMock\EasyMock;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 
 /**
  * @covers \DI\Definition\Resolver\EnvironmentVariableResolver
  */
-class EnvironmentVariableResolverTest extends \PHPUnit_Framework_TestCase
+class EnvironmentVariableResolverTest extends TestCase
 {
     use EasyMock;
 

--- a/tests/UnitTest/Definition/Resolver/FactoryParameterResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/FactoryParameterResolverTest.php
@@ -9,12 +9,13 @@ use DI\Factory\RequestedEntry;
 use DI\Invoker\FactoryParameterResolver;
 use DI\Test\UnitTest\Definition\Resolver\Fixture\NoConstructor;
 use EasyMock\EasyMock;
+use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
 /**
  * @covers \DI\Invoker\FactoryParameterResolver
  */
-class FactoryParameterResolverTest extends \PHPUnit_Framework_TestCase
+class FactoryParameterResolverTest extends TestCase
 {
     use EasyMock;
 

--- a/tests/UnitTest/Definition/Resolver/FactoryResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/FactoryResolverTest.php
@@ -12,12 +12,13 @@ use DI\NotFoundException;
 use DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureClass;
 use DI\Test\UnitTest\Definition\Resolver\Fixture\NoConstructor;
 use EasyMock\EasyMock;
+use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
 /**
  * @covers \DI\Definition\Resolver\FactoryResolver
  */
-class FactoryResolverTest extends \PHPUnit_Framework_TestCase
+class FactoryResolverTest extends TestCase
 {
     use EasyMock;
 

--- a/tests/UnitTest/Definition/Resolver/InstanceInjectorTest.php
+++ b/tests/UnitTest/Definition/Resolver/InstanceInjectorTest.php
@@ -13,11 +13,12 @@ use DI\Definition\Resolver\ResolverDispatcher;
 use DI\Proxy\ProxyFactory;
 use DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureClass;
 use EasyMock\EasyMock;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Definition\Resolver\InstanceInjector
  */
-class InstanceInjectorTest extends \PHPUnit_Framework_TestCase
+class InstanceInjectorTest extends TestCase
 {
     use EasyMock;
 

--- a/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
+++ b/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
@@ -16,13 +16,14 @@ use DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureClass;
 use DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureInterface;
 use DI\Test\UnitTest\Definition\Resolver\Fixture\NoConstructor;
 use EasyMock\EasyMock;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 
 /**
  * @covers \DI\Definition\Resolver\ObjectCreator
  * @covers \DI\Definition\Resolver\ParameterResolver
  */
-class ObjectCreatorTest extends \PHPUnit_Framework_TestCase
+class ObjectCreatorTest extends TestCase
 {
     use EasyMock;
 

--- a/tests/UnitTest/Definition/Resolver/ResolverDispatcherTest.php
+++ b/tests/UnitTest/Definition/Resolver/ResolverDispatcherTest.php
@@ -10,12 +10,13 @@ use DI\Definition\StringDefinition;
 use DI\Definition\ValueDefinition;
 use DI\Proxy\ProxyFactory;
 use EasyMock\EasyMock;
+use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
 /**
  * @covers \DI\Definition\Resolver\ResolverDispatcher
  */
-class ResolverDispatcherTest extends \PHPUnit_Framework_TestCase
+class ResolverDispatcherTest extends TestCase
 {
     use EasyMock;
 

--- a/tests/UnitTest/Definition/Source/AnnotationBasedAutowiringTest.php
+++ b/tests/UnitTest/Definition/Source/AnnotationBasedAutowiringTest.php
@@ -17,11 +17,12 @@ use DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixture4;
 use DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixture5;
 use DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixtureChild;
 use DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationInjectableFixture;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Definition\Source\AnnotationBasedAutowiring
  */
-class AnnotationBasedAutowiringTest extends \PHPUnit_Framework_TestCase
+class AnnotationBasedAutowiringTest extends TestCase
 {
     public function testUnknownClass()
     {

--- a/tests/UnitTest/Definition/Source/DefinitionArrayTest.php
+++ b/tests/UnitTest/Definition/Source/DefinitionArrayTest.php
@@ -10,11 +10,12 @@ use DI\Definition\FactoryDefinition;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\Source\DefinitionArray;
 use DI\Definition\ValueDefinition;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Definition\Source\DefinitionArray
  */
-class DefinitionArrayTest extends \PHPUnit_Framework_TestCase
+class DefinitionArrayTest extends TestCase
 {
     public function testEntryNotFound()
     {

--- a/tests/UnitTest/Definition/Source/DefinitionFileTest.php
+++ b/tests/UnitTest/Definition/Source/DefinitionFileTest.php
@@ -7,11 +7,12 @@ namespace DI\Test\UnitTest\Definition\Source;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\Source\DefinitionFile;
 use DI\Definition\ValueDefinition;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Definition\Source\DefinitionFile
  */
-class DefinitionFileTest extends \PHPUnit_Framework_TestCase
+class DefinitionFileTest extends TestCase
 {
     /**
      * @test

--- a/tests/UnitTest/Definition/Source/ReflectionBasedAutowiringTest.php
+++ b/tests/UnitTest/Definition/Source/ReflectionBasedAutowiringTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DI\Test\UnitTest\Definition\Source;
 
 use DI\Definition\Reference;
+use PHPUnit\Framework\TestCase;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\ObjectDefinition\MethodInjection;
 use DI\Definition\Source\ReflectionBasedAutowiring;
@@ -14,7 +15,7 @@ use DI\Test\UnitTest\Definition\Source\Fixtures\AutowiringFixtureChild;
 /**
  * @covers \DI\Definition\Source\ReflectionBasedAutowiring
  */
-class ReflectionBasedAutowiringTest extends \PHPUnit_Framework_TestCase
+class ReflectionBasedAutowiringTest extends TestCase
 {
     public function testUnknownClass()
     {

--- a/tests/UnitTest/Definition/Source/SourceChainTest.php
+++ b/tests/UnitTest/Definition/Source/SourceChainTest.php
@@ -8,11 +8,12 @@ use DI\Definition\Definition;
 use DI\Definition\Source\DefinitionArray;
 use DI\Definition\Source\SourceChain;
 use DI\Definition\ValueDefinition;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Definition\Source\SourceChain
  */
-class SourceChainTest extends \PHPUnit_Framework_TestCase
+class SourceChainTest extends TestCase
 {
     /**
      * @test

--- a/tests/UnitTest/Definition/StringDefinitionTest.php
+++ b/tests/UnitTest/Definition/StringDefinitionTest.php
@@ -7,12 +7,13 @@ namespace DI\Test\UnitTest\Definition;
 use DI\Definition\StringDefinition;
 use DI\NotFoundException;
 use EasyMock\EasyMock;
+use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
 /**
  * @covers \DI\Definition\StringDefinition
  */
-class StringDefinitionTest extends \PHPUnit_Framework_TestCase
+class StringDefinitionTest extends TestCase
 {
     use EasyMock;
 

--- a/tests/UnitTest/Definition/ValueDefinitionTest.php
+++ b/tests/UnitTest/Definition/ValueDefinitionTest.php
@@ -6,12 +6,13 @@ namespace DI\Test\UnitTest\Definition;
 
 use DI\Definition\ValueDefinition;
 use EasyMock\EasyMock;
+use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
 /**
  * @covers \DI\Definition\ValueDefinition
  */
-class ValueDefinitionTest extends \PHPUnit_Framework_TestCase
+class ValueDefinitionTest extends TestCase
 {
     use EasyMock;
 

--- a/tests/UnitTest/FunctionsTest.php
+++ b/tests/UnitTest/FunctionsTest.php
@@ -16,11 +16,12 @@ use DI\Definition\Helper\FactoryDefinitionHelper;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\StringDefinition;
 use DI\Definition\ValueDefinition;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the helper functions.
  */
-class FunctionsTest extends \PHPUnit_Framework_TestCase
+class FunctionsTest extends TestCase
 {
     /**
      * @covers ::\DI\value

--- a/tests/UnitTest/Proxy/ProxyFactoryTest.php
+++ b/tests/UnitTest/Proxy/ProxyFactoryTest.php
@@ -6,11 +6,12 @@ namespace DI\Test\UnitTest\Proxy;
 
 use DI\Proxy\ProxyFactory;
 use DI\Test\UnitTest\Proxy\Fixtures\ClassToProxy;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DI\Proxy\ProxyFactory
  */
-class ProxyFactoryTest extends \PHPUnit_Framework_TestCase
+class ProxyFactoryTest extends TestCase
 {
     /**
      * @test


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

As we support `PHP 7`, we are able to update to `PHPUnit 6`. But, there are some dev dependencies, like `mnapoli/phpunit-easymock` that don't allow us. Should we refactor then as well?