### PR TITLE
DefinitionGlob

### DIFF
--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -8,6 +8,7 @@ use DI\Compiler\Compiler;
 use DI\Definition\Source\AnnotationBasedAutowiring;
 use DI\Definition\Source\DefinitionArray;
 use DI\Definition\Source\DefinitionFile;
+use DI\Definition\Source\DefinitionGlob;
 use DI\Definition\Source\DefinitionSource;
 use DI\Definition\Source\NoAutowiring;
 use DI\Definition\Source\ReflectionBasedAutowiring;
@@ -141,6 +142,8 @@ class ContainerBuilder
                 return new DefinitionFile($definitions, $autowiring);
             } elseif (is_array($definitions)) {
                 return new DefinitionArray($definitions, $autowiring);
+            } elseif ($definitions instanceof DefinitionGlob) {
+                $definitions->setAutowiring($autowiring);
             }
 
             return $definitions;

--- a/src/Definition/Source/DefinitionGlob.php
+++ b/src/Definition/Source/DefinitionGlob.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Definition\Source;
+
+/**
+ * Reads DI definitions from files matching glob pattern.
+ *
+ */
+class DefinitionGlob extends SourceChain
+{
+    /**
+     * @var bool
+     */
+    private $initialized = false;
+
+    /**
+     * Glob pattern to files containing definitions
+     * @var string|null
+     */
+    private $pattern;
+
+    /**
+     * @var Autowiring
+     */
+    private $autowiring;
+
+    /**
+     * @param string $pattern Glob pattern to files containing definitions
+     */
+    public function __construct($pattern)
+    {
+        // Lazy-loading to improve performances
+        $this->pattern = $pattern;
+
+        parent::__construct([]);
+    }
+
+    public function setAutowiring(Autowiring $autowiring)
+    {
+        $this->autowiring = $autowiring;
+    }
+
+    public function getDefinition(string $name, int $startIndex = 0)
+    {
+        $this->initialize();
+
+        return parent::getDefinition($name, $startIndex);
+    }
+
+    public function getDefinitions() : array
+    {
+        $this->initialize();
+
+        return parent::getDefinitions();
+    }
+
+    /**
+     * Lazy-loading of the definitions.
+     */
+    private function initialize()
+    {
+        if ($this->initialized === true) {
+            return;
+        }
+
+        $paths = glob($this->pattern, GLOB_BRACE);
+        foreach ($paths as $path)
+        {
+            $this->sources[] = new DefinitionFile($path, $this->autowiring);
+        }
+
+        $this->initialized = true;
+    }
+}

--- a/src/Definition/Source/SourceChain.php
+++ b/src/Definition/Source/SourceChain.php
@@ -17,7 +17,7 @@ class SourceChain implements DefinitionSource, MutableDefinitionSource
     /**
      * @var DefinitionSource[]
      */
-    protected $sources;
+    private $sources;
 
     /**
      * @var DefinitionSource

--- a/src/Definition/Source/SourceChain.php
+++ b/src/Definition/Source/SourceChain.php
@@ -17,7 +17,7 @@ class SourceChain implements DefinitionSource, MutableDefinitionSource
     /**
      * @var DefinitionSource[]
      */
-    private $sources;
+    protected $sources;
 
     /**
      * @var DefinitionSource

--- a/tests/UnitTest/Definition/Source/DefinitionGlobTest.php
+++ b/tests/UnitTest/Definition/Source/DefinitionGlobTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\UnitTest\Definition\Source;
+
+use DI\Definition\Source\DefinitionGlob;
+use DI\Definition\ValueDefinition;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * @covers \DI\Definition\Source\DefinitionGlob
+ */
+class DefinitionGlobTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function should_load_definitions_from_glob()
+    {
+        $pattern = __DIR__ . '/*/definitions.php';
+        $source = new DefinitionGlob($pattern);
+
+        $class = new ReflectionClass(DefinitionGlob::class);
+        $property = $class->getProperty('sources');
+        $property->setAccessible(true);
+        $definitions = $property->getValue($source);
+        // sources are not initialized (and files are not read) before getting definitions
+        $this->assertCount(0, $definitions);
+
+        $definitions = $source->getDefinitions();
+        $this->assertCount(2, $definitions);
+
+        /** @var ValueDefinition $definition */
+        $definition = $definitions['foo'];
+        $this->assertInstanceOf(ValueDefinition::class, $definition);
+        $this->assertEquals('bar', $definition->getValue());
+        $this->assertInternalType('string', $definition->getValue());
+    }
+
+    /**
+     * @test
+     */
+    public function empty_definitions_for_pattern_not_matching_any_files()
+    {
+        $pattern = __DIR__ . '/*/no-definitions-here.php';
+        $source = new DefinitionGlob($pattern);
+
+        $definitions = $source->getDefinitions();
+        $this->assertCount(0, $definitions);
+    }
+}

--- a/tests/UnitTest/Definition/Source/DefinitionGlobTest.php
+++ b/tests/UnitTest/Definition/Source/DefinitionGlobTest.php
@@ -23,11 +23,11 @@ class DefinitionGlobTest extends TestCase
         $source = new DefinitionGlob($pattern);
 
         $class = new ReflectionClass(DefinitionGlob::class);
-        $property = $class->getProperty('sources');
+        $property = $class->getProperty('sourceChain');
         $property->setAccessible(true);
-        $definitions = $property->getValue($source);
+        $sourceChain = $property->getValue($source);
         // sources are not initialized (and files are not read) before getting definitions
-        $this->assertCount(0, $definitions);
+        $this->assertNull($sourceChain);
 
         $definitions = $source->getDefinitions();
         $this->assertCount(2, $definitions);


### PR DESCRIPTION
 DefinitionGlob to specify a pattern for definition files

- there might be multiple definitions files scattered around in a modularized architecture
- instead of listing all the files upfront, specify a glob pattern where to look for the files
- directories would be scanned and files read lazily, when a definition is actually requested - to avoid performance hit on init

_[from ovos/PHP-DI#2]_