### PR TITLE
Update to PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
         "nikic/php-parser": "^2.0|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7",
-        "mnapoli/phpunit-easymock": "~0.2.3",
+        "phpunit/phpunit": "~6.4",
+        "mnapoli/phpunit-easymock": "~1.0",
         "doctrine/annotations": "~1.2",
         "ocramius/proxy-manager": "~2.0.2",
         "friendsofphp/php-cs-fixer": "^2.4"

--- a/tests/UnitTest/Definition/Helper/AutowireDefinitionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/AutowireDefinitionHelperTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DI\Test\UnitTest\Definition\Helper;
 
-use DI\Definition\Exception\InvalidDefinition;
 use DI\Definition\Helper\AutowireDefinitionHelper;
 use DI\Definition\ObjectDefinition\MethodInjection;
 use DI\Test\UnitTest\Definition\Helper\Fixtures\Class1;
@@ -175,6 +174,10 @@ class AutowireDefinitionHelperTest extends TestCase
         $this->assertEquals([42], $definition->getConstructorInjection()->getParameters());
     }
 
+    /**
+     * @expectedException \DI\Definition\Exception\InvalidDefinition
+     * @expectedExceptionMessage Parameter with name 'wrongName' could not be found
+     */
     public function test_error_message_on_unknown_parameter()
     {
         if (defined('HHVM_VERSION')) {
@@ -182,7 +185,6 @@ class AutowireDefinitionHelperTest extends TestCase
         }
         $helper = new AutowireDefinitionHelper();
         $helper->methodParameter('__construct', 'wrongName', 42);
-        $this->setExpectedException(InvalidDefinition::class, "Parameter with name 'wrongName' could not be found");
         $helper->getDefinition(Class1::class);
     }
 }

--- a/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
+++ b/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DI\Test\UnitTest\Definition\Resolver;
 
-use DI\Definition\Exception\InvalidDefinition;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\ObjectDefinition\MethodInjection;
 use DI\Definition\ObjectDefinition\PropertyInjection;
@@ -181,6 +180,9 @@ class ObjectCreatorTest extends TestCase
         $this->assertEquals('defaultValue', $object->methodParam2);
     }
 
+    /**
+     * @expectedException \DI\Definition\Exception\InvalidDefinition
+     */
     public function testUnknownClass()
     {
         $message = <<<'MESSAGE'
@@ -191,13 +193,16 @@ Object (
     lazy = false
 )
 MESSAGE;
-        $this->setExpectedException(InvalidDefinition::class, $message);
+        $this->expectExceptionMessage($message);
 
         $definition = new ObjectDefinition('foo', 'bar');
 
         $this->resolver->resolve($definition);
     }
 
+    /**
+     * @expectedException \DI\Definition\Exception\InvalidDefinition
+     */
     public function testNotInstantiable()
     {
         $message = <<<'MESSAGE'
@@ -208,13 +213,16 @@ Object (
     lazy = false
 )
 MESSAGE;
-        $this->setExpectedException(InvalidDefinition::class, $message);
+        $this->expectExceptionMessage($message);
 
         $definition = new ObjectDefinition('ArrayAccess');
 
         $this->resolver->resolve($definition);
     }
 
+    /**
+     * @expectedException \DI\Definition\Exception\InvalidDefinition
+     */
     public function testUndefinedInjection()
     {
         $message = <<<'MESSAGE'
@@ -225,7 +233,7 @@ Object (
     lazy = false
 )
 MESSAGE;
-        $this->setExpectedException(InvalidDefinition::class, $message);
+        $this->expectExceptionMessage($message);
 
         $definition = new ObjectDefinition(FixtureClass::class);
 


### PR DESCRIPTION
As we are support `PHP 7`, and the `mnapoli/phpunit-easymock` updated, now we can update our suite of tests to [`PHPUnit 6`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#600---2017-02-03). I used [this article](https://thephp.cc/news/2017/02/migrating-to-phpunit-6) from @sebastianbergmann to help me in this upgrade.