### PR TITLE
Fix #648 by reverting 6.0.7 changes

### DIFF
--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -160,7 +160,7 @@ class Compiler
     /**
      * Use a hash to ensure that the used method names in the CompiledContainer are both unique and idempotent.
      */
-    private function getHashedValue(string $prefix, string $value) : string
+    private function getHashedValue(string $prefix, string $value): string
     {
         return $prefix . md5($value);
     }
@@ -175,7 +175,7 @@ class Compiler
         $methodName = $this->getHashedValue('get', $entryName);
 
         //In case an Entry is already added, the used method should be equal
-        if (isset($this->entryToMethodMapping[$entryName]) && $this->entryToMethodMapping[$entryName] !== $methodName) {
+        if(isset($this->entryToMethodMapping[$entryName]) && $this->entryToMethodMapping[$entryName] !== $methodName){
             throw new InvalidDefinition(sprintf(
                 'Entry "%s" cannot be compiled. An Entry with the same name already exists pointing to method %s(), while this one points to method %s().',
                 $entryName,

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -158,32 +158,14 @@ class Compiler
     }
 
     /**
-     * Use a hash to ensure that the used method names in the CompiledContainer are both unique and idempotent.
-     */
-    private function getHashedValue(string $prefix, string $value): string
-    {
-        return $prefix . md5($value);
-    }
-
-    /**
      * @throws DependencyException
      * @throws InvalidDefinition
      * @return string The method name
      */
     private function compileDefinition(string $entryName, Definition $definition) : string
     {
-        $methodName = $this->getHashedValue('get', $entryName);
-
-        //In case an Entry is already added, the used method should be equal
-        if(isset($this->entryToMethodMapping[$entryName]) && $this->entryToMethodMapping[$entryName] !== $methodName){
-            throw new InvalidDefinition(sprintf(
-                'Entry "%s" cannot be compiled. An Entry with the same name already exists pointing to method %s(), while this one points to method %s().',
-                $entryName,
-                $this->entryToMethodMapping[$entryName],
-                $methodName
-            ));
-        }
-
+        // Generate a unique method name
+        $methodName = str_replace('.', '', uniqid('get', true));
         $this->entryToMethodMapping[$entryName] = $methodName;
 
         switch (true) {
@@ -294,8 +276,8 @@ PHP;
         }
 
         if ($value instanceof Definition) {
-            $subEntryName = $this->getHashedValue('SubEntry', $value->getName() . $value);
-
+            // Give it an arbitrary unique name
+            $subEntryName = uniqid('SubEntry');
             // Compile the sub-definition in another method
             $methodName = $this->compileDefinition($subEntryName, $value);
             // The value is now a method call to that method (which returns the value)

--- a/tests/IntegrationTest/CompiledContainerTest.php
+++ b/tests/IntegrationTest/CompiledContainerTest.php
@@ -56,54 +56,6 @@ class CompiledContainerTest extends BaseContainerTest
         self::assertEquals('bar', $container->get('foo'));
     }
 
-    /** @test */
-    public function the_compiled_container_is_idempotent()
-    {
-        $compiledContainerClass1 = self::generateCompiledClassName();
-        $compiledContainerClass2 = self::generateCompiledClassName();
-
-        $definitions = [
-            'foo' => 'barFromFoo',
-            'fooReference' => \DI\get('foo'),
-            'factory' => function () {
-                return 'barFromFactory';
-            },
-            'factoryReference' => \DI\get('factory'),
-            'array' => [
-                1,
-                2,
-                3,
-                'fooBar',
-            ],
-            'arrayValue' => \DI\value('array'),
-            CompiledContainerTest\AllKindsOfInjections::class => create()
-                ->constructor(create('stdClass'))
-                ->property('property', autowire(CompiledContainerTest\Autowireable::class))
-                ->method('method', \DI\factory(
-                        function () {
-                            return new \stdClass;
-                        }
-                    )
-                ),
-            CompiledContainerTest\Autowireable::class  => \DI\autowire(),
-        ];
-
-        // Create a compiled container in a specific file
-        $builder1 = new ContainerBuilder;
-        $builder1->addDefinitions($definitions);
-        $builder1->enableCompilation(self::COMPILATION_DIR, $compiledContainerClass1);
-        $builder1->build();
-
-        // Create a second compiled container with the same configuration but in a different file
-        $builder2 = new ContainerBuilder;
-        $builder2->addDefinitions($definitions);
-        $builder2->enableCompilation(self::COMPILATION_DIR, $compiledContainerClass2);
-        $builder2->build();
-
-        // The method mapping of the resulting CompiledContainers should be equal
-        self::assertEquals($compiledContainerClass1::METHOD_MAPPING, $compiledContainerClass2::METHOD_MAPPING);
-    }
-
     /**
      * @test
      * @expectedException \DI\Definition\Exception\InvalidDefinition
@@ -318,31 +270,5 @@ class ConstructorWithAbstractClassTypehint
 }
 
 abstract class AbstractClass
-{
-}
-
-class AllKindsOfInjections
-{
-    public $property;
-    public $constructorParameter;
-    public $methodParameter;
-    public function __construct($constructorParameter)
-    {
-        $this->constructorParameter = $constructorParameter;
-    }
-    public function method($methodParameter)
-    {
-        $this->methodParameter = $methodParameter;
-    }
-}
-class Autowireable
-{
-    private $dependency;
-    public function __construct(AutowireableDependency $dependency)
-    {
-        $this->dependency = $dependency;
-    }
-}
-class AutowireableDependency
 {
 }


### PR DESCRIPTION
Fix #648 by reverting #605 as discussed [here](https://github.com/PHP-DI/PHP-DI/issues/648#issuecomment-478951613).

That means that the changes in the [6.0.7]() release will be rolled back. For reference:

> #605 Fixes some bugs with platforms like Heroku.
>
> In previous versions some random strings were used in the CompiledContainer which caused each regeneration/compilation of the container to have a different result, while no change in the configuration were made. The CompiledContainer has now been made idempotent: "a specific PHP-DI configuration X always results in CompiledContainer Y".