### PR TITLE
WIP: Pluggable caching backends

### DIFF
--- a/src/Definition/Source/Cache/AbstractCache.php
+++ b/src/Definition/Source/Cache/AbstractCache.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace DI\Definition\Source\Cache;
+
+use DI\Definition\AutowireDefinition;
+use DI\Definition\Definition;
+use DI\Definition\ObjectDefinition;
+use DI\Definition\Source\DefinitionSource;
+use LogicException;
+
+/**
+ * The AbstractCache provides all the boilerplate logic for different cache implementations.
+ *
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ * @author Benjamin Zikarsky <benjamin.zikarsky@jaumo.com>
+ */
+abstract class AbstractCache implements Cache
+{
+    /**
+     * @var DefinitionSource
+     */
+    private $cachedSource;
+
+    /**
+     * The constructor is protected - use `static::create(..)` instead.
+     *
+     * @param DefinitionSource $cachedSource
+     */
+    protected function __construct(DefinitionSource $cachedSource)
+    {
+        $this->cachedSource = $cachedSource;
+    }
+
+    /** {@inheritdoc} */
+    public static function create(DefinitionSource $source) : Cache
+    {
+        return new static($source);
+    }
+
+    /** {@inheritdoc} */
+    public function getDefinition(string $name)
+    {
+        $definition = $this->fetch($name);
+
+        if ($definition === false) {
+            $definition = $this->cachedSource->getDefinition($name);
+
+            // Update the cache
+            if ($this->shouldBeCached($definition)) {
+                $this->store($name, $definition);
+            }
+        }
+
+        return $definition;
+    }
+
+    /**
+     * Fetch a definition from cache.
+     *
+     * Since both nulls and objects can be cached, a cache-miss is indicated by a strictly typed boolean false.
+     *
+     * @param string $name
+     * @return false|Definition|null
+     */
+    abstract protected function fetch(string $name);
+
+    /**
+     * Store a definition with given name in cache.
+     *
+     * @param string $name
+     * @param Definition $definition
+     */
+    abstract protected function store(string $name, Definition $definition);
+
+    /**
+     * Used only for the compilation so we can skip the cache safely.
+     */
+    public function getDefinitions() : array
+    {
+        return $this->cachedSource->getDefinitions();
+    }
+
+    /** {@inheritdoc} */
+    public function addDefinition(Definition $definition)
+    {
+        throw new LogicException('You cannot set a definition at runtime on a container that has caching '
+            . 'enabled. Doing so would risk caching the definition for the next execution, where it might be different. '
+            . 'You can either put your definitions in a file, remove the cache or ->set() a raw value directly (PHP '
+            . 'object, string, int, ...) instead of a PHP-DI definition.');
+    }
+
+    /**
+     * Check whether a definition should be cached.
+     *
+     * Currently it makes only sense to cache missing, object- and autowired definitions.
+     *
+     * @param Definition|null $definition
+     * @return bool
+     */
+    private function shouldBeCached(Definition $definition = null) : bool
+    {
+        return
+            // Cache missing definitions
+            ($definition === null)
+            // Object definitions are used with `make()`
+            || ($definition instanceof ObjectDefinition)
+            // Autowired definitions cannot be all compiled and are used with `make()`
+            || ($definition instanceof AutowireDefinition);
+    }
+}

--- a/src/Definition/Source/Cache/ApcuCache.php
+++ b/src/Definition/Source/Cache/ApcuCache.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace DI\Definition\Source\Cache;
+
+use DI\Definition\Definition;
+use const PHP_SAPI;
+
+/**
+ * Definition cache with uses apcu as a caching backend.
+ *
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ * @author Benjamin Zikarsky <benjamin.zikarsky@jaumo.com>
+ */
+class ApcuCache extends AbstractCache
+{
+    /**
+     * @var string
+     */
+    const CACHE_KEY = 'php-di.definitions.';
+
+    /** {@inheritdoc} */
+    protected function fetch(string $name)
+    {
+        return apcu_fetch(self::CACHE_KEY . $name);
+    }
+
+    /** {@inheritdoc} */
+    protected function store(string $name, Definition $definition)
+    {
+        apcu_store(self::CACHE_KEY . $name, $definition);
+    }
+
+    /** {@inheritdoc} */
+    public static function isSupported() : bool
+    {
+        return function_exists('apcu_fetch')
+            && ini_get('apc.enabled')
+            && ! ('cli' === PHP_SAPI && ! ini_get('apc.enable_cli'));
+    }
+}

--- a/src/Definition/Source/Cache/ArrayCache.php
+++ b/src/Definition/Source/Cache/ArrayCache.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace DI\Definition\Source\Cache;
+
+use DI\Definition\Definition;
+
+/**
+ * Definition cache with uses an in-memory array.
+ *
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ * @author Benjamin Zikarsky <benjamin.zikarsky@jaumo.com>
+ */
+class ArrayCache extends AbstractCache
+{
+    /**
+     * @var Definition[]
+     */
+    private $cache = [];
+
+    /** {@inheritdoc} */
+    protected function fetch(string $name)
+    {
+        return isset($this->cache[$name]) ?? false;
+    }
+
+    /** {@inheritdoc} */
+    protected function store(string $name, Definition $definition)
+    {
+        $this->cache[$name] = $definition;
+    }
+
+    /** {@inheritdoc} */
+    public static function isSupported() : bool
+    {
+        return true;
+    }
+}

