### PR TITLE
Apply #533 into master

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -53,6 +53,13 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
     private $definitionResolver;
 
     /**
+     * Map of definitions that are already fetched / looked up.
+     *
+     * @var array
+     */
+    private $fetchedDefinitions = [];
+
+    /**
      * Array of entries being resolved. Used to avoid circular dependencies and infinite loops.
      * @var array
      */
@@ -122,7 +129,7 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
             return $this->resolvedEntries[$name];
         }
 
-        $definition = $this->definitionSource->getDefinition($name);
+        $definition = $this->getDefinition($name);
         if (! $definition) {
             throw new NotFoundException("No entry or class found for '$name'");
         }
@@ -132,6 +139,15 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
         $this->resolvedEntries[$name] = $value;
 
         return $value;
+    }
+
+    private function getDefinition($name)
+    {
+        if(!array_key_exists($name, $this->fetchedDefinitions)){
+            $this->fetchedDefinitions[$name] = $this->definitionSource->getDefinition($name);
+        }
+
+        return $this->fetchedDefinitions[$name];
     }
 
     /**
@@ -161,7 +177,7 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
             ));
         }
 
-        $definition = $this->definitionSource->getDefinition($name);
+        $definition = $this->getDefinition($name);
         if (! $definition) {
             // If the entry is already resolved we return it
             if (array_key_exists($name, $this->resolvedEntries)) {
@@ -195,7 +211,7 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
             return true;
         }
 
-        $definition = $this->definitionSource->getDefinition($name);
+        $definition = $this->getDefinition($name);
         if ($definition === null) {
             return false;
         }

--- a/src/Container.php
+++ b/src/Container.php
@@ -379,6 +379,9 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
         if (array_key_exists($name, $this->resolvedEntries)) {
             unset($this->resolvedEntries[$name]);
         }
+        if (array_key_exists($name, $this->fetchedDefinitions)) {
+            unset($this->fetchedDefinitions[$name]);
+        }
 
         $this->definitionSource->addDefinition($definition);
     }

--- a/src/Container.php
+++ b/src/Container.php
@@ -53,11 +53,11 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
     private $definitionResolver;
 
     /**
-     * Map of definitions that are already fetched / looked up.
+     * Map of definitions that are already looked up.
      *
      * @var array
      */
-    private $fetchedDefinitions = [];
+    private $definitionCache = [];
 
     /**
      * Array of entries being resolved. Used to avoid circular dependencies and infinite loops.
@@ -143,11 +143,11 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
 
     private function getDefinition($name)
     {
-        if(!array_key_exists($name, $this->fetchedDefinitions)){
-            $this->fetchedDefinitions[$name] = $this->definitionSource->getDefinition($name);
+        if(!array_key_exists($name, $this->definitionCache)){
+            $this->definitionCache[$name] = $this->definitionSource->getDefinition($name);
         }
 
-        return $this->fetchedDefinitions[$name];
+        return $this->definitionCache[$name];
     }
 
     /**
@@ -379,8 +379,8 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
         if (array_key_exists($name, $this->resolvedEntries)) {
             unset($this->resolvedEntries[$name]);
         }
-        if (array_key_exists($name, $this->fetchedDefinitions)) {
-            unset($this->fetchedDefinitions[$name]);
+        if (array_key_exists($name, $this->definitionCache)) {
+            unset($this->definitionCache[$name]);
         }
 
         $this->definitionSource->addDefinition($definition);

--- a/src/Container.php
+++ b/src/Container.php
@@ -143,7 +143,7 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
 
     private function getDefinition($name)
     {
-        if(!array_key_exists($name, $this->definitionCache)){
+        if (!array_key_exists($name, $this->definitionCache)) {
             $this->definitionCache[$name] = $this->definitionSource->getDefinition($name);
         }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -379,9 +379,7 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
         if (array_key_exists($name, $this->resolvedEntries)) {
             unset($this->resolvedEntries[$name]);
         }
-        if (array_key_exists($name, $this->definitionCache)) {
-            unset($this->definitionCache[$name]);
-        }
+        $this->definitionCache = []; //Completely clear definitionCache
 
         $this->definitionSource->addDefinition($definition);
     }


### PR DESCRIPTION
See #533 

The "definition cache" (not the same as the old definition cache of v5, this is just a simple in-memory cache) can be useful in v6 when using `make()` (does not use the compiled code) or when using wildcard definitions (not compiled yet). Let's take advantage of these performance improvements.

Thanks @holtkamp 