### PR TITLE
Remove Container::get() InvalidArgumentException

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -118,7 +118,6 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
      *
      * @param string $name Entry name or a class name.
      *
-     * @throws InvalidArgumentException The name parameter must be of type string.
      * @throws DependencyException Error while resolving the entry.
      * @throws NotFoundException No entry found for the given name.
      * @return mixed


### PR DESCRIPTION
Long time ago there was `is_string` check of `$name`. I can't find commit that removed it.
Personally I'd rather return `is_string` check, becuase currently `array_key_exists` will emit warning if `$name` is not a string and not an int.
If you decide to return `is_string` check, than `InvalidArgumentException` should be replaced with `NotFoundException` or `DependencyException` to not break interface contract.