### PR TITLE
Fixes FactoryResolver#resolve ignoring passed parameters

### DIFF
--- a/src/Definition/Resolver/FactoryResolver.php
+++ b/src/Definition/Resolver/FactoryResolver.php
@@ -75,7 +75,7 @@ class FactoryResolver implements DefinitionResolver
         try {
             $providedParams = [$this->container, $definition];
             $extraParams = $this->resolveExtraParams($definition->getParameters());
-            $providedParams = array_merge($providedParams, $extraParams);
+            $providedParams = array_merge($providedParams, $extraParams, $parameters);
 
             return $this->invoker->call($callable, $providedParams);
         } catch (NotCallableException $e) {

--- a/tests/IntegrationTest/ContainerMakeTest.php
+++ b/tests/IntegrationTest/ContainerMakeTest.php
@@ -170,6 +170,25 @@ class ContainerMakeTest extends BaseContainerTest
         ]);
         $this->assertEquals('baz', $result->bar);
     }
+
+    /**
+     * Test that factory method can access to the values provided to the make call
+     * @dataProvider provideContainer
+     */
+    public function testFactoryFunctionForwardsPassedParameters(ContainerBuilder $builder)
+    {
+        $builder->addDefinitions([
+            'some_alias' => function ($bar) {
+                return new Fixture\Foo($bar . ' + local_manipulation');
+            },
+        ]);
+        $container = $builder->build();
+
+        $result = $container->make('some_alias', [
+            'bar' => 'baz'
+        ]);
+        $this->assertEquals('baz + local_manipulation', $result->bar);
+    }
 }
 
 namespace DI\Test\IntegrationTest\Fixture;

--- a/tests/UnitTest/Definition/Resolver/FactoryResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/FactoryResolverTest.php
@@ -99,14 +99,15 @@ class FactoryResolverTest extends TestCase
         $resolver = new FactoryResolver($container, $this->easyMock(DefinitionResolver::class));
 
         $testCase = $this;
-        $definition = new FactoryDefinition('foo', function ($c, $par1, $par2) use ($testCase) {
+        $definition = new FactoryDefinition('foo', function ($c, $par1, $par2, $baz) use ($testCase) {
             $testCase->assertEquals('Parameter 1', $par1);
             $testCase->assertEquals(2, $par2);
+            $testCase->assertEquals('bar', $baz);
 
             return $c;
         }, ['par1' => 'Parameter 1', 'par2' => 2]);
 
-        $value = $resolver->resolve($definition);
+        $value = $resolver->resolve($definition, ['baz' => 'bar']);
 
         $this->assertInstanceOf(ContainerInterface::class, $value);
     }


### PR DESCRIPTION
FactoryResolver#resolve seems to be ignoring the passed arguments. 