### PR TITLE
Feature/service locator

### DIFF
--- a/src/CompiledContainer.php
+++ b/src/CompiledContainer.php
@@ -122,14 +122,15 @@ abstract class CompiledContainer extends Container
     }
 
     /**
-     * Resolve ServiceLocator for given subscriber class (based on \DI\Definition\ServiceLocatorDefinition::resolve)
+     * Resolve ServiceLocator for given subscriber class (based on \DI\Definition\ServiceLocatorDefinition::resolve).
      *
      * @param string $requestingName class name of a subscriber, implementing ServiceSubscriberInterface
      * @param string $repositoryClass ServiceLocatorRepository
      * @return ServiceLocator
      * @throws ServiceSubscriberException
      */
-    protected function resolveServiceLocator($requestingName, $repositoryClass) {
+    protected function resolveServiceLocator($requestingName, $repositoryClass)
+    {
         if (!method_exists($requestingName, 'getSubscribedServices')) {
             throw new ServiceSubscriberException(sprintf('The class %s does not implement ServiceSubscriberInterface.', $requestingName));
         }

--- a/src/CompiledContainer.php
+++ b/src/CompiledContainer.php
@@ -120,4 +120,24 @@ abstract class CompiledContainer extends Container
             throw new InvalidDefinition("Entry \"$entryName\" cannot be resolved: " . $e->getMessage());
         }
     }
+
+    /**
+     * Resolve ServiceLocator for given subscriber class (based on \DI\Definition\ServiceLocatorDefinition::resolve)
+     *
+     * @param string $requestingName class name of a subscriber, implementing ServiceSubscriberInterface
+     * @param string $repositoryClass ServiceLocatorRepository
+     * @return ServiceLocator
+     * @throws ServiceSubscriberException
+     */
+    protected function resolveServiceLocator($requestingName, $repositoryClass) {
+        if (!method_exists($requestingName, 'getSubscribedServices')) {
+            throw new ServiceSubscriberException(sprintf('The class %s does not implement ServiceSubscriberInterface.', $requestingName));
+        }
+
+        /** @var ServiceLocatorRepository $repository */
+        $repository = $this->delegateContainer->get($repositoryClass);
+        $services = $requestingName::getSubscribedServices();
+
+        return $repository->create($requestingName, $services);
+    }
 }

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -12,7 +12,6 @@ use DI\Definition\Exception\InvalidDefinition;
 use DI\Definition\FactoryDefinition;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\Reference;
-use DI\Definition\ServiceLocatorDefinition;
 use DI\Definition\Source\DefinitionSource;
 use DI\Definition\StringDefinition;
 use DI\Definition\ValueDefinition;
@@ -178,11 +177,7 @@ class Compiler
                 if ($definition->isServiceLocatorEntry()) {
                     $requestingEntry = $definition->getRequestingName();
                     $serviceLocatorDefinition = $definition->getServiceLocatorDefinition();
-                    // compiled ServiceLocatorDefinition::resolve
-                    $code = '$repository = $this->delegateContainer->get(' . $this->compileValue($serviceLocatorDefinition::$serviceLocatorRepositoryClass) . ');
-        $services = ' . $requestingEntry . '::getSubscribedServices();
-        $serviceLocator = $repository->create(' . $this->compileValue($requestingEntry) . ', $services);
-        return $serviceLocator;';
+                    $code = 'return $this->resolveServiceLocator(' . $this->compileValue($requestingEntry) . ', ' . $this->compileValue($serviceLocatorDefinition::$serviceLocatorRepositoryClass) . ');';
                     break;
                 }
 

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -57,6 +57,11 @@ class ContainerBuilder
     private $useAnnotations = false;
 
     /**
+     * @var int
+     */
+    private $annotationsFlags = 0;
+
+    /**
      * @var bool
      */
     private $ignorePhpDocErrors = false;
@@ -126,7 +131,7 @@ class ContainerBuilder
         $sources = array_reverse($this->definitionSources);
 
         if ($this->useAnnotations) {
-            $autowiring = new AnnotationBasedAutowiring($this->ignorePhpDocErrors);
+            $autowiring = new AnnotationBasedAutowiring($this->ignorePhpDocErrors, $this->annotationsFlags);
             $sources[] = $autowiring;
         } elseif ($this->useAutowiring) {
             $autowiring = new ReflectionBasedAutowiring;
@@ -239,11 +244,12 @@ class ContainerBuilder
      *
      * @return $this
      */
-    public function useAnnotations(bool $bool) : self
+    public function useAnnotations(bool $bool, int $flags = 0) : self
     {
         $this->ensureNotLocked();
 
         $this->useAnnotations = $bool;
+        $this->annotationsFlags = $flags;
 
         return $this;
     }

--- a/src/Definition/AutowireDefinition.php
+++ b/src/Definition/AutowireDefinition.php
@@ -9,4 +9,26 @@ namespace DI\Definition;
  */
 class AutowireDefinition extends ObjectDefinition
 {
+    /**
+     * @var bool|null
+     */
+    protected $useAnnotations;
+
+    /**
+     * Enable/disable reading annotations for this definition, regardless of a container configuration.
+     * @param bool $flag
+     */
+    public function useAnnotations(bool $flag = true)
+    {
+        $this->useAnnotations = $flag;
+    }
+
+    /**
+     * Returns boolean if the useAnnotation flag was explicitly set, otherwise null.
+     * @return bool|null
+     */
+    public function isUsingAnnotations()
+    {
+        return $this->useAnnotations;
+    }
 }

--- a/src/Definition/Helper/AutowireDefinitionHelper.php
+++ b/src/Definition/Helper/AutowireDefinitionHelper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DI\Definition\Helper;
 
 use DI\Definition\AutowireDefinition;
+use DI\Definition\Definition;
 
 /**
  * Helps defining how to create an instance of a class using autowiring.
@@ -14,6 +15,8 @@ use DI\Definition\AutowireDefinition;
 class AutowireDefinitionHelper extends CreateDefinitionHelper
 {
     const DEFINITION_CLASS = AutowireDefinition::class;
+
+    protected $useAnnotations;
 
     /**
      * Defines a value for a specific argument of the constructor.
@@ -68,5 +71,32 @@ class AutowireDefinitionHelper extends CreateDefinitionHelper
         $this->methods[$method][0][$parameter] = $value;
 
         return $this;
+    }
+
+    /**
+     * Define if entry should use annotation reader for reading dependencies.
+     * This is turned off by default if autowire() helper is used, and turned on if entry is not defined explicitly in the di config.
+     * @param bool $useAnnotations
+     * @return $this
+     */
+    public function useAnnotations(bool $useAnnotations = true)
+    {
+        $this->useAnnotations = $useAnnotations;
+
+        return $this;
+    }
+
+    /**
+     * @return AutowireDefinition
+     */
+    public function getDefinition(string $entryName) : Definition
+    {
+        /** @var AutowireDefinition $definition */
+        $definition = parent::getDefinition($entryName);
+        if ($this->useAnnotations !== null) {
+            $definition->useAnnotations($this->useAnnotations);
+        }
+
+        return $definition;
     }
 }

