### PR TITLE
Use fqn to helpers in example code

### DIFF
--- a/doc/php-definitions.md
+++ b/doc/php-definitions.md
@@ -125,7 +125,7 @@ return [
     },
     
     // Same as
-    'Foo' => factory(function (ContainerInterface $c) {
+    'Foo' => DI\factory(function (ContainerInterface $c) {
         return new Foo($c->get('db.host'));
     }),
 ];
@@ -446,8 +446,8 @@ Keep in mind that closures are equivalent to "factory" definitions. As such, **c
 
 ```php
 return [
-    'router' => create(Router::class)
-        ->method('setErrorHandler', value(function () {
+    'router' => DI\create(Router::class)
+        ->method('setErrorHandler', DI\value(function () {
             ...
         })),
 ];


### PR DESCRIPTION
Updated some examples to use the fully qualified name to the helper functions, as most examples already did.