### PR TITLE
Optimize compiled factory definitions

### DIFF
--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Compiler;
 
+use DI\Container;
 use DI\Definition\ArrayDefinition;
 use DI\Definition\DecoratorDefinition;
 use DI\Definition\Definition;
@@ -19,6 +20,8 @@ use DI\DependencyException;
 use DI\Proxy\ProxyFactory;
 use InvalidArgumentException;
 use PhpParser\Node\Expr\Closure;
+use ReflectionFunction;
+use ReflectionFunctionAbstract;
 use SuperClosure\Analyzer\AstAnalyzer;
 use SuperClosure\Exception\ClosureAnalysisException;
 
@@ -244,6 +247,35 @@ PHP;
                     ));
                 }
 
+                if ($value instanceof \Closure) {
+                    $reflection = new ReflectionFunction($value);
+                    $requestedEntry = new RequestedEntryHolder($entryName);
+                    $parametersByClassName = [
+                        'DI\Factory\RequestedEntry' => $requestedEntry,
+                    ];
+                    // default non-typehinted parameters
+                    $defaultParameters = [new Reference(Container::class), $requestedEntry];
+
+                    $resolvedParameters = $this->resolveFactoryParameters(
+                        $reflection,
+                        $definition->getParameters(),
+                        $parametersByClassName,
+                        $defaultParameters
+                    );
+
+                    $definitionParameters = array_map(function ($value) {
+                        return $this->compileValue($value);
+                    }, $resolvedParameters);
+
+                    $code = sprintf(
+                        'return (%s)(%s);',
+                        $this->compileValue($value),
+                        implode(', ', $definitionParameters)
+                    );
+                    break;
+                }
+
+                // todo optimize other (non-closure) factories
                 $definitionParameters = '';
                 if (!empty($definition->getParameters())) {
                     $definitionParameters = ', ' . $this->compileValue($definition->getParameters());
@@ -273,6 +305,11 @@ PHP;
         $errorMessage = $this->isCompilable($value);
         if ($errorMessage !== true) {
             throw new InvalidDefinition($errorMessage);
+        }
+
+        // one step ahead to skip CompiledContainer->resolveFactory
+        if ($value instanceof RequestedEntryHolder) {
+            return 'new DI\Compiler\RequestedEntryHolder(\'' . $value->getName() . '\')';
         }
 
         if ($value instanceof Definition) {
@@ -333,6 +370,10 @@ PHP;
         if ($value instanceof \Closure) {
             return true;
         }
+        // added for skipping CompiledContainer->resolveFactory - there is a special case for this in compileValue method
+        if ($value instanceof RequestedEntryHolder) {
+            return true;
+        }
         if (is_object($value)) {
             return 'An object was found but objects cannot be compiled';
         }
@@ -375,5 +416,40 @@ PHP;
         $code = trim($code, "\t\n\r;");
 
         return $code;
+    }
+
+    public function resolveFactoryParameters(
+        ReflectionFunctionAbstract $reflection,
+        array $definitionParameters = [],
+        array $parametersByClassName = [],
+        array $defaultParameters = []
+    ) {
+        $resolvedParameters = [];
+        $parameters = $reflection->getParameters();
+
+        foreach ($parameters as $index => $parameter) {
+            $name = $parameter->getName();
+            if (array_key_exists($name, $definitionParameters)) {
+                $resolvedParameters[$index] = $definitionParameters[$name];
+                continue;
+            }
+
+            $parameterClass = $parameter->getClass();
+            if (!$parameterClass) {
+                if (array_key_exists($index, $defaultParameters)) {
+                    // take default parameters, when no typehint
+                    $resolvedParameters[$index] = $defaultParameters[$index];
+                }
+                continue;
+            }
+
+            if (isset($parametersByClassName[$parameterClass->name])) {
+                $resolvedParameters[$index] = $parametersByClassName[$parameterClass->name];
+            } else {
+                $resolvedParameters[$index] = new Reference($parameterClass->name);
+            }
+        }
+
+        return $resolvedParameters;
     }
 }


### PR DESCRIPTION
- compile final function with injected dependencies
- only for closure factories for now (as the first step)

1) Simple example:
before:
```php
return $this->resolveFactory(static function () {
    return 'bar';
}, 'factory');
```
now:
```php
return (static function () {
    return 'bar';
})();
```
2) More complex example:
before:
```php
return $this->resolveFactory(static function (\DI\Factory\RequestedEntry $entry, \DI\Container $c, $dbName = null) {
    $parts = explode('.', $entry->getName());
    $type = $parts[1];
    if ($dbName === null && isset($parts[2])) {
        $dbName = $parts[2] !== '0' ? $parts[2] : false;
    }
    $factory = $c->get(\CMS\Database\ConnectionFactory::class);
    return $factory->create($type, $dbName);
}, 'db.mysql', [
            'dbName' => NULL,
        ]);
```
now:
```php
return (static function (\DI\Factory\RequestedEntry $entry, \DI\Container $c, $dbName = null) {
    $parts = explode('.', $entry->getName());
    $type = $parts[1];
    if ($dbName === null && isset($parts[2])) {
        $dbName = $parts[2] !== '0' ? $parts[2] : false;
    }
    $factory = $c->get(\CMS\Database\ConnectionFactory::class);
    return $factory->create($type, $dbName);
})(new DI\Compiler\RequestedEntryHolder('db.mysql'), $this->get5cc4bd5c6dc8e808068072(), NULL);
```

_[from ovos/PHP-DI#6]_