### PR TITLE
#674 Special interpretation of `\DI\value` in `\DI\Container::set`

### DIFF
--- a/doc/container.md
+++ b/doc/container.md
@@ -30,6 +30,10 @@ You can set entries directly on the container:
 ```php
 $container->set('foo', 'bar');
 $container->set('MyInterface', \DI\create('MyClass'));
+
+// Use \DI\value if you need to set a closure as raw value,
+// because closures are interpreted as factories by default
+$container->set('myClosure', \DI\value(function() { /* ... */ }));
 ```
 
 However it is recommended to use definition files. See the [definition documentation](definition.md).

--- a/src/Container.php
+++ b/src/Container.php
@@ -16,6 +16,7 @@ use DI\Definition\Source\DefinitionArray;
 use DI\Definition\Source\MutableDefinitionSource;
 use DI\Definition\Source\ReflectionBasedAutowiring;
 use DI\Definition\Source\SourceChain;
+use DI\Definition\ValueDefinition;
 use DI\Invoker\DefinitionParameterResolver;
 use DI\Proxy\ProxyFactory;
 use InvalidArgumentException;
@@ -282,7 +283,9 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
             $value = new FactoryDefinition($name, $value);
         }
 
-        if ($value instanceof Definition) {
+        if ($value instanceof ValueDefinition) {
+            $this->resolvedEntries[$name] = $value->getValue();
+        } elseif ($value instanceof Definition) {
             $value->setName($name);
             $this->setDefinition($name, $value);
         } else {

--- a/tests/IntegrationTest/ContainerSetTest.php
+++ b/tests/IntegrationTest/ContainerSetTest.php
@@ -7,6 +7,7 @@ namespace DI\Test\IntegrationTest;
 use DI\ContainerBuilder;
 use function DI\create;
 use function DI\get;
+use function DI\value;
 
 /**
  * Tests the set() method from the container.
@@ -56,6 +57,28 @@ class ContainerSetTest extends BaseContainerTest
         $container->set('foo', 'hello');
 
         $this->assertSame('hello', $container->get('foo'));
+    }
+
+    /**
+     * @see https://github.com/PHP-DI/PHP-DI/issues/674
+     * @test
+     * @dataProvider provideContainer
+     */
+    public function value_definitions_are_interpreted_as_raw_values(ContainerBuilder $builder)
+    {
+        $container = $builder->build();
+
+        $foo = 'foo';
+        $bar = new ContainerSetTest\Dummy();
+        $baz = function() {};
+
+        $container->set('foo', value($foo));
+        $container->set('bar', value($bar));
+        $container->set('baz', value($baz));
+
+        $this->assertSame($foo, $container->get('foo'));
+        $this->assertSame($bar, $container->get('bar'));
+        $this->assertSame($baz, $container->get('baz'));
     }
 
     /**


### PR DESCRIPTION
This fixes #674

`\DI\value` now can be used in `\DI\Container::set` to set raw values. This is useful when you need to set a `Closure` as raw value because by default `Closure`s are interpreted as factories:

```
$container->set('foo', function() { return 'bar' }));
$container->get('foo'); // returns 'bar'

$container->set('foo', \DI\value(function() { return 'bar' })));
$container->get('foo'); // returns Closure
```