--- a/src/Definition/Reference.php
+++ b/src/Definition/Reference.php
@@ -70,8 +70,6 @@ class Reference implements Definition, SelfResolvingDefinition
         return $this->targetEntryName;
     }
 
-    // added
-
     /**
      * Returns the name of the entity requesting this entry.
      * @return string
@@ -88,8 +86,12 @@ class Reference implements Definition, SelfResolvingDefinition
 
     public function getServiceLocatorDefinition() : ServiceLocatorDefinition
     {
-        if (!$this->isServiceLocatorEntry) {
-            throw new InvalidDefinition('Invalid service locator definition');
+        if (!$this->isServiceLocatorEntry || $this->requestingName === null) {
+            throw new InvalidDefinition(sprintf(
+                "Invalid service locator definition ('%s' for '%s')",
+                $this->targetEntryName,
+                $this->requestingName
+            ));
         }
         if (!$this->serviceLocatorDefinition) {
             $this->serviceLocatorDefinition = new ServiceLocatorDefinition($this->getTargetEntryName(), $this->requestingName);

--- a/src/Definition/ServiceLocatorDefinition.php
+++ b/src/Definition/ServiceLocatorDefinition.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Definition;
+
+use DI\ServiceLocatorRepository;
+use Psr\Container\ContainerInterface;
+
+class ServiceLocatorDefinition implements Definition, SelfResolvingDefinition
+{
+    public static $serviceLocatorRepositoryClass = ServiceLocatorRepository::class;
+
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var string
+     */
+    protected $requestingName;
+
+    /**
+     * @param string $name           Entry name
+     * @param string $requestingName name of an entry - holder of a definition requesting service locator
+     */
+    public function __construct($name, $requestingName)
+    {
+        $this->name = $name;
+        $this->requestingName = $requestingName;
+    }
+
+    /**
+     * Returns the name of the entry in the container.
+     */
+    public function getName() : string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Returns the name of the holder of the definition requesting service locator.
+     * @return string
+     */
+    public function getRequestingName() : string
+    {
+        return $this->requestingName;
+    }
+
+    /**
+     * Resolve the definition and return the resulting value.
+     *
+     * @param ContainerInterface $container
+     * @return mixed
+     */
+    public function resolve(ContainerInterface $container)
+    {
+        /** @var ServiceLocatorRepository $repository */
+        $repository = $container->get(self::$serviceLocatorRepositoryClass);
+        $services = $this->requestingName::getSubscribedServices();
+        $serviceLocator = $repository->create($this->requestingName, $services);
+
+        return $serviceLocator;
+    }
+
+    /**
+     * Check if a definition can be resolved.
+     * @param ContainerInterface $container
+     * @return bool
+     */
+    public function isResolvable(ContainerInterface $container) : bool
+    {
+        return true;
+    }
+
+    public function replaceNestedDefinitions(callable $replacer)
+    {
+        // no nested definitions
+    }
+
+    /**
+     * Definitions can be cast to string for debugging information.
+     */
+    public function __toString()
+    {
+        return sprintf(
+            'get(%s)',
+            $this->name
+        );
+    }
+}

--- a/src/Definition/Source/AnnotationBasedAutowiring.php
+++ b/src/Definition/Source/AnnotationBasedAutowiring.php
@@ -177,7 +177,7 @@ class AnnotationBasedAutowiring implements DefinitionSource, Autowiring
         }
 
         $definition->addPropertyInjection(
-            new PropertyInjection($property->getName(), new Reference($entryName), $classname)
+            new PropertyInjection($property->getName(), new Reference($entryName, $classname), $classname)
         );
     }
 
@@ -220,7 +220,7 @@ class AnnotationBasedAutowiring implements DefinitionSource, Autowiring
             $entryName = $this->getMethodParameter($index, $parameter, []);
 
             if ($entryName !== null) {
-                $parameters[$index] = new Reference($entryName);
+                $parameters[$index] = new Reference($entryName, $class->getName());
             }
         }
 

--- a/src/Definition/Source/AnnotationBasedAutowiring.php
+++ b/src/Definition/Source/AnnotationBasedAutowiring.php
@@ -6,6 +6,7 @@ namespace DI\Definition\Source;
 
 use DI\Annotation\Inject;
 use DI\Annotation\Injectable;
+use DI\Definition\AutowireDefinition;
 use DI\Definition\Exception\InvalidAnnotation;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\ObjectDefinition\MethodInjection;
