### PR TITLE
Make compiled container (almost) idempotent

### DIFF
--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -52,12 +52,12 @@ class Compiler
      * @var int
      */
     private $subEntryCounter;
-    
+
     /**
      * @var int
      */
     private $methodMappingCounter;
-    
+
     /**
      * Map of entry names to method names.
      *

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -49,11 +49,23 @@ class Compiler
     private $entriesToCompile;
 
     /**
+     * Progressive counter for definitions.
+     *
+     * Each key in $entriesToCompile is defined as 'SubEntry' + counter
+     * and each definition has always the same key in the CompiledContainer
+     * if PHP-DI configuration does not change
+     *
      * @var int
      */
     private $subEntryCounter;
 
     /**
+     * Progressive counter for CompiledContainer get methods
+     *
+     * Each CompiledContainer method name is defined as 'get' + counter
+     * and remains the same after each recompilation
+     * if PHP-DI configuration does not change
+     *
      * @var int
      */
     private $methodMappingCounter;
@@ -175,7 +187,7 @@ class Compiler
     private function compileDefinition(string $entryName, Definition $definition) : string
     {
         // Generate a unique method name
-        $methodName = 'get' . sprintf('%022d', ++$this->methodMappingCounter);
+        $methodName = 'get' . (++$this->methodMappingCounter);
         $this->entryToMethodMapping[$entryName] = $methodName;
 
         switch (true) {
@@ -287,7 +299,7 @@ PHP;
 
         if ($value instanceof Definition) {
             // Give it an arbitrary unique name
-            $subEntryName = 'subEntry' . sprintf('%013d', ++$this->subEntryCounter);
+            $subEntryName = 'subEntry' . (++$this->subEntryCounter);
             // Compile the sub-definition in another method
             $methodName = $this->compileDefinition($subEntryName, $value);
             // The value is now a method call to that method (which returns the value)

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -53,18 +53,18 @@ class Compiler
      *
      * Each key in $entriesToCompile is defined as 'SubEntry' + counter
      * and each definition has always the same key in the CompiledContainer
-     * if PHP-DI configuration does not change
+     * if PHP-DI configuration does not change.
      *
      * @var int
      */
     private $subEntryCounter;
 
     /**
-     * Progressive counter for CompiledContainer get methods
+     * Progressive counter for CompiledContainer get methods.
      *
      * Each CompiledContainer method name is defined as 'get' + counter
      * and remains the same after each recompilation
-     * if PHP-DI configuration does not change
+     * if PHP-DI configuration does not change.
      *
      * @var int
      */

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -49,6 +49,16 @@ class Compiler
     private $entriesToCompile;
 
     /**
+     * @var int
+     */
+    private $subEntryCounter;
+    
+    /**
+     * @var int
+     */
+    private $methodMappingCounter;
+    
+    /**
      * Map of entry names to method names.
      *
      * @var string[]
@@ -165,7 +175,7 @@ class Compiler
     private function compileDefinition(string $entryName, Definition $definition) : string
     {
         // Generate a unique method name
-        $methodName = str_replace('.', '', uniqid('get', true));
+        $methodName = 'get' . sprintf('%022d', ++$this->$methodMappingCounter);
         $this->entryToMethodMapping[$entryName] = $methodName;
 
         switch (true) {
@@ -277,7 +287,7 @@ PHP;
 
         if ($value instanceof Definition) {
             // Give it an arbitrary unique name
-            $subEntryName = uniqid('SubEntry');
+            $subEntryName = 'subEntry' . sprintf('%013d', ++$this->$subEntryCounter);
             // Compile the sub-definition in another method
             $methodName = $this->compileDefinition($subEntryName, $value);
             // The value is now a method call to that method (which returns the value)

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -175,7 +175,7 @@ class Compiler
     private function compileDefinition(string $entryName, Definition $definition) : string
     {
         // Generate a unique method name
-        $methodName = 'get' . sprintf('%022d', ++$this->$methodMappingCounter);
+        $methodName = 'get' . sprintf('%022d', ++$this->methodMappingCounter);
         $this->entryToMethodMapping[$entryName] = $methodName;
 
         switch (true) {
@@ -287,7 +287,7 @@ PHP;
 
         if ($value instanceof Definition) {
             // Give it an arbitrary unique name
-            $subEntryName = 'subEntry' . sprintf('%013d', ++$this->$subEntryCounter);
+            $subEntryName = 'subEntry' . sprintf('%013d', ++$this->subEntryCounter);
             // Compile the sub-definition in another method
             $methodName = $this->compileDefinition($subEntryName, $value);
             // The value is now a method call to that method (which returns the value)


### PR DESCRIPTION
Using a progressive counter for mapped methods/sub entries, container recompilation produces always the same result if definitions do not change.
It's not fully idempotent because changing definitions order leads to a different container, even if functionally unchanged.
Partially fixes #604