### PR TITLE
Alternative solution to fix #648 and keep the container idempotent

### DIFF
--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -188,9 +188,9 @@ class Compiler
                 }
                 break;
             case $definition instanceof StringDefinition:
-                $entryName = $this->compileValue($definition->getName());
+                $compiledEntryName = $this->compileValue($definition->getName());
                 $expression = $this->compileValue($definition->getExpression());
-                $code = 'return \DI\Definition\StringDefinition::resolveExpression(' . $entryName . ', ' . $expression . ', $this->delegateContainer);';
+                $code = 'return \DI\Definition\StringDefinition::resolveExpression(' . $compiledEntryName . ', ' . $expression . ', $this->delegateContainer);';
                 break;
             case $definition instanceof EnvironmentVariableDefinition:
                 $variableName = $this->compileValue($definition->getVariableName());

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -262,6 +262,10 @@ PHP;
                     ));
                 }
 
+                if($value instanceof \Closure){
+                    $methodName .= '_closure_' . \md5($this->compileClosure($value));
+                }
+
                 $definitionParameters = '';
                 if (!empty($definition->getParameters())) {
                     $definitionParameters = ', ' . $this->compileValue($definition->getParameters());

--- a/src/Compiler/ObjectCreationCompiler.php
+++ b/src/Compiler/ObjectCreationCompiler.php
@@ -134,6 +134,8 @@ class ObjectCreationCompiler
     private function compileLazyDefinition(ObjectDefinition $definition) : string
     {
         $subDefinition = clone $definition;
+        // We don't want 2 definitions with the same name in the compiled container
+        $subDefinition->setName($subDefinition->getName() . '__inner');
         $subDefinition->setLazy(false);
         $subDefinition = $this->compiler->compileValue($subDefinition);
 

--- a/src/Definition/ArrayDefinition.php
+++ b/src/Definition/ArrayDefinition.php
@@ -70,4 +70,18 @@ class ArrayDefinition implements Definition
 
         return $str . ']';
     }
+
+    public function getCompilationHash() : string
+    {
+        // Cast values to something serializable
+        $hashedValues = array_map(function ($value) {
+            if ($value instanceof Definition) {
+                return $value->getCompilationHash();
+            }
+
+            return $value;
+        }, $this->values);
+
+        return md5(serialize($hashedValues));
+    }
 }

--- a/src/Definition/ArrayDefinitionExtension.php
+++ b/src/Definition/ArrayDefinitionExtension.php
@@ -38,5 +38,23 @@ class ArrayDefinitionExtension extends ArrayDefinition implements ExtendsPreviou
         }
 
         $this->subDefinition = $definition;
+        // Replace the name of the extended definition to avoid having 2 definitions with the same name
+        $this->subDefinition->setName($this->subDefinition->getName() . '___extended');
+    }
+
+    public function setName(string $name)
+    {
+        parent::setName($name);
+        if ($this->subDefinition) {
+            // Replace the name of the extended definition to avoid having 2 definitions with the same name
+            $this->subDefinition->setName($this->subDefinition->getName() . '___extended');
+        }
+    }
+
+    public function getCompilationHash() : string
+    {
+        $subDefinitionHash = $this->subDefinition ? $this->subDefinition->getCompilationHash() : '';
+
+        return md5(__CLASS__ . parent::getCompilationHash() . $subDefinitionHash);
     }
 }

--- a/src/Definition/DecoratorDefinition.php
+++ b/src/Definition/DecoratorDefinition.php
@@ -20,6 +20,17 @@ class DecoratorDefinition extends FactoryDefinition implements Definition, Exten
     public function setExtendedDefinition(Definition $definition)
     {
         $this->decorated = $definition;
+        // Replace the name of the extended definition to avoid having 2 definitions with the same name
+        $this->decorated->setName($this->decorated->getName() . '___decorated');
+    }
+
+    public function setName(string $name)
+    {
+        parent::setName($name);
+        if ($this->decorated) {
+            // Replace the name of the extended definition to avoid having 2 definitions with the same name
+            $this->decorated->setName($this->decorated->getName() . '___decorated');
+        }
     }
 
     /**
@@ -38,5 +49,12 @@ class DecoratorDefinition extends FactoryDefinition implements Definition, Exten
     public function __toString()
     {
         return 'Decorate(' . $this->getName() . ')';
+    }
+
+    public function getCompilationHash() : string
+    {
+        $decoratedHash = $this->decorated ? $this->decorated->getCompilationHash() : '';
+
+        return md5(__CLASS__ . parent::getCompilationHash() . $decoratedHash);
     }
 }

--- a/src/Definition/Definition.php
+++ b/src/Definition/Definition.php
@@ -34,4 +34,9 @@ interface Definition extends RequestedEntry
      * Definitions can be cast to string for debugging information.
      */
     public function __toString();