@@ -32,6 +33,25 @@ use UnexpectedValueException;
  */
 class AnnotationBasedAutowiring implements DefinitionSource, Autowiring
 {
+    // Annotations configuration flags:
+    // enable on implicit definitions
+    const IMPLICIT = 1;
+    // enable on all autowire definitions (which are written in DI config) by default
+    const EXPLICIT = 2;
+    // read @Injectable annotations for classes
+    const INJECTABLE = 4;
+    // read @Inject annotations for properties
+    const PROPERTIES = 8;
+    // read @Inject annotations for methods' parameters
+    const METHODS = 16;
+    // all options enabled
+    const ALL = 31;
+
+    /**
+     * @var int
+     */
+    private $flags;
+
     /**
      * @var Reader
      */
@@ -47,9 +67,10 @@ class AnnotationBasedAutowiring implements DefinitionSource, Autowiring
      */
     private $ignorePhpDocErrors;
 
-    public function __construct($ignorePhpDocErrors = false)
+    public function __construct($ignorePhpDocErrors = false, int $flags = 0)
     {
         $this->ignorePhpDocErrors = (bool) $ignorePhpDocErrors;
+        $this->flags = $flags > 0 ? $flags : self::ALL; // all flags turned on by default
     }
 
     public function autowire(string $name, ObjectDefinition $definition = null)
@@ -61,16 +82,35 @@ class AnnotationBasedAutowiring implements DefinitionSource, Autowiring
         }
 
         $definition = $definition ?: new ObjectDefinition($name);
+        $useAnnotations = $definition instanceof AutowireDefinition
+            ? ($definition->isUsingAnnotations() ?? ($this->flags & self::EXPLICIT))
+            : ($this->flags & self::IMPLICIT);
 
-        $class = new ReflectionClass($className);
+        $class = null;
+        if ($useAnnotations && $this->flags >= self::INJECTABLE) {
+            $class = new ReflectionClass($className);
 
-        $this->readInjectableAnnotation($class, $definition);
+            if ($this->flags & self::INJECTABLE) {
+                $this->readInjectableAnnotation($class, $definition);
+            }
 
-        // Browse the class properties looking for annotated properties
-        $this->readProperties($class, $definition);
+            // Browse the class properties looking for annotated properties
+            if ($this->flags & self::PROPERTIES) {
+                $this->readProperties($class, $definition);
+            }
 
-        // Browse the object's methods looking for annotated methods
-        $this->readMethods($class, $definition);
+            // Browse the object's methods looking for annotated methods
+            if ($this->flags & self::METHODS) {
+                $this->readMethods($class, $definition);
+            }
+        }
+
+        // constructor parameters should always be read, even if annotations are disabled (completely or i.a. for methods)
+        // so that it behaves at least as ReflectionBasedAutowiring
+        if (!$useAnnotations || !($this->flags & self::METHODS)) {
+            $class = $class ?? new ReflectionClass($className);
+            $this->readConstructor($class, $definition);
+        }
 
         return $definition;
     }
@@ -164,6 +204,28 @@ class AnnotationBasedAutowiring implements DefinitionSource, Autowiring
                 $objectDefinition->completeFirstMethodInjection($methodInjection);
             }
         }
+    }
+
+    /**
+     * Browse the object's constructor parameters and inject dependencies.
+     */
+    private function readConstructor(ReflectionClass $class, ObjectDefinition $definition)
+    {
+        if (!($constructor = $class->getConstructor()) || !$constructor->isPublic()) {
+            return;
+        }
+
+        $parameters = [];
+        foreach ($constructor->getParameters() as $index => $parameter) {
+            $entryName = $this->getMethodParameter($index, $parameter, []);
+
+            if ($entryName !== null) {
+                $parameters[$index] = new Reference($entryName);
+            }
+        }
+
+        $constructorInjection = MethodInjection::constructor($parameters);
+        $definition->completeConstructorInjection($constructorInjection);
     }
 
     /**

--- a/src/Definition/Source/ReflectionBasedAutowiring.php
+++ b/src/Definition/Source/ReflectionBasedAutowiring.php
@@ -29,7 +29,7 @@ class ReflectionBasedAutowiring implements DefinitionSource, Autowiring
         $class = new \ReflectionClass($className);
         $constructor = $class->getConstructor();
         if ($constructor && $constructor->isPublic()) {
-            $constructorInjection = MethodInjection::constructor($this->getParametersDefinition($constructor));
+            $constructorInjection = MethodInjection::constructor($this->getParametersDefinition($constructor, $class->getName()));
             $definition->completeConstructorInjection($constructorInjection);
         }
 
@@ -52,7 +52,7 @@ class ReflectionBasedAutowiring implements DefinitionSource, Autowiring
     /**
      * Read the type-hinting from the parameters of the function.
      */
-    private function getParametersDefinition(\ReflectionFunctionAbstract $constructor) : array
+    private function getParametersDefinition(\ReflectionFunctionAbstract $constructor, string $className) : array
     {
         $parameters = [];
 
@@ -65,7 +65,7 @@ class ReflectionBasedAutowiring implements DefinitionSource, Autowiring
             $parameterClass = $parameter->getClass();
 
             if ($parameterClass) {
-                $parameters[$index] = new Reference($parameterClass->getName());
+                $parameters[$index] = new Reference($parameterClass->getName(), $className);
             }
         }
 

