### PR TITLE
Restore a definition cache for autowiring and Container::make() performances

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -6,10 +6,10 @@ This is the complete change log. You can also read the [migration guide](doc/mig
 
 Improvements:
 
+- [#494](https://github.com/PHP-DI/PHP-DI/pull/494) The container can now be compiled for optimum performances in production
 - [#294](https://github.com/PHP-DI/PHP-DI/issues/294), [#349](https://github.com/PHP-DI/PHP-DI/issues/349), [#449](https://github.com/PHP-DI/PHP-DI/pull/449): `DI\object()` has been replaced by more specific and less ambiguous helpers:
     - `DI\create()` creates an object, overrides autowiring and previous definitions
     - `DI\autowire()` autowires an object and allows to override specific constructor and method parameters
-- [#494](https://github.com/PHP-DI/PHP-DI/pull/494) The container can now be compiled for optimum performances in production
 - The container can now be built without parameters: `new Container()`
 - Definitions can be nested:
     - [#490](https://github.com/PHP-DI/PHP-DI/issues/490) Definitions can be nested in arrays (by [@yuloh](https://github.com/yuloh))
@@ -17,6 +17,7 @@ Improvements:
     - [#487](https://github.com/PHP-DI/PHP-DI/issues/487) & [#540](https://github.com/PHP-DI/PHP-DI/issues/540) Closures are now handled as factories when they are nested in other definitions
 - [#242](https://github.com/PHP-DI/PHP-DI/issues/242) Error in case a definition is not indexed by a string
 - [#505](https://github.com/PHP-DI/PHP-DI/pull/505) Debug container entries
+- Caching was made almost entirely obsolete by the container compilation, however there is still a caching system entirely rebuilt over APCu for covering the last cases that compilation could not address (see [php-di.org/doc/performances.html](http://php-di.org/doc/performances.html))
 
 Fixes:
 
@@ -30,6 +31,7 @@ BC breaks:
 - PHP 7 or greater is required and HHVM is no longer supported
 - `DI\object()` has been removed, use `DI\create()` or `DI\autowire()` instead
 - [#409](https://github.com/PHP-DI/PHP-DI/issues/409): Scopes are removed, read more in the [scopes](doc/scopes.md) documentation.
+- Caching was replaced by compiling the container: `ContainerBuilder::setDefinitionCache()` was removed, use `ContainerBuilder::enableCompilation()` instead.
 - [#463](https://github.com/PHP-DI/PHP-DI/issues/463) & [#485](https://github.com/PHP-DI/PHP-DI/issues/485): Container-interop support was removed, PSR-11 is used instead (by [@juliangut](https://github.com/juliangut))
 - The deprecated `DI\link()` helper was removed, used `DI\get()` instead
 - [#484](https://github.com/PHP-DI/PHP-DI/pull/484) The deprecated `\DI\Debug` class has been removed. Definitions can be cast to string directly

--- a/change-log.md
+++ b/change-log.md
@@ -17,7 +17,7 @@ Improvements:
     - [#487](https://github.com/PHP-DI/PHP-DI/issues/487) & [#540](https://github.com/PHP-DI/PHP-DI/issues/540) Closures are now handled as factories when they are nested in other definitions
 - [#242](https://github.com/PHP-DI/PHP-DI/issues/242) Error in case a definition is not indexed by a string
 - [#505](https://github.com/PHP-DI/PHP-DI/pull/505) Debug container entries
-- Caching was made almost entirely obsolete by the container compilation, however there is still a caching system entirely rebuilt over APCu for covering the last cases that compilation could not address (see [php-di.org/doc/performances.html](http://php-di.org/doc/performances.html))
+- [#564](https://github.com/PHP-DI/PHP-DI/pull/564) Caching was made almost entirely obsolete by the container compilation, however there is still a caching system entirely rebuilt over APCu for covering the last cases that compilation could not address (see [php-di.org/doc/performances.html](http://php-di.org/doc/performances.html))
 
 Fixes:
 

--- a/doc/migration/6.0.md
+++ b/doc/migration/6.0.md
@@ -80,9 +80,9 @@ Read more details and alternatives in the [scopes](../scopes.md) documentation.
 
 ## Caching
 
-Caching has been removed completely in favor of the much faster alternative: compiling the container (see the section about compiling the container).
+Caching has been almost entirely removed in favor of a much faster alternative: compiling the container (see the section about compiling the container below).
 
-As such, the `ContainerBuilder::setDefinitionCache()` method was removed. In your code you can remove that line (and maybe compile the container instead).
+As such, the `ContainerBuilder::setDefinitionCache()` method was removed. In your code you can remove that line (and compile the container instead). Read the ["performances" guide](../performances.md) for more information.
 
 ## Compiling the container
 

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace DI;
 
 use DI\Definition\Source\AnnotationBasedAutowiring;
-use DI\Definition\Source\SourceCache;
 use DI\Definition\Source\DefinitionArray;
 use DI\Definition\Source\DefinitionFile;
 use DI\Definition\Source\DefinitionSource;
 use DI\Definition\Source\NoAutowiring;
 use DI\Definition\Source\ReflectionBasedAutowiring;
+use DI\Definition\Source\SourceCache;
 use DI\Definition\Source\SourceChain;
 use DI\Proxy\ProxyFactory;
 use InvalidArgumentException;

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DI;
 
 use DI\Definition\Source\AnnotationBasedAutowiring;
+use DI\Definition\Source\SourceCache;
 use DI\Definition\Source\DefinitionArray;
 use DI\Definition\Source\DefinitionFile;
 use DI\Definition\Source\DefinitionSource;
@@ -94,6 +95,11 @@ class ContainerBuilder
     private $compileToDirectory;
 
     /**
+     * @var bool
+     */
+    private $sourceCache = false;
+
+    /**
      * Build a container configured for the dev environment.
      */
     public static function buildDevContainer() : Container
@@ -142,6 +148,14 @@ class ContainerBuilder
 
         // Mutable definition source
         $source->setMutableDefinitionSource(new DefinitionArray([], $autowiring));
+
+        if ($this->sourceCache) {
+            if (!SourceCache::isSupported()) {
+                throw new \Exception('APCu is not enabled, PHP-DI cannot use it as a cache');
+            }
+            // Wrap the source with the cache decorator
+            $source = new SourceCache($source);
+        }
 
         $proxyFactory = new ProxyFactory($this->writeProxiesToFile, $this->proxyDirectory);
 
@@ -309,6 +323,34 @@ class ContainerBuilder
         }
 
         $this->definitionSources[] = $definitions;
+
+        return $this;
+    }
+
+    /**
+     * Enables the use of APCu to cache definitions.
+     *
+     * You must have APCu enabled to use it.
+     *
+     * Before using this feature, you should try these steps first:
+     * - enable compilation if not already done (see `enableCompilation()`)
+     * - if you use autowiring or annotations, add all the classes you are using into your configuration so that
+     *   PHP-DI knows about them and compiles them
+     * Once this is done, you can try to optimize performances further with APCu. It can also be useful if you use
+     * `Container::make()` instead of `get()` (`make()` calls cannot be compiled so they are not optimized).
+     *
+     * Remember to clear APCu on each deploy else your application will have a stale cache. Do not enable the cache
+     * in development environment: any change you will make to the code will be ignored because of the cache.
+     *
+     * @see http://php-di.org/doc/performances.html
+     *
+     * @return $this
+     */
+    public function enableDefinitionCache() : ContainerBuilder
+    {
+        $this->ensureNotLocked();
+
+        $this->sourceCache = true;
 
         return $this;
     }

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -346,7 +346,7 @@ class ContainerBuilder
      *
      * @return $this
      */
-    public function enableDefinitionCache() : ContainerBuilder
+    public function enableDefinitionCache() : self
     {
         $this->ensureNotLocked();
 

--- a/src/Definition/Source/SourceCache.php
+++ b/src/Definition/Source/SourceCache.php
@@ -16,19 +16,12 @@ class SourceCache implements DefinitionSource, MutableDefinitionSource
     /**
      * @var string
      */
-    const CACHE_KEY = 'php-di.definitions';
+    const CACHE_KEY = 'php-di.definitions.';
 
     /**
      * @var DefinitionSource
      */
     private $cachedSource;
-
-    /**
-     * Definitions loaded from the cache (or null if not loaded yet).
-     *
-     * @var Definition[]|null
-     */
-    private $cachedDefinitions;
 
     public function __construct(DefinitionSource $cachedSource)
     {
@@ -37,20 +30,14 @@ class SourceCache implements DefinitionSource, MutableDefinitionSource
 
     public function getDefinition(string $name)
     {
-        if ($this->cachedDefinitions === null) {
-            $this->cachedDefinitions = apcu_fetch(self::CACHE_KEY) ?: [];
-        }
-
-        // Look in cache
-        $definition = $this->cachedDefinitions[$name] ?? false;
+        $definition = apcu_fetch(self::CACHE_KEY . $name);
 
         if ($definition === false) {
             $definition = $this->cachedSource->getDefinition($name);
 
             // Update the cache
             if ($this->shouldBeCached($definition)) {
-                $this->cachedDefinitions[$name] = $definition;
-                apcu_store(self::CACHE_KEY, $this->cachedDefinitions);
+                apcu_store(self::CACHE_KEY . $name, $definition);
             }
         }
 

--- a/src/Definition/Source/SourceCache.php
+++ b/src/Definition/Source/SourceCache.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace DI\Definition\Source;
+
+use DI\Definition\AutowireDefinition;
+use DI\Definition\Definition;
+use DI\Definition\ObjectDefinition;
+
+/**
+ * Decorator that caches another definition source.
+ *
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ */
+class SourceCache implements DefinitionSource, MutableDefinitionSource
+{
+    /**
+     * @var string
+     */
+    const CACHE_KEY = 'php-di.definitions';
+
+    /**
+     * @var DefinitionSource
+     */
+    private $cachedSource;
+
+    /**
+     * Definitions loaded from the cache (or null if not loaded yet).
+     *
+     * @var Definition[]|null
+     */
+    private $cachedDefinitions;
+
+    public function __construct(DefinitionSource $cachedSource)
+    {
+        $this->cachedSource = $cachedSource;
+    }
+
+    public function getDefinition(string $name)
+    {
+        if ($this->cachedDefinitions === null) {
+            $this->cachedDefinitions = apcu_fetch(self::CACHE_KEY) ?: [];
+        }
+
+        // Look in cache
+        $definition = $this->cachedDefinitions[$name] ?? false;
+
+        if ($definition === false) {
+            $definition = $this->cachedSource->getDefinition($name);
+
+            // Update the cache
+            if ($this->shouldBeCached($definition)) {
+                $this->cachedDefinitions[$name] = $definition;
+                apcu_store(self::CACHE_KEY, $this->cachedDefinitions);
+            }
+        }
+
+        return $definition;
+    }
+
+    /**
+     * Used only for the compilation so we can skip the cache safely.
+     */
+    public function getDefinitions() : array
+    {
+        return $this->cachedSource->getDefinitions();
+    }
+
+    public static function isSupported() : bool
+    {
+        return function_exists('apcu_fetch')
+            && ini_get('apc.enabled')
+            && ! ('cli' === PHP_SAPI && ! ini_get('apc.enable_cli'));
+    }
+
+    public function addDefinition(Definition $definition)
+    {
+        throw new \LogicException('You cannot set a definition at runtime on a container that has caching enabled. Doing so would risk caching the definition for the next execution, where it might be different. You can either put your definitions in a file, remove the cache or ->set() a raw value directly (PHP object, string, int, ...) instead of a PHP-DI definition.');
+    }
+
+    private function shouldBeCached(Definition $definition = null) : bool
+    {
+        return
+            // Cache missing definitions
+            ($definition === null)
+            // Object definitions are used with `make()`
+            || ($definition instanceof ObjectDefinition)
+            // Autowired definitions cannot be all compiled and are used with `make()`
+            || ($definition instanceof AutowireDefinition)
+        ;
+    }
+}

--- a/src/Definition/Source/SourceCache.php
+++ b/src/Definition/Source/SourceCache.php
@@ -85,7 +85,6 @@ class SourceCache implements DefinitionSource, MutableDefinitionSource
             // Object definitions are used with `make()`
             || ($definition instanceof ObjectDefinition)
             // Autowired definitions cannot be all compiled and are used with `make()`
-            || ($definition instanceof AutowireDefinition)
-        ;
+            || ($definition instanceof AutowireDefinition);
     }
 }

--- a/tests/IntegrationTest/CacheTest.php
+++ b/tests/IntegrationTest/CacheTest.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace DI\Test\IntegrationTest;
+
+use DI\ContainerBuilder;
+use DI\Definition\Source\SourceCache;
+use PHPUnit\Framework\TestCase;
+
+class CacheTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        if (! SourceCache::isSupported()) {
+            $this->markTestSkipped('APCu extension is required');
+        }
+        apcu_clear_cache();
+    }
+
+    /**
+     * @test
+     */
+    public function cached_definitions_should_be_overridable()
+    {
+        $builder = new ContainerBuilder();
+        $builder->enableDefinitionCache();
+        $builder->addDefinitions([
+            'foo' => 'bar',
+        ]);
+        $container = $builder->build();
+        $this->assertEquals('bar', $container->get('foo'));
+        $container->set('foo', 'hello');
+        $this->assertEquals('hello', $container->get('foo'));
+    }
+}

--- a/tests/UnitTest/ContainerBuilderTest.php
+++ b/tests/UnitTest/ContainerBuilderTest.php
@@ -8,6 +8,7 @@ use DI\CompiledContainer;
 use DI\Container;
 use DI\ContainerBuilder;
 use DI\Definition\Source\DefinitionArray;
+use DI\Definition\Source\SourceCache;
 use DI\Definition\ValueDefinition;
 use DI\Test\IntegrationTest\BaseContainerTest;
 use DI\Test\UnitTest\Fixtures\FakeContainer;
@@ -36,6 +37,25 @@ class ContainerBuilderTest extends TestCase
         $this->assertFalse($container instanceof CompiledContainer);
         // Proxies evaluated in memory
         $this->assertFalse($this->getObjectAttribute($container->proxyFactory, 'writeProxiesToFile'));
+    }
+
+    /**
+     * @test
+     */
+    public function should_allow_to_configure_a_cache()
+    {
+        if (! SourceCache::isSupported()) {
+            $this->markTestSkipped('APCu extension is required');
+            return;
+        }
+
+        $builder = new ContainerBuilder(FakeContainer::class);
+        $builder->enableDefinitionCache();
+
+        /** @var FakeContainer $container */
+        $container = $builder->build();
+
+        $this->assertTrue($container->definitionSource instanceof SourceCache);
     }
 
     /**
@@ -193,6 +213,9 @@ class ContainerBuilderTest extends TestCase
         $this->assertSame($builder, $result);
 
         $result = $builder->enableCompilation('foo');
+        $this->assertSame($builder, $result);
+
+        $result = $builder->enableDefinitionCache();
         $this->assertSame($builder, $result);
 
         $result = $builder->wrapContainer($this->easyMock(ContainerInterface::class));

--- a/tests/UnitTest/Definition/Source/SourceCacheTest.php
+++ b/tests/UnitTest/Definition/Source/SourceCacheTest.php
@@ -19,7 +19,6 @@ class SourceCacheTest extends TestCase
         if (! SourceCache::isSupported()) {
             $this->markTestSkipped('APCu extension is required');
         }
-
         apcu_clear_cache();
     }
 

--- a/tests/UnitTest/Definition/Source/SourceCacheTest.php
+++ b/tests/UnitTest/Definition/Source/SourceCacheTest.php
@@ -8,7 +8,6 @@ use DI\Definition\Reference;
 use DI\Definition\Source\DefinitionArray;
 use DI\Definition\Source\DefinitionSource;
 use DI\Definition\Source\SourceCache;
-use EasyMock\EasyMock;
 use PHPUnit\Framework\TestCase;
 
 class SourceCacheTest extends TestCase
@@ -39,8 +38,8 @@ class SourceCacheTest extends TestCase
 
         $source = new SourceCache($wrappedSource);
 
-        self::assertSame($definition, $source->getDefinition('foo'));
-        self::assertSame($definition, $source->getDefinition('foo'));
+        self::assertEquals($definition, $source->getDefinition('foo'));
+        self::assertEquals($definition, $source->getDefinition('foo'));
     }
 
     /**
@@ -94,7 +93,7 @@ class SourceCacheTest extends TestCase
 
     private static function assertSavedInCache(string $definitionName, $expectedValue)
     {
-        $definitions = apcu_fetch(SourceCache::CACHE_KEY);
-        self::assertEquals($expectedValue, $definitions[$definitionName]);
+        $definition = apcu_fetch(SourceCache::CACHE_KEY . $definitionName);
+        self::assertEquals($expectedValue, $definition);
     }
 }

--- a/tests/UnitTest/Definition/Source/SourceCacheTest.php
+++ b/tests/UnitTest/Definition/Source/SourceCacheTest.php
@@ -1,0 +1,100 @@
+<?php
+declare(strict_types=1);
+
+namespace DI\Test\UnitTest\Definition\Source;
+
+use DI\Definition\ObjectDefinition;
+use DI\Definition\Reference;
+use DI\Definition\Source\DefinitionArray;
+use DI\Definition\Source\DefinitionSource;
+use DI\Definition\Source\SourceCache;
+use EasyMock\EasyMock;
+use PHPUnit\Framework\TestCase;
+
+class SourceCacheTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        if (! SourceCache::isSupported()) {
+            $this->markTestSkipped('APCu extension is required');
+        }
+
+        apcu_clear_cache();
+    }
+
+    /**
+     * @test
+     */
+    public function should_get_from_cache()
+    {
+        $definition = new ObjectDefinition('foo');
+
+        $wrappedSource = $this->createMock(DefinitionSource::class);
+        $wrappedSource
+            ->expects($this->once())// The sub-source should be called ONLY ONCE
+            ->method('getDefinition')
+            ->willReturn($definition);
+
+        $source = new SourceCache($wrappedSource);
+
+        self::assertSame($definition, $source->getDefinition('foo'));
+        self::assertSame($definition, $source->getDefinition('foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function should_save_to_cache_and_return()
+    {
+        $cachedSource = new DefinitionArray([
+            'foo' => \DI\create(),
+        ]);
+
+        $source = new SourceCache($cachedSource);
+
+        // Sanity check
+        self::assertSavedInCache('foo', null);
+        // Return the definition
+        self::assertEquals(new ObjectDefinition('foo'), $source->getDefinition('foo'));
+        // The definition is saved in the cache
+        self::assertSavedInCache('foo', new ObjectDefinition('foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function should_save_null_to_cache_and_return_null()
+    {
+        $source = new SourceCache(new DefinitionArray);
+
+        self::assertNull($source->getDefinition('foo'));
+        self::assertSavedInCache('foo', null);
+    }
+
+    /**
+     * @test
+     */
+    public function should_only_cache_object_and_autowire_definitions()
+    {
+        $definition = new Reference('foo');
+
+        $wrappedSource = $this->createMock(DefinitionSource::class);
+        $wrappedSource
+            ->expects($this->exactly(2))
+            ->method('getDefinition')
+            ->willReturn($definition);
+
+        $source = new SourceCache($wrappedSource);
+
+        self::assertSame($definition, $source->getDefinition('foo'));
+        self::assertSame($definition, $source->getDefinition('foo'));
+    }
+
+    private static function assertSavedInCache(string $definitionName, $expectedValue)
+    {
+        $definitions = apcu_fetch(SourceCache::CACHE_KEY);
+        self::assertEquals($expectedValue, $definitions[$definitionName]);
+    }
+}


### PR DESCRIPTION
This PR restores some kind of cache like there was in PHP-DI 4 and 5 (which was removed during v6's development). However this is not a full restore, this new cache is very simple and targeted at specific use cases.

Fixes #543 (indirectly) and related to #547 (workaround).

Compiling the container is the most efficient solution, but it has some limits. The following cases are not optimized:

- autowired (or annotated) classes that are not declared in the configuration
- wildcard definitions
- usage of `Container::make()` or `Container::injectOn()` (because those are not using the compiled code)

If you make heavy use of those features, and if it slows down your application you can enable the caching system. The cache will ensure annotations or the reflection is not read again on every request.

The cache relies on **APCu** directly because it is the only cache system that makes sense (very fast to write and read). Other caches are not good options, this is why PHP-DI does not use PSR-6 or PSR-16.

To enable the cache:

```php
$containerBuilder = new \DI\ContainerBuilder();
if (/* is production */) {
    $containerBuilder->enableDefinitionCache();
}
```

To be clear: compilation should be used first. This cache is only for specific use cases.

TODO:

- [x] Test that compiled entries are not fetched and stored into cache with `get()`
- [x] Store each definition in a separate cache entry
  