+
+    /**
+     * Returns a unique hash that identifies this definition.
+     */
+    public function getCompilationHash() : string;
 }

--- a/src/Definition/EnvironmentVariableDefinition.php
+++ b/src/Definition/EnvironmentVariableDefinition.php
@@ -109,4 +109,15 @@ class EnvironmentVariableDefinition implements Definition
 
         return sprintf('Environment variable (' . PHP_EOL . '%s' . PHP_EOL . ')', $str);
     }
+
+    public function getCompilationHash() : string
+    {
+        if ($this->defaultValue instanceof Definition) {
+            $defaultValueStr = $this->defaultValue->getCompilationHash();
+        } else {
+            $defaultValueStr = serialize($this->defaultValue);
+        }
+
+        return md5(__CLASS__ . $this->variableName . $this->isOptional . $defaultValueStr);
+    }
 }

--- a/src/Definition/FactoryDefinition.php
+++ b/src/Definition/FactoryDefinition.php
@@ -78,4 +78,15 @@ class FactoryDefinition implements Definition
 
         return 'Factory' . $suffix;
     }
+
+    public function getCompilationHash() : string
+    {
+        $value = $this->factory;
+        if ($this->factory instanceof \Closure) {
+            $reflectionFunction = new \ReflectionFunction($this->factory);
+            $value = $reflectionFunction->getFileName() . ':' . $reflectionFunction->getStartLine();
+        }
+
+        return md5(serialize($value));
+    }
 }

--- a/src/Definition/FactoryDefinition.php
+++ b/src/Definition/FactoryDefinition.php
@@ -74,6 +74,8 @@ class FactoryDefinition implements Definition
 
     public function __toString()
     {
-        return 'Factory';
+        $suffix = is_array($this->getCallable()) ? md5(implode('_', $this->getCallable())) : '';
+
+        return 'Factory' .$suffix ;
     }
 }

--- a/src/Definition/FactoryDefinition.php
+++ b/src/Definition/FactoryDefinition.php
@@ -76,6 +76,6 @@ class FactoryDefinition implements Definition
     {
         $suffix = is_array($this->getCallable()) ? md5(implode('_', $this->getCallable())) : '';
 
-        return 'Factory' .$suffix ;
+        return 'Factory' . $suffix;
     }
 }

--- a/src/Definition/InstanceDefinition.php
+++ b/src/Definition/InstanceDefinition.php
@@ -66,4 +66,9 @@ class InstanceDefinition implements Definition
     {
         return 'Instance';
     }
+
+    public function getCompilationHash() : string
+    {
+        throw new \RuntimeException('Instance definitions cannot be compiled');
+    }
 }

--- a/src/Definition/ObjectDefinition.php
+++ b/src/Definition/ObjectDefinition.php
@@ -24,8 +24,8 @@ class ObjectDefinition implements Definition
     private $name;
 
     /**
-     * Class name (if null, then the class name is $name).
-     * @var string|null
+     * Class name.
+     * @var string
      */
     protected $className;
 
@@ -71,8 +71,10 @@ class ObjectDefinition implements Definition
      */
     public function __construct(string $name, string $className = null)
     {
-        $this->name = $name;
-        $this->setClassName($className);
+        if ($className !== null) {
+            $this->setClassName($className);
+        }
+        $this->setName($name);
     }
 
     public function getName() : string
