### PR TITLE
Adds support for autowire of __construct for wildcards

### DIFF
--- a/src/Definition/Source/DefinitionArray.php
+++ b/src/Definition/Source/DefinitionArray.php
@@ -115,6 +115,7 @@ class DefinitionArray implements DefinitionSource, MutableDefinitionSource
                     $definition->setClassName(
                         $this->replaceWildcards($definition->getClassName(), $matches)
                     );
+                    $definition = $this->normalizer->normalizeRootDefinition($definition, $name);
                 }
 
                 return $definition;

--- a/tests/IntegrationTest/Definitions/WildcardDefinitionsTest.php
+++ b/tests/IntegrationTest/Definitions/WildcardDefinitionsTest.php
@@ -8,7 +8,9 @@ use DI\Annotation\Inject;
 use DI\ContainerBuilder;
 use DI\Test\IntegrationTest\BaseContainerTest;
 use DI\Test\IntegrationTest\Fixtures\Implementation1;
+use DI\Test\IntegrationTest\Fixtures\Implementation2;
 use DI\Test\IntegrationTest\Fixtures\Interface1;
+use DI\Test\IntegrationTest\Fixtures\Interface2;
 
 /**
  * Test definitions using wildcards.
@@ -35,6 +37,28 @@ class WildcardDefinitionsTest extends BaseContainerTest
         self::assertEntryIsNotCompiled($container, 'foo1');
         self::assertEntryIsNotCompiled($container, 'DI\Test\IntegrationTest\*\Interface*');
         self::assertEntryIsNotCompiled($container, Interface1::class);
+    }
+
+    /**
+     * @dataProvider provideContainer
+     */
+    public function test_wildcards_autowire(ContainerBuilder $builder)
+    {
+        $builder->addDefinitions([
+            'DI\Test\IntegrationTest\*\Interface*' => \DI\autowire('DI\Test\IntegrationTest\*\Implementation*'),
+        ]);
+        $container = $builder->build();
+
+        $object = $container->get(Interface1::class);
+        $this->assertInstanceOf(Implementation1::class, $object);
+
+        $object2 = $container->get(Interface2::class);
+        $this->assertInstanceOf(Implementation2::class, $object2);
+        $this->assertInstanceOf(Implementation1::class, $object2->dependency);
+
+        self::assertEntryIsNotCompiled($container, 'DI\Test\IntegrationTest\*\Interface*');
+        self::assertEntryIsNotCompiled($container, Interface1::class);
+        self::assertEntryIsNotCompiled($container, Interface2::class);
     }
 
     /**

--- a/tests/IntegrationTest/Fixtures/Implementation2.php
+++ b/tests/IntegrationTest/Fixtures/Implementation2.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\IntegrationTest\Fixtures;
+
+/**
+ * Fixture class.
+ */
+class Implementation2 implements Interface2
+{
+    /**
+     * @var Interface1
+     */
+    public $dependency;
+
+    public function __construct(Interface1 $dependency) {
+        $this->dependency = $dependency;
+    }
+}

--- a/tests/IntegrationTest/Fixtures/Interface2.php
+++ b/tests/IntegrationTest/Fixtures/Interface2.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\IntegrationTest\Fixtures;
+
+interface Interface2
+{
+}


### PR DESCRIPTION
In 5.x it was possible to have auto wiring of wildcard definitions via reflection, this PR enables that functionality again.

The "fix" might be a bit hacky however, as I wasn't able to find a cleaner way for ReflectionBasedAutowiring to be aware of what class to use reflection on, unless I sent the wildcard class through the normalizer a second time after the derived implementation class name was set.