--- a/src/ServiceLocator.php
+++ b/src/ServiceLocator.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI;
+
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+/**
+ * Class ServiceLocator.
+ *
+ * Serving "lazy" dependencies for classes using ServiceSubscriberInterface.
+ * Suggested as a lightweight alternative for heavyweight proxies from ocramius/proxy-manager
+ */
+class ServiceLocator implements ContainerInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * Name of an entry to which this service locator instance belongs to.
+     * @var string
+     */
+    protected $entry;
+
+    /**
+     * @var array
+     */
+    protected $services = [];
+
+    /**
+     * Constructor.
+     * @param ContainerInterface $container
+     * @param array $services
+     * @param string|null $entry Name of an entry to which this service locator instance belongs to
+     */
+    public function __construct(ContainerInterface $container, array $services, string $entry = null)
+    {
+        $this->container = $container;
+        $this->entry = $entry;
+        $this->setServices($services);
+    }
+
+    /**
+     * @param array $services
+     */
+    protected function setServices(array $services)
+    {
+        foreach ($services as $key => $value) {
+            if (is_numeric($key)) {
+                $key = $value;
+            }
+            $this->services[$key] = $value;
+        }
+    }
+
+    /**
+     * Get defined services.
+     * @return array
+     */
+    public function getServices()
+    {
+        return $this->services;
+    }
+
+    /**
+     * Finds a service by its identifier.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @throws NotFoundExceptionInterface  No entry was found for **this** identifier.
+     * @throws ContainerExceptionInterface Error while retrieving the entry.
+     *
+     * @return mixed Entry.
+     */
+    public function get($id)
+    {
+        if (!isset($this->services[$id])) {
+            throw new NotFoundException("Service '$id' is not defined.");
+        }
+
+        return $this->container->get($this->services[$id]);
+    }
+
+    /**
+     * Returns true if the container can return an entry for the given identifier.
+     * Returns false otherwise.
+     *
+     * `has($id)` returning true does not mean that `get($id)` will not throw an exception.
+     * It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @return bool
+     */
+    public function has($id)
+    {
+        if (!isset($this->services[$id])) {
+            return false;
+        }
+
+        return $this->container->has($this->services[$id]);
+    }
+}

--- a/src/ServiceLocator.php
+++ b/src/ServiceLocator.php
@@ -19,29 +19,29 @@ class ServiceLocator implements ContainerInterface
     /**
      * @var ContainerInterface
      */
-    protected $container;
-
-    /**
-     * Name of an entry to which this service locator instance belongs to.
-     * @var string
-     */
-    protected $entry;
+    private $container;
 
     /**
      * @var array
      */
-    protected $services = [];
+    private $services = [];
+
+    /**
+     * Name of a class to which this service locator instance belongs to.
+     * @var string|null
+     */
+    private $subscriber;
 
     /**
      * Constructor.
      * @param ContainerInterface $container
      * @param array $services
-     * @param string|null $entry Name of an entry to which this service locator instance belongs to
+     * @param string|null $subscriber className of a ServiceSubscriber to which this service locator instance belongs to
      */
-    public function __construct(ContainerInterface $container, array $services, string $entry = null)
+    public function __construct(ContainerInterface $container, array $services, string $subscriber = null)
     {
         $this->container = $container;
-        $this->entry = $entry;
+        $this->subscriber = $subscriber;
         $this->setServices($services);
     }
 
@@ -62,9 +62,18 @@ class ServiceLocator implements ContainerInterface
      * Get defined services.
      * @return array
      */
-    public function getServices()
+    public function getServices() : array
     {
         return $this->services;
+    }
+
+    /**
+     * Get name of a class to which this service locator instance belongs to.
+     * @return string
+     */
+    public function getSubscriber() : string
+    {
+        return $this->subscriber;
     }
 
     /**

--- a/src/ServiceLocatorRepository.php
+++ b/src/ServiceLocatorRepository.php
@@ -14,7 +14,7 @@ class ServiceLocatorRepository implements ContainerInterface
     private $locators = [];
 
     /**
-     * Overrides for ServiceLocators
+     * Overrides for ServiceLocators.
      * @var array
      */
     private $overrides = [];
@@ -88,6 +88,7 @@ class ServiceLocatorRepository implements ContainerInterface
 
         $serviceEntry = $serviceEntry ?? $serviceId;
         $this->overrides[$entry][$serviceId] = $serviceEntry;
+
         return $this;
     }
 

--- a/src/ServiceLocatorRepository.php
+++ b/src/ServiceLocatorRepository.php
@@ -49,21 +49,6 @@ class ServiceLocatorRepository implements ContainerInterface
     }
 
     /**
-     * Inject service locator on an ServiceSubscriber instance.
-     * @param ServiceSubscriberInterface $instance
-     * @param null $entry
-     * @return $this
-     */
-    public function injectOn(ServiceSubscriberInterface $instance, $entry = null)
-    {
-        $entry = $entry ?? get_class($instance);
-        $serviceLocator = $this->create($entry, $instance->getSubscribedServices());
-        $instance->setServiceLocator($serviceLocator);
-
-        return $this;
-    }
-
-    /**
      * Modify a single entry for a service locator.
      *
      * @param string $entry

--- a/src/ServiceLocatorRepository.php
+++ b/src/ServiceLocatorRepository.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI;
+
+use Psr\Container\ContainerInterface;
+
+class ServiceLocatorRepository implements ContainerInterface
+{
+    /**
+     * @var ServiceLocator[]
+     */
+    protected $locators = [];
+
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * Constructor.
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Create or modify service locator.
+     *
+     * @param string $entry
+     * @param array $services
+     * @param bool $overwrite if service locator for an entry already exists, should its services be overwritten?
+     * @return ServiceLocator
+     */
+    public function create(string $entry, array $services = [], $overwrite = false) : ServiceLocator
+    {
+        if (isset($this->locators[$entry]) && !$overwrite) {
+            $services = $overwrite
+                ? array_merge($this->locators[$entry]->getServices(), $services)
+                : array_merge($services, $this->locators[$entry]->getServices());
+        }
+
+        $this->locators[$entry] = new ServiceLocator($this->container, $services, $entry);
+
+        return $this->locators[$entry];
+    }
+
+    /**
+     * Inject service locator on an ServiceSubscriber instance.
+     * @param ServiceSubscriberInterface $instance
+     * @param null $entry
+     * @return $this
+     */
+    public function injectOn(ServiceSubscriberInterface $instance, $entry = null)
+    {
+        $entry = $entry ?? get_class($instance);
+        $serviceLocator = $this->create($entry, $instance->getSubscribedServices());
+        $instance->setServiceLocator($serviceLocator);
+
+        return $this;
+    }
+
+    /**
+     * Modify a single entry for a service locator.
+     *
+     * @param string $entry
+     * @param string $serviceId
+     * @param string|null $serviceEntry
+     * @return $this
+     */
+    public function setService(string $entry, string $serviceId, string $serviceEntry = null)
+    {
+        $serviceEntry = $serviceEntry ?? $serviceId;
+        $this->create($entry, [$serviceId => $serviceEntry], true);
+
+        return $this;
+    }
+
+    /**
+     * Get a service locator for an entry.
+     * @param string $entry
+     * @return ServiceLocator
+     * @throws NotFoundException
+     */
+    public function get($entry) : ServiceLocator
+    {
+        if (!isset($this->locators[$entry])) {
+            throw new NotFoundException("Service locator for entry '$entry' is not initialized.");
+        }
+
+        return $this->locators[$entry];
+    }
+
+    /**
+     * @param string $entry
+     * @return bool
+     */
+    public function has($entry)
+    {
+        return isset($this->locators[$entry]);
+    }
+}