@@ -83,6 +85,9 @@ class ObjectDefinition implements Definition
     public function setName(string $name)
     {
         $this->name = $name;
+        if ($this->className === null) {
+            $this->setClassName($name);
+        }
     }
 
     public function setClassName(string $className = null)
@@ -94,11 +99,7 @@ class ObjectDefinition implements Definition
 
     public function getClassName() : string
     {
-        if ($this->className !== null) {
-            return $this->className;
-        }
-
-        return $this->name;
+        return $this->className;
     }
 
     /**
@@ -262,5 +263,14 @@ class ObjectDefinition implements Definition
 
         $class = new ReflectionClass($className);
         $this->isInstantiable = $class->isInstantiable();
+    }
+
+    public function getCompilationHash() : string
+    {
+        if ($this->getName()) {
+            return md5($this->getName());
+        }
+
+        return md5($this->__toString());
     }
 }

--- a/src/Definition/ObjectDefinition/MethodInjection.php
+++ b/src/Definition/ObjectDefinition/MethodInjection.php
@@ -83,4 +83,10 @@ class MethodInjection implements Definition
     {
         return sprintf('method(%s)', $this->methodName);
     }
+
+    public function getCompilationHash() : string
+    {
+        // Method calls are not compiled as a separate entry so we don't care
+        return '';
+    }
 }

--- a/src/Definition/Reference.php
+++ b/src/Definition/Reference.php
@@ -70,4 +70,9 @@ class Reference implements Definition, SelfResolvingDefinition
             $this->targetEntryName
         );
     }
+
+    public function getCompilationHash() : string
+    {
+        return md5(__CLASS__ . $this->targetEntryName);
+    }
 }

--- a/src/Definition/Source/DefinitionNormalizer.php
+++ b/src/Definition/Source/DefinitionNormalizer.php
@@ -90,7 +90,8 @@ class DefinitionNormalizer
      */
     public function normalizeNestedDefinition($definition)
     {
-        $name = '<nested definition>';
+        // Nested definitions don't have a name
+        $name = '';
 
         if ($definition instanceof DefinitionHelper) {
             $definition = $definition->getDefinition($name);

--- a/src/Definition/StringDefinition.php
+++ b/src/Definition/StringDefinition.php
@@ -94,4 +94,9 @@ class StringDefinition implements Definition, SelfResolvingDefinition
 
         return $result;
     }
+
+    public function getCompilationHash() : string
+    {
+        return md5($this->expression);
+    }
 }

--- a/src/Definition/ValueDefinition.php
+++ b/src/Definition/ValueDefinition.php
@@ -69,4 +69,9 @@ class ValueDefinition implements Definition, SelfResolvingDefinition
     {
         return sprintf('Value (%s)', var_export($this->value, true));
     }
+
+    public function getCompilationHash() : string
+    {
+        return md5(serialize($this->value));
+    }
 }

--- a/tests/IntegrationTest/BaseContainerTest.php
+++ b/tests/IntegrationTest/BaseContainerTest.php
@@ -52,7 +52,7 @@ abstract class BaseContainerTest extends TestCase
 
     protected static function generateCompiledClassName()
     {
-        return 'Container' . uniqid();
+        return uniqid('Container', false);
     }
 
     /**

--- a/tests/IntegrationTest/BaseContainerTest.php
+++ b/tests/IntegrationTest/BaseContainerTest.php
@@ -66,7 +66,7 @@ abstract class BaseContainerTest extends TestCase
 
         /** @noinspection PhpUndefinedFieldInspection */
         $compiledEntries = $container::METHOD_MAPPING;