--- a/src/Definition/Source/Cache/Cache.php
+++ b/src/Definition/Source/Cache/Cache.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DI\Definition\Source\Cache;
+
+use DI\Definition\Source\DefinitionSource;
+use DI\Definition\Source\MutableDefinitionSource;
+
+/**
+ * A definition cache can decorate another definition source to improve lookup performance.
+ *
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ * @author Benjamin Zikarsky <benjamin.zikarsky@jaumo.com>
+ */
+interface Cache extends DefinitionSource, MutableDefinitionSource
+{
+    /**
+     * Create a Cache instance which decorates the given definition source.
+     *
+     * @param DefinitionSource $source
+     * @return Cache
+     */
+    public static function create(DefinitionSource $source) : self;
+
+    /**
+     * Test that the Cache implementation is supported by the PHP runtime.
+     *
+     * This method should test for required extensions, etc.
+     *
+     * @return bool
+     */
+    public static function isSupported() : bool;
+}

--- a/src/Definition/Source/DefinitionSource.php
+++ b/src/Definition/Source/DefinitionSource.php
@@ -17,6 +17,7 @@ interface DefinitionSource
     /**
      * Returns the DI definition for the entry name.
      *
+     * @param string $name The name of the definition to get
      * @throws InvalidDefinition An invalid definition was found.
      * @return Definition|null
      */

--- a/src/Definition/Source/SourceCache.php
+++ b/src/Definition/Source/SourceCache.php
@@ -2,76 +2,20 @@
 
 namespace DI\Definition\Source;
 
-use DI\Definition\AutowireDefinition;
-use DI\Definition\Definition;
-use DI\Definition\ObjectDefinition;
+use DI\Definition\Source\Cache\ApcuCache;
 
 /**
  * Decorator that caches another definition source.
  *
+ * This class is deprecated in favour of `DI\Definition\Source\Cache\ApcuCache`.
+ *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ * @deprecated
  */
-class SourceCache implements DefinitionSource, MutableDefinitionSource
+class SourceCache extends ApcuCache
 {
-    /**
-     * @var string
-     */
-    const CACHE_KEY = 'php-di.definitions.';
-
-    /**
-     * @var DefinitionSource
-     */
-    private $cachedSource;
-
-    public function __construct(DefinitionSource $cachedSource)
+    public function __construct(DefinitionSource $source)
     {
-        $this->cachedSource = $cachedSource;
-    }
-
-    public function getDefinition(string $name)
-    {
-        $definition = apcu_fetch(self::CACHE_KEY . $name);
-
-        if ($definition === false) {
-            $definition = $this->cachedSource->getDefinition($name);
-
-            // Update the cache
-            if ($this->shouldBeCached($definition)) {
-                apcu_store(self::CACHE_KEY . $name, $definition);
-            }
-        }
-
-        return $definition;
-    }
-
-    /**
-     * Used only for the compilation so we can skip the cache safely.
-     */
-    public function getDefinitions() : array
-    {
-        return $this->cachedSource->getDefinitions();
-    }
-
-    public static function isSupported() : bool
-    {
-        return function_exists('apcu_fetch')
-            && ini_get('apc.enabled')
-            && ! ('cli' === \PHP_SAPI && ! ini_get('apc.enable_cli'));
-    }
-
-    public function addDefinition(Definition $definition)
-    {
-        throw new \LogicException('You cannot set a definition at runtime on a container that has caching enabled. Doing so would risk caching the definition for the next execution, where it might be different. You can either put your definitions in a file, remove the cache or ->set() a raw value directly (PHP object, string, int, ...) instead of a PHP-DI definition.');
-    }
-
-    private function shouldBeCached(Definition $definition = null) : bool
-    {
-        return
-            // Cache missing definitions
-            ($definition === null)
-            // Object definitions are used with `make()`
-            || ($definition instanceof ObjectDefinition)
-            // Autowired definitions cannot be all compiled and are used with `make()`
-            || ($definition instanceof AutowireDefinition);
+        parent::__construct($source);
     }
 }


### PR DESCRIPTION
# Overview 

This PR relates to #589 and refactors `SourceCache` into pluggable caching-backends while keeping backwards compatibility.

# Current state

- [x] Implemented new caching classes
- [x] Integrated new caching classes into `ContainerBuilder`
- [ ] Added unit-tests for the new classes

# Contents

## Create an explicit, new class hierarchy for definition caching  

- Establish interface `Cache\Cache` which represents any definition-cache
- Move logic from `SourceCache` to both `Cache\AbstractCache` and
  `Cache\ApcuCache`
- Deprecate `SourceCache` in favour of `Cache\ApcuCache` but still
  keep its functionality by extending the former. This is to keep
  backwards compatibility
- Create a new simple cache-backend `ArrayCache` which just caches
  lookups in memory

## Integrate new Cache backend into ContainerBuilder 

Instead of tracking the caching status with a boolean, this commit changes
`$sourceCache` to a nullable string. This allows to define different cache-
backends.

`::enableDefinitionCache(..)` not takes an optional parameter - optional to
keep backwards compatibility - with the class-name of the definition cache to
use. By default the `ApcuCache` is used which is identical to the deprecated,
original `SourceCache`

## Tests

TODO :smile: 

# Future work

1) This functionality can be used to provide adapters to more general caching-backends, such as PSR-6 or PSR-16 compatible libraries.

2) In a major release `SourceCache` can be removed.