--- a/src/ServiceSubscriberException.php
+++ b/src/ServiceSubscriberException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI;
+
+use Exception;
+
+class ServiceSubscriberException extends Exception
+{
+}

--- a/src/ServiceSubscriberInterface.php
+++ b/src/ServiceSubscriberInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI;
+
+// based on https://github.com/symfony/symfony/pull/21708
+/**
+ * A ServiceSubscriber exposes its dependencies via the static {@link getSubscribedServices} method.
+ * >>> Suggested as a lightweight alternative for heavyweight proxies from ocramius/proxy-manager.
+ *
+ * The getSubscribedServices method returns an array of service types required by such instances,
+ * optionally keyed by the service names used internally.
+ *
+ * The injected service locators SHOULD NOT allow access to any other services not specified by the method.
+ *
+ * It is expected that ServiceSubscriber instances consume PSR-11-based service locators internally.
+ * This interface does not dictate any injection method for these service locators, although constructor
+ * injection is recommended.
+ */
+interface ServiceSubscriberInterface
+{
+    /**
+     * Lazy instantiate heavy dependencies on-demand
+     * Returns an array of service types required by such instances, optionally keyed by the service names used internally.
+     *
+     *  * ['logger' => Psr\Log\LoggerInterface::class] means the objects use the "logger" name
+     *    internally to fetch a service which must implement Psr\Log\LoggerInterface.
+     *  * ['Psr\Log\LoggerInterface'] is a shortcut for
+     *  * ['Psr\Log\LoggerInterface' => 'Psr\Log\LoggerInterface']
+     *
+     * @return array The required service types, optionally keyed by service names
+     */
+    public static function getSubscribedServices() : array;
+}

--- a/tests/IntegrationTest/Definitions/ServiceLocatorDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/ServiceLocatorDefinitionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\IntegrationTest\Definitions;
+
+use DI\ContainerBuilder;
+use DI\ServiceLocator;
+use DI\Test\IntegrationTest\BaseContainerTest;
+use function DI\autowire;
+
+/**
+ * Test service locator definitions.
+ */
+class ServiceLocatorDefinitionTest extends BaseContainerTest
+{
+    /**
+     * @dataProvider provideContainer
+     */
+    public function test_service_locator(ContainerBuilder $builder)
+    {
+        $builder->addDefinitions([
+            ServiceLocatorDefinitionTest\TestClass::class => autowire()
+        ]);
+        $container = $builder->build();
+
+        self::assertEntryIsCompiled($container, ServiceLocatorDefinitionTest\TestClass::class);
+
+        $instance = $container->get(ServiceLocatorDefinitionTest\TestClass::class);
+        $this->assertInstanceOf(ServiceLocator::class, $instance->serviceLocator);
+        $this->assertEquals(ServiceLocatorDefinitionTest\TestClass::class, $instance->serviceLocator->getSubscriber());
+        $this->assertEquals(['foo' => 'foo'], $instance->serviceLocator->getServices());
+    }
+}
+
+namespace DI\Test\IntegrationTest\Definitions\ServiceLocatorDefinitionTest;
+
+use DI\ServiceLocator;
+use DI\ServiceSubscriberInterface;
+
+class TestClass implements ServiceSubscriberInterface
+{
+    public $serviceLocator;
+
+    public function __construct(ServiceLocator $serviceLocator)
+    {
+        $this->serviceLocator = $serviceLocator;
+    }
+
+    public static function getSubscribedServices(): array
+    {
+        return ['foo'];
+    }
+}

