### PR TITLE
Optimize compiled string definitions

### DIFF
--- a/src/CompiledContainer.php
+++ b/src/CompiledContainer.php
@@ -16,6 +16,7 @@ use Invoker\ParameterResolver\AssociativeArrayResolver;
 use Invoker\ParameterResolver\DefaultValueResolver;
 use Invoker\ParameterResolver\NumericArrayResolver;
 use Invoker\ParameterResolver\ResolverChain;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * Compiled version of the dependency injection container.
@@ -118,6 +119,23 @@ abstract class CompiledContainer extends Container
             throw new InvalidDefinition("Entry \"$entryName\" cannot be resolved: factory " . $e->getMessage());
         } catch (NotEnoughParametersException $e) {
             throw new InvalidDefinition("Entry \"$entryName\" cannot be resolved: " . $e->getMessage());
+        }
+    }
+
+    /**
+     * Resolve a placeholder in string definition
+     * - wrap possible NotFound exception to conform to the one from StringDefinition::resolveExpression.
+     */
+    protected function resolveStringPlaceholder($placeholder, $entryName)
+    {
+        try {
+            return $this->delegateContainer->get($placeholder);
+        } catch (NotFoundExceptionInterface $e) {
+            throw new DependencyException(sprintf(
+                "Error while parsing string expression for entry '%s': %s",
+                $entryName,
+                $e->getMessage()
+            ), 0, $e);
         }
     }
 }

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -182,9 +182,12 @@ class Compiler
                 }
                 break;
             case $definition instanceof StringDefinition:
-                $entryName = $this->compileValue($definition->getName());
-                $expression = $this->compileValue($definition->getExpression());
-                $code = 'return \DI\Definition\StringDefinition::resolveExpression(' . $entryName . ', ' . $expression . ', $this->delegateContainer);';
+                $expression = $definition->getExpression();
+                $callback = function (array $matches) use ($definition) {
+                    return '\'.$this->resolveStringPlaceholder(' . $this->compileValue($matches[1]) . ', ' . $this->compileValue($definition->getName()) . ').\'';
+                };
+                $value = preg_replace_callback('#\{([^\{\}]+)\}#', $callback, $expression);
+                $code = 'return \'' . $value . '\';';
                 break;
             case $definition instanceof EnvironmentVariableDefinition:
                 $variableName = $this->compileValue($definition->getVariableName());


### PR DESCRIPTION
 - run preg_replace_callback already during compilation

from:
```php
    protected function get5ce3da5dc66c0791095127()
    {
        return \DI\Definition\StringDefinition::resolveExpression('path.cache', '{BASE_PATH}/application/cache', $this->delegateContainer);
    }

    protected function get5ce3da5dc66c3314070297()
    {
        return \DI\Definition\StringDefinition::resolveExpression('path.cache.app', '{path.cache}/file', $this->delegateContainer);
    }
```

to:
```php
    protected function get5ce3da5dc66c0791095127()
    {
        return ''.$this->resolveStringPlaceholder('BASE_PATH', 'path.cache').'/application/cache';
    }

    protected function get5ce3da5dc66c3314070297()
    {
        return ''.$this->resolveStringPlaceholder('path.cache', 'path.cache.app').'/file';
    }
```

where `resolveStringPlaceholder` proxies to `$this->delegateContainer->get()`

_[from ovos/PHP-DI#5]_