### PR TITLE
Set allow risky in php_cs

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -47,4 +47,5 @@ return PhpCsFixer\Config::create()
         'yoda_style' => false,
         'native_function_invocation' => false,
     ])
+    ->setRiskyAllowed(true)
     ->setFinder($finder);


### PR DESCRIPTION
Recently I needed to run `php-cs-fixer fix` and I receive the error message showing that I need to set the `--allow-risky` flag, and to solve this confusion in the future I add this flag in the `.php_cs` file