--- a/tests/IntegrationTest/ServiceLocatorTest.php
+++ b/tests/IntegrationTest/ServiceLocatorTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\IntegrationTest;
+
+use DI\ContainerBuilder;
+use function DI\autowire;
+use DI\ServiceLocatorRepository;
+
+/**
+ * Test service locators for service subscribers.
+ */
+class ServiceLocatorTest extends BaseContainerTest
+{
+    /**
+     * @dataProvider provideContainer
+     */
+    public function testServiceLocator(ContainerBuilder $builder)
+    {
+        $builder->addDefinitions([
+            'foo' => 'value of foo',
+            'baz' => 'baz',
+        ]);
+
+        $container = $builder->build();
+        $instance = $container->get(ServiceLocatorTest\ServiceSubscriber::class);
+        $this->assertEquals('value of foo', $instance->getFoo());
+        $this->assertEquals('baz', $instance->getBar());
+        $this->assertInstanceOf(ServiceLocatorTest\SomeService::class, $instance->getClass());
+    }
+
+    /**
+     * @dataProvider provideContainer
+     * @expectedException \DI\NotFoundException
+     * @expectedExceptionMessage Service 'baz' is not defined.
+     */
+    public function testServiceLocatorThrowsForInvalidService(ContainerBuilder $builder)
+    {
+        $builder->addDefinitions([
+            'baz' => 'baz',
+        ]);
+
+        $container = $builder->build();
+        $instance = $container->get(ServiceLocatorTest\ServiceSubscriber::class);
+        $instance->getInvalid();
+    }
+
+    /**
+     * @dataProvider provideContainer
+     */
+    public function testServicesLazyResolve(ContainerBuilder $builder)
+    {
+        $container = $builder->build();
+
+        // services should not be resolved on instantiation of a subscriber class
+        $instance = $container->get(ServiceLocatorTest\ServiceSubscriber::class);
+        $this->assertNotContains(ServiceLocatorTest\SomeService::class, $container->getKnownEntryNames());
+
+        // resolve on demand
+        $instance->getClass();
+        $this->assertContains(ServiceLocatorTest\SomeService::class, $container->getKnownEntryNames());
+    }
+
+    /**
+     * @dataProvider provideContainer
+     */
+    public function testOverrideService(ContainerBuilder $builder)
+    {
+        $builder->addDefinitions([
+            'foo' => 'foo',
+            'baz' => 'baz',
+            'anotherFoo' => 'overridden foo',
+        ]);
+        $container = $builder->build();
+        $repository = $container->get(ServiceLocatorRepository::class);
+        $repository->override(ServiceLocatorTest\ServiceSubscriber::class, 'foo', 'anotherFoo');
+
+        $instance = $container->get(ServiceLocatorTest\ServiceSubscriber::class);
+        $this->assertEquals('overridden foo', $instance->getFoo());
+    }
+
+    /**
+     * @dataProvider provideContainer
+     */
+    public function testOverrideServiceInRepositoryDefinition(ContainerBuilder $builder)
+    {
+        $builder->addDefinitions([
+            ServiceLocatorRepository::class => autowire()
+                ->method('override', ServiceLocatorTest\ServiceSubscriber::class, 'foo', 'anotherFoo'),
+            'anotherFoo' => 'overridden foo',
+        ]);
+
+        $container = $builder->build();
+
+        $instance = $container->get(ServiceLocatorTest\ServiceSubscriber::class);
+        $this->assertEquals('overridden foo', $instance->getFoo());
+    }
+
+    /**
+     * @dataProvider provideContainer
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Service 'foo' for 'DI\Test\IntegrationTest\ServiceLocatorTest\ServiceSubscriber' cannot be overridden - ServiceLocator is already created.
+     */
+    public function testCannotOverrideServiceForAlreadyInstantiatedSubscriber(ContainerBuilder $builder)
+    {
+        $container = $builder->build();
+
+        $container->get(ServiceLocatorTest\ServiceSubscriber::class);
+
+        $repository = $container->get(ServiceLocatorRepository::class);
+        $repository->override(ServiceLocatorTest\ServiceSubscriber::class, 'foo', 'anotherFoo');
+    }
+
+    /**
+     * @dataProvider provideContainer
+     */
+    public function testMultipleSubscriberInstances(ContainerBuilder $builder)
+    {
+        $container = $builder->build();
+        $instance1 = $container->make(ServiceLocatorTest\ServiceSubscriber::class);
+        $instance2 = $container->make(ServiceLocatorTest\ServiceSubscriber::class);
+
+        // different instances
+        $this->assertNotSame($instance1, $instance2);
+        // but the same service locator instance
+        $this->assertSame($instance1->getServiceLocator(), $instance2->getServiceLocator());
+        // and an instance of a service should be shared too
+        $this->assertSame($instance1->getClass(), $instance2->getClass());
+    }
+
+}
+
+namespace DI\Test\IntegrationTest\ServiceLocatorTest;
+
+use DI\ServiceLocator;
+use DI\ServiceSubscriberInterface;
+
+/**
+ * Fixture class for testing service locators
+ */
+class ServiceSubscriber implements ServiceSubscriberInterface
+{
+    /**
+     * @var ServiceLocator
+     */
+    protected $serviceLocator;
+
+    /**
+     * @param ServiceLocator $serviceLocator
+     */
+    public function __construct(ServiceLocator $serviceLocator)
+    {
+        $this->serviceLocator = $serviceLocator;
+    }
+
+    /**
+     * Lazy instantiate heavy dependencies on-demand
+     */
+    public static function getSubscribedServices(): array
+    {
+        return [
+            'foo',
+            'bar' => 'baz',
+            SomeService::class,
+        ];
+    }
+
+    public function getFoo()
+    {
+        return $this->serviceLocator->get('foo');
+    }
+
+    public function getBar()
+    {
+        return $this->serviceLocator->get('bar');
+    }
+
+    public function getClass()
+    {
+        return $this->serviceLocator->get(SomeService::class);
+    }
+
+    /**
+     * @throws \DI\NotFoundException
+     */
+    public function getInvalid()
+    {
+        return $this->serviceLocator->get('baz');
+    }
+
+    public function getServiceLocator()
+    {
+        return $this->serviceLocator;
+    }
+}
+
+class SomeService
+{
+}

--- a/tests/UnitTest/Definition/ReferenceTest.php
+++ b/tests/UnitTest/Definition/ReferenceTest.php
@@ -72,4 +72,53 @@ class ReferenceTest extends TestCase
     {
         $this->assertEquals('get(bar)', (string) new Reference('bar'));
     }
