### PR TITLE
Allow PHPUnit 7.x and PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,29 +10,49 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - php: nightly
-  include:
-    - php: 7.0
-      env: dependencies=lowest
+env:
+  - COMPOSER_FLAGS="--prefer-lowest"
+  - COMPOSER_FLAGS=""
+
+stages:
+  - static code analysis
+  - test
+  - test with coverage
 
 cache:
   directories:
     - $HOME/.composer/cache
 
-before_script:
-  - if [[ $(phpenv version-name) == '7.1' ]]; then composer require satooshi/php-coveralls '~1.0' -n ; fi
-  - if [[ $(phpenv version-name) != '7.1' ]]; then composer install -n ; fi
-  - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable -n; fi;
+before_install:
+  - phpenv config-rm xdebug.ini || echo "xdebug not available"
+  - composer self-update
 
-script:
-  - if [[ $(phpenv version-name) == '7.1' ]]; then vendor/bin/phpunit --coverage-clover clover.xml ; fi
-  - if [[ $(phpenv version-name) != '7.1' ]]; then vendor/bin/phpunit ; fi
-  - if [[ $(phpenv version-name) != '7.1' ]]; then vendor/bin/phpstan analyse -l 6 -c phpstan.neon src ; fi
+install: travis_retry composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction --no-suggest $COMPOSER_FLAGS -vv
 
-after_script:
-  - if [[ $(phpenv version-name) == '7.1' ]]; then php vendor/bin/coveralls -v ; fi
+script: vendor/bin/phpunit --colors --columns 117 --no-coverage
+
+jobs:
+  allow_failures:
+    - php: 7.3
+    - php: nightly
+  include:
+    - php: nightly
+      env: COMPOSER_FLAGS="--ignore-platform-reqs"
+
+    - stage: test with coverage
+      os: linux
+      php: 7.1
+      env: COMPOSER_FLAGS=""
+      before_install: composer self-update
+      script: vendor/bin/phpunit --colors --coverage-clover=clover.xml --coverage-text
+      after_success:
+        - wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.1.0/php-coveralls.phar && php -n php-coveralls.phar --verbose --coverage_clover=clover.xml
+
+    - stage: static code analysis
+      os: linux
+      php: 7.0
+      env: COMPOSER_FLAGS=""
+      script: vendor/bin/phpstan analyse -l 6 -c phpstan.neon --no-progress src

--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,15 @@
         "nikic/php-parser": "^2.0|^3.0|^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.4",
+        "sebastian/diff": "^2.0|^3.0",
+        "phpunit/phpunit-mock-objects": "~4.0|~5.0|~6.0",
+        "phpunit/phpunit": "~6.4|~7.0",
         "mnapoli/phpunit-easymock": "~1.0",
         "doctrine/annotations": "~1.2",
-        "ocramius/proxy-manager": "~2.0.2",
+        "ocramius/package-versions": "^1.2.0",
+        "ocramius/proxy-manager": "^2.0.4",
         "friendsofphp/php-cs-fixer": "^2.4",
-        "phpstan/phpstan": "^0.9.2"
+        "phpstan/phpstan": "^0.9.2|^0.10.0"
     },
     "provide": {
         "psr/container-implementation": "^1.0"


### PR DESCRIPTION
This PR want the following:

- allow tests on PHP 7.3 on travis-ci (nightly is now 7.4-dev)
- allow tests with PHPUnit 7.x
- use the build stages on travis-ci to avoid if commands
- test against --prefer-lowest for every PHP version
- remove xdebug for builds without coverage to make them faster

I had to add some Dev-Dependencies to get the `--prefer-lowest` passing. 