### PR TITLE
Use assertNull

### DIFF
--- a/tests/IntegrationTest/Definitions/AutowireDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/AutowireDefinitionTest.php
@@ -177,7 +177,7 @@ class AutowireDefinitionTest extends BaseContainerTest
         ])->build();
 
         $foo = $container->get('foo');
-        self::assertEquals(null, $foo->bar, 'The "bar" property is not set');
+        self::assertNull($foo->bar, 'The "bar" property is not set');
         self::assertEquals(456, $foo->bim, 'The "bim" property is set');
     }
 

--- a/tests/IntegrationTest/Definitions/CreateDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/CreateDefinitionTest.php
@@ -162,7 +162,7 @@ class CreateDefinitionTest extends BaseContainerTest
         $container = $builder->build();
 
         $foo = $container->get('foo');
-        self::assertEquals(null, $foo->bar, 'The "bar" property is not set');
+        self::assertNull($foo->bar, 'The "bar" property is not set');
         self::assertEquals(456, $foo->bim, 'The "bim" property is set');
     }
 
@@ -267,7 +267,7 @@ class CreateDefinitionTest extends BaseContainerTest
         $object = $container->get(PrivatePropertyInjectionSubClass::class);
 
         // For now it's not possible to define private properties in parent classes using array config
-        self::assertEquals(null, $object->getPrivate());
+        self::assertNull($object->getPrivate());
         self::assertEquals('overloaded', $object->getProtected());
         self::assertEquals('child', $object->getSubClassPrivate());
     }

--- a/tests/UnitTest/FunctionsTest.php
+++ b/tests/UnitTest/FunctionsTest.php
@@ -152,7 +152,7 @@ class FunctionsTest extends TestCase
         $this->assertTrue($definition instanceof EnvironmentVariableDefinition);
         $this->assertEquals('foo', $definition->getVariableName());
         $this->assertTrue($definition->isOptional());
-        $this->assertSame(null, $definition->getDefaultValue());
+        $this->assertNull($definition->getDefaultValue());
     }
 
     /**


### PR DESCRIPTION
I've refactored some tests using the [`assertNull`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertNull) method.