+
+    /**
+     * @test
+     */
+    public function should_have_a_requesting_name()
+    {
+        $definition = new Reference('bar', 'foo');
+        $this->assertEquals('foo', $definition->getRequestingName());
+    }
+
+    /**
+     * @test
+     */
+    public function should_be_a_service_locator_entry()
+    {
+        $definition = new Reference(Reference::$serviceLocatorClass, 'foo');
+        $this->assertTrue($definition->isServiceLocatorEntry());
+    }
+
+    /**
+     * @test
+     */
+    public function should_not_be_a_service_locator_entry()
+    {
+        $definition = new Reference('bar', 'foo');
+        $this->assertFalse($definition->isServiceLocatorEntry());
+    }
+
+    /**
+     * @test
+     * @expectedException \DI\Definition\Exception\InvalidDefinition
+     * @expectedExceptionMessage Invalid service locator definition ('bar' for 'foo')
+     */
+    public function should_throw_on_invalid_service_locator_entry()
+    {
+        $definition = new Reference('bar', 'foo');
+        $definition->getServiceLocatorDefinition();
+    }
+
+    /**
+     * @test
+     * @expectedException \DI\Definition\Exception\InvalidDefinition
+     * @expectedExceptionMessage Invalid service locator definition ('DI\ServiceLocator' for '')
+     */
+    public function should_throw_on_invalid_service_locator_entry2()
+    {
+        $definition = new Reference(Reference::$serviceLocatorClass);
+        $definition->getServiceLocatorDefinition();
+    }
 }

--- a/tests/UnitTest/Definition/ServiceLocatorDefinitionTest.php
+++ b/tests/UnitTest/Definition/ServiceLocatorDefinitionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\UnitTest\Definition;
+
+use DI\Definition\ServiceLocatorDefinition;
+use DI\ServiceLocator;
+use DI\Test\UnitTest\Fixtures\Singleton;
+use EasyMock\EasyMock;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * @covers \DI\Definition\ServiceLocatorDefinition
+ */
+class ServiceLocatorDefinitionTest extends TestCase
+{
+    use EasyMock;
+
+    /**
+     * @test
+     */
+    public function should_have_a_name_and_requesting_name()
+    {
+        $definition = new ServiceLocatorDefinition('ServiceLocator', 'subscriber');
+        $this->assertEquals('ServiceLocator', $definition->getName());
+        $definition->setName('foo');
+        $this->assertEquals('foo', $definition->getName());
+
+        $this->assertEquals('subscriber', $definition->getRequestingName());
+    }
+
+    /**
+     * @test
+     * @expectedException \DI\ServiceSubscriberException
+     * @expectedExceptionMessage The class DI\Test\UnitTest\Fixtures\Singleton does not implement ServiceSubscriberInterface.
+     */
+    public function cannot_resolve_without_proper_subscriber()
+    {
+        $container = $this->easyMock(ContainerInterface::class);
+        $definition = new ServiceLocatorDefinition(ServiceLocator::class, Singleton::class);
+
+        $this->assertFalse($definition->isResolvable($container));
+        $definition->resolve($container);
+    }
+
+    /**
+     * @test
+     */
+    public function should_cast_to_string()
+    {
+        $definition = new ServiceLocatorDefinition('bar', 'subscriber');
+        $this->assertEquals("get(bar) for 'subscriber'", (string) $definition);
+    }
+}

--- a/tests/UnitTest/Definition/Source/ReflectionBasedAutowiringTest.php
+++ b/tests/UnitTest/Definition/Source/ReflectionBasedAutowiringTest.php
@@ -35,7 +35,7 @@ class ReflectionBasedAutowiringTest extends TestCase
         $this->assertCount(1, $parameters);
 
         $param1 = $parameters[0];
-        $this->assertEquals(new Reference(AutowiringFixture::class), $param1);
+        $this->assertEquals(new Reference(AutowiringFixture::class, AutowiringFixture::class), $param1);
     }
 
     public function testConstructorInParentClass()
@@ -50,6 +50,6 @@ class ReflectionBasedAutowiringTest extends TestCase
         $this->assertCount(1, $parameters);
 
         $param1 = $parameters[0];
-        $this->assertEquals(new Reference(AutowiringFixture::class), $param1);
+        $this->assertEquals(new Reference(AutowiringFixture::class, AutowiringFixtureChild::class), $param1);
     }
 }

