### PR TITLE
Fix #526 Support optional parameters in factories

### DIFF
--- a/src/CompiledContainer.php
+++ b/src/CompiledContainer.php
@@ -13,6 +13,7 @@ use Invoker\Exception\NotEnoughParametersException;
 use Invoker\Invoker;
 use Invoker\InvokerInterface;
 use Invoker\ParameterResolver\AssociativeArrayResolver;
+use Invoker\ParameterResolver\DefaultValueResolver;
 use Invoker\ParameterResolver\NumericArrayResolver;
 use Invoker\ParameterResolver\ResolverChain;
 
@@ -101,6 +102,7 @@ abstract class CompiledContainer extends Container
                 new AssociativeArrayResolver,
                 new FactoryParameterResolver($this->delegateContainer),
                 new NumericArrayResolver,
+                new DefaultValueResolver,
             ]);
 
             $this->factoryInvoker = new Invoker($parameterResolver, $this->delegateContainer);

--- a/src/Definition/Resolver/FactoryResolver.php
+++ b/src/Definition/Resolver/FactoryResolver.php
@@ -12,6 +12,7 @@ use Invoker\Exception\NotCallableException;
 use Invoker\Exception\NotEnoughParametersException;
 use Invoker\Invoker;
 use Invoker\ParameterResolver\AssociativeArrayResolver;
+use Invoker\ParameterResolver\DefaultValueResolver;
 use Invoker\ParameterResolver\NumericArrayResolver;
 use Invoker\ParameterResolver\ResolverChain;
 use Psr\Container\ContainerInterface;
@@ -62,9 +63,10 @@ class FactoryResolver implements DefinitionResolver
     {
         if (! $this->invoker) {
             $parameterResolver = new ResolverChain([
-               new AssociativeArrayResolver,
-               new FactoryParameterResolver($this->container),
-               new NumericArrayResolver,
+                new AssociativeArrayResolver,
+                new FactoryParameterResolver($this->container),
+                new NumericArrayResolver,
+                new DefaultValueResolver,
             ]);
 
             $this->invoker = new Invoker($parameterResolver, $this->container);

--- a/tests/IntegrationTest/Definitions/FactoryDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/FactoryDefinitionTest.php
@@ -551,6 +551,21 @@ class FactoryDefinitionTest extends BaseContainerTest
         $builder->addDefinitions(__DIR__ . '/FactoryDefinition/config.inc');
         $this->assertEquals('foo', $builder->build()->get('factory'));
     }
+
+    /**
+     * @dataProvider provideContainer
+     */
+    public function test_optional_parameters_can_be_omitted(ContainerBuilder $builder)
+    {
+        $builder->addDefinitions([
+            'factory' => function ($c, $entry, $a = 'foo') {
+                return $a;
+            },
+        ]);
+        $container = $builder->build();
+
+        self::assertEquals('foo', $container->get('factory'));
+    }
 }
 
 class FactoryDefinitionTestClass


### PR DESCRIPTION
Factories can have optional parameters. With this change PHP-DI will take the default value of those optional parameters when they are not specified.

That will avoid having to specify all the optional parameters (even though they are optional).

See #526 for more details.