-        self::assertArrayHasKey($entry, $compiledEntries, "Entry $entry is not compiled");
+        self::assertArrayHasKey($entry, $compiledEntries, sprintf('Entry "%s" is not compiled, it should exist as key in associative array: %s', $entry, print_r($compiledEntries, true)));
     }
 
     /**

--- a/tests/IntegrationTest/CompiledContainerTest.php
+++ b/tests/IntegrationTest/CompiledContainerTest.php
@@ -102,18 +102,15 @@ class CompiledContainerTest extends BaseContainerTest
         $builder1->addDefinitions($definitions);
         $builder1->enableCompilation(self::COMPILATION_DIR, $compiledContainerClass1);
         $container1 = $builder1->build();
-        $this->assertInstanceOf($container1->get(CompiledContainerTest\AllKindsOfInjections::class), CompiledContainerTest\AllKindsOfInjections::class);
-        $this->assertInstanceOf($container1->get(CompiledContainerTest\Autowireable::class), CompiledContainerTest\Autowireable::class);
-        $this->assertInstanceOf($container1->get(CompiledContainerTest\Autowireable2::class), CompiledContainerTest\Autowireable2::class);
+        $this->assertInstanceOf(CompiledContainerTest\AllKindsOfInjections::class, $container1->get(CompiledContainerTest\AllKindsOfInjections::class));
+        $this->assertInstanceOf(CompiledContainerTest\Autowireable::class, $container1->get(CompiledContainerTest\Autowireable::class));
+        $this->assertInstanceOf(CompiledContainerTest\Autowireable2::class, $container1->get(CompiledContainerTest\Autowireable2::class));
 
         // Create a second compiled container with the same configuration but in a different file
         $builder2 = new ContainerBuilder;
         $builder2->addDefinitions($definitions);
         $builder2->enableCompilation(self::COMPILATION_DIR, $compiledContainerClass2);
         $container2 = $builder2->build();
-        $this->assertInstanceOf($container2->get(CompiledContainerTest\AllKindsOfInjections::class), CompiledContainerTest\AllKindsOfInjections::class);
-        $this->assertInstanceOf($container2->get(CompiledContainerTest\Autowireable::class), CompiledContainerTest\Autowireable::class);
-        $this->assertInstanceOf($container2->get(CompiledContainerTest\Autowireable2::class), CompiledContainerTest\Autowireable2::class);
 
         // The method mapping of the resulting CompiledContainers should be equal
         self::assertEquals($compiledContainerClass1::METHOD_MAPPING, $compiledContainerClass2::METHOD_MAPPING);

--- a/tests/IntegrationTest/CompiledContainerTest.php
+++ b/tests/IntegrationTest/CompiledContainerTest.php
@@ -94,7 +94,7 @@ class CompiledContainerTest extends BaseContainerTest
             CompiledContainerTest\Autowireable::class  => \DI\autowire(),
             CompiledContainerTest\Autowireable2::class  => \DI\autowire()
                 ->constructorParameter('dependencyA', \Di\factory([CompiledContainerTest\AutowireableDependencyA::class, 'create']))
-                ->constructorParameter('dependencyB', \Di\factory([CompiledContainerTest\AutowireableDependencyB::class, 'createWithParameters', 10, 'someStringParameter'])),
+                ->constructorParameter('dependencyB', \Di\factory([CompiledContainerTest\AutowireableDependencyB::class, 'create'])),
         ];
 
         // Create a compiled container in a specific file
@@ -387,7 +387,7 @@ class AutowireableDependencyA
 }
 class AutowireableDependencyB
 {
-    public function createWithParameters(int $integer, string $string): self
+    public function create(): self
     {
         return new static();
     }

--- a/tests/IntegrationTest/CompiledContainerTest.php
+++ b/tests/IntegrationTest/CompiledContainerTest.php
@@ -102,6 +102,8 @@ class CompiledContainerTest extends BaseContainerTest
         $builder1->addDefinitions($definitions);
         $builder1->enableCompilation(self::COMPILATION_DIR, $compiledContainerClass1);
         $container1 = $builder1->build();
+        $this->assertEquals('barFromFactory', $container1->get('factory'));
+        $this->assertEquals('barFromFactory', $container1->get('factoryReference'));
         $this->assertInstanceOf(CompiledContainerTest\AllKindsOfInjections::class, $container1->get(CompiledContainerTest\AllKindsOfInjections::class));
         $this->assertInstanceOf(CompiledContainerTest\Autowireable::class, $container1->get(CompiledContainerTest\Autowireable::class));
         $this->assertInstanceOf(CompiledContainerTest\Autowireable2::class, $container1->get(CompiledContainerTest\Autowireable2::class));

--- a/tests/IntegrationTest/CompiledContainerTest.php
+++ b/tests/IntegrationTest/CompiledContainerTest.php
@@ -86,19 +86,24 @@ class CompiledContainerTest extends BaseContainerTest
                     )
                 ),
             CompiledContainerTest\Autowireable::class  => \DI\autowire(),
+            CompiledContainerTest\Autowireable2::class  => \DI\autowire()
+                ->constructorParameter('dependencyA', \Di\factory([CompiledContainerTest\AutowireableDependencyA::class, 'create']))
+                ->constructorParameter('dependencyB', \Di\factory([CompiledContainerTest\AutowireableDependencyB::class, 'create'])),
         ];
 
         // Create a compiled container in a specific file
         $builder1 = new ContainerBuilder;
         $builder1->addDefinitions($definitions);
         $builder1->enableCompilation(self::COMPILATION_DIR, $compiledContainerClass1);
-        $builder1->build();
+        $container1 = $builder1->build();
+        $this->assertInstanceOf($container1->get(CompiledContainerTest\Autowireable2::class), CompiledContainerTest\Autowireable2::class);
 
         // Create a second compiled container with the same configuration but in a different file
         $builder2 = new ContainerBuilder;
         $builder2->addDefinitions($definitions);
         $builder2->enableCompilation(self::COMPILATION_DIR, $compiledContainerClass2);
-        $builder2->build();
+        $container2 = $builder2->build();
+        $this->assertInstanceOf($container2->get(CompiledContainerTest\Autowireable2::class), CompiledContainerTest\Autowireable2::class);
 
         // The method mapping of the resulting CompiledContainers should be equal
         self::assertEquals($compiledContainerClass1::METHOD_MAPPING, $compiledContainerClass2::METHOD_MAPPING);
@@ -345,4 +350,33 @@ class Autowireable
 }
 class AutowireableDependency
 {
+}
+
+
+
+
+class Autowireable2
+{
+    private $dependencyA;
+    private $dependencyB;
+
+    public function __construct(AutowireableDependencyA $dependencyA, AutowireableDependencyB $dependencyB)
+    {
+        $this->dependencyA = $dependencyA;
+        $this->dependencyB = $dependencyB;
+    }
+}
+class AutowireableDependencyA
+{
+    public function create(): self
+    {
+        return new static();
+    }
+}
+class AutowireableDependencyB
+{
+    public function create(): self
+    {
+        return new static();
+    }
 }

--- a/tests/IntegrationTest/Definitions/ValueDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/ValueDefinitionTest.php
@@ -41,7 +41,7 @@ class ValueDefinitionTest extends BaseContainerTest
         self::assertEntryIsCompiled($container, 'helper');
         $this->assertEquals('foo', $container->get('helper'));
 
-        self::assertEntryIsCompiled($container, 'closure');
+        self::assertEntryIsNotCompiled($container, 'closure');
         $this->assertEquals('foo', call_user_func($container->get('closure')));
     }
 }

--- a/tests/UnitTest/ContainerBuilderTest.php
+++ b/tests/UnitTest/ContainerBuilderTest.php
@@ -177,7 +177,7 @@ class ContainerBuilderTest extends TestCase
     public function should_allow_to_customize_the_class_name_of_the_compiled_container()
     {
         $builder = new ContainerBuilder();
-        $className = 'Container' . uniqid();
+        $className = uniqid('Container', false);
         $builder->enableCompilation(BaseContainerTest::COMPILATION_DIR, $className);
 
         $this->assertInstanceOf(CompiledContainer::class, $builder->build());


### PR DESCRIPTION
This PR builds on top of #649 and implements what's suggested in https://github.com/PHP-DI/PHP-DI/pull/649/files#r264150572

It adds more complexity, but at least we have a sane way to make sure every definition can be hashed to something unique (I am afraid #649 doesn't cover every case because it only focuses on closures).

The idea is that each definition is compiled into a method which bears a unique name. That unique name is a hash generated from the definition.

Each definition generates its own hash, so that two different definitions have two different hashes. But it's okay if different definitions have the same hash if they are actually equal.