--- a/tests/UnitTest/ServiceLocator/ServiceLocatorRepositoryTest.php
+++ b/tests/UnitTest/ServiceLocator/ServiceLocatorRepositoryTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\UnitTest;
+
+use DI\ContainerBuilder;
+use DI\ServiceLocator;
+use DI\ServiceLocatorRepository;
+use EasyMock\EasyMock;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for ServiceLocatorRepository.
+ *
+ * @covers \DI\ServiceLocatorRepository
+ */
+class ServiceLocatorRepositoryTest extends TestCase
+{
+    use EasyMock;
+
+    public function testCreateServiceLocator()
+    {
+        $container = ContainerBuilder::buildDevContainer();
+        $repository = new ServiceLocatorRepository($container);
+
+        $services = ['SomeServiceClass'];
+        $expectedServices = ['SomeServiceClass' => 'SomeServiceClass'];
+
+        $serviceLocator = $repository->create('test', $services);
+
+        $this->assertEquals('test', $serviceLocator->getSubscriber());
+        $this->assertEquals($expectedServices, $serviceLocator->getServices());
+    }
+
+    /**
+     * @expectedException \DI\NotFoundException
+     * @expectedExceptionMessage Service locator for entry 'something' is not initialized.
+     */
+    public function testServiceLocatorNotCreated()
+    {
+        $container = ContainerBuilder::buildDevContainer();
+        $repository = new ServiceLocatorRepository($container);
+        $repository->get('something');
+    }
+
+    public function testGetServiceLocator()
+    {
+        $container = ContainerBuilder::buildDevContainer();
+        $repository = new ServiceLocatorRepository($container);
+        $repository->create('test');
+
+        $this->assertInstanceOf(ServiceLocator::class, $repository->get('test'));
+    }
+
+    public function testHasServiceLocator()
+    {
+        $container = ContainerBuilder::buildDevContainer();
+        $repository = new ServiceLocatorRepository($container);
+        $repository->create('test');
+
+        $this->assertTrue($repository->has('test'));
+        $this->assertFalse($repository->has('something-else'));
+    }
+
+    public function testOverrideService()
+    {
+        $container = ContainerBuilder::buildDevContainer();
+        $repository = new ServiceLocatorRepository($container);
+        $repository->override('test', 'foo');
+        $repository->override('test', 'bar', 'baz');
+
+        $locator = $repository->create('test');
+        $this->assertEquals(['foo' => 'foo', 'bar' => 'baz'], $locator->getServices());
+    }
+
+    public function testCanCreateMultipleWithSameServices()
+    {
+        $container = ContainerBuilder::buildDevContainer();
+        $repository = new ServiceLocatorRepository($container);
+        $locator1 = $repository->create('test', ['foo']);
+        $locator2 = $repository->create('test', ['foo']);
+
+        // same instance
+        $this->assertSame($locator1, $locator2);
+
+        $repository->override('test2', 'bar', 'baz');
+        $locator3 = $repository->create('test2');
+        $locator4 = $repository->create('test2');
+        $this->assertSame($locator3, $locator4);
+
+        // still same services, because that matches the initial override
+        $locator5 = $repository->create('test2', ['bar' => 'baz']);
+        $this->assertSame($locator3, $locator5);
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage ServiceLocator for 'test' cannot be recreated with different services.
+     */
+    public function testCannotCreateMultipleWithDifferentServices()
+    {
+        $container = ContainerBuilder::buildDevContainer();
+        $repository = new ServiceLocatorRepository($container);
+
+        $repository->create('test', ['foo']);
+        $repository->create('test', ['foo2']);
+    }
+}

--- a/tests/UnitTest/ServiceLocator/ServiceLocatorTest.php
+++ b/tests/UnitTest/ServiceLocator/ServiceLocatorTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\UnitTest;
+
+use DI\ContainerBuilder;
+use DI\ServiceLocator;
+use DI\Test\UnitTest\Fixtures\Singleton;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for ServiceLocator.
+ *
+ * @covers \DI\ServiceLocator
+ */
+class ServiceLocatorTest extends TestCase
+{
+    public function testInstantiation()
+    {
+        $container = ContainerBuilder::buildDevContainer();
+
+        $services = [
+            'foo' => 'bar',
+            'baz',
+        ];
+        $serviceLocator = new ServiceLocator($container, $services, 'test');
+
+        $this->assertEquals([
+            'foo' => 'bar',
+            'baz' => 'baz',
+        ], $serviceLocator->getServices());
+        $this->assertEquals('test', $serviceLocator->getSubscriber());
+    }
+
+    /**
+     * @expectedException \DI\NotFoundException
+     * @expectedExceptionMessage Service 'something' is not defined.
+     */
+    public function testServiceNotDefined()
+    {
+        $container = ContainerBuilder::buildDevContainer();
+        $serviceLocator = new ServiceLocator($container, [], 'test');
+        $serviceLocator->get('something');
+    }
+
+    public function testGetService()
+    {
+        $services = [
+            'stdClass',
+            'service' => Singleton::class,
+        ];
+        $services2 = [
+            Singleton::class,
+        ];
+
+        $container = ContainerBuilder::buildDevContainer();
+        $serviceLocator = new ServiceLocator($container, $services, 'test');
+        $serviceLocator2 = new ServiceLocator($container, $services2, 'test2');
+
+        $this->assertInstanceOf('stdClass', $serviceLocator->get('stdClass'));
+
+        $service1 = $serviceLocator->get('service');
+        $this->assertInstanceOf(Singleton::class, $service1);
+
+        $service2 = $serviceLocator2->get(Singleton::class);
+        $this->assertInstanceOf(Singleton::class, $service2);
+
+        // it should be the same instances shared from the container
+        $this->assertSame($service1, $service2);
+    }
+
+    public function testHasService()
+    {
+        $services = [
+            'service' => Singleton::class,
+        ];
+
+        $container = ContainerBuilder::buildDevContainer();
+        $serviceLocator = new ServiceLocator($container, $services, 'test');
+
+        $this->assertTrue($serviceLocator->has('service'));
+        $this->assertFalse($serviceLocator->has(Singleton::class));
+    }
+}


### PR DESCRIPTION
ServiceLocator
- Serving "lazy" dependencies for classes using ServiceSubscriberInterface.
- A ServiceSubscriber exposes its dependencies via static getSubscribedServices() method.
- A ServiceLocator instance could then be injected into a class via constructor or a property - the instance would be already configured with dependences read from getSubscribedServices(), but the dependences won't be instantiated until first get - that's how "laziness" is introduced
- DI\Definition\Reference checks if it's a ServiceLocator entry by comparing its name with DI\Definition\Reference::$serviceLocatorClass
- Reference definitions are passed with additional parameter - $requestingName which generally points to name of the class which implements ServiceSubscriberInterface - to resolve ServiceLocator for that class
- Suggested as a lightweight alternative for heavyweight proxies from ocramius/proxy-manager

note:
- it's based on changes from PHP-DI/PHP-DI#662 (so commit 59a2216 is included here as well) - since there is second argument passed to `Reference` constructor, to also cover `AnnotationBasedAutowiring::readConstructor()` method, which was introduced in that PR

Usage:
```php
class MyClass implements ServiceSubscriberInterface
{
    /**
     * @var ServiceLocator
     */
    protected $serviceLocator;

    /**
     * @param ServiceLocator $serviceLocator
     */
    public function __construct(ServiceLocator $serviceLocator)
    {
        $this->serviceLocator = $serviceLocator;
    }

    /**
     * Lazy instantiate heavy dependencies on-demand
     */
    public static function getSubscribedServices(): array
    {
        return [
            SomeClass::class,
            'heavyDependency' => HeavyService::class,
        ];
    }

    public function doOperation()
    {
        $someClass = $this->serviceLocator->get(SomeClass::class);
        return $someClass->doSomething();
    }

    public function getSomethingFromThatHeavyDependency()
    {
        // this method may be rarely used, and it might be good idea to skip resolving the dependency every time during instantiation for performance reasons
        return $this->serviceLocator->get('heavyDependency')->getSomething();
    }
}

```

_[from ovos/PHP-DI#7]_