### PR TITLE
SourceCache: namespacing cache keys

### DIFF
--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -101,6 +101,11 @@ class ContainerBuilder
     private $sourceCache = false;
 
     /**
+     * @var string
+     */
+    protected $sourceCacheNamespace;
+
+    /**
      * Build a container configured for the dev environment.
      */
     public static function buildDevContainer() : Container
@@ -155,7 +160,7 @@ class ContainerBuilder
                 throw new \Exception('APCu is not enabled, PHP-DI cannot use it as a cache');
             }
             // Wrap the source with the cache decorator
-            $source = new SourceCache($source);
+            $source = new SourceCache($source, $this->sourceCacheNamespace);
         }
 
         $proxyFactory = new ProxyFactory(
@@ -350,13 +355,15 @@ class ContainerBuilder
      *
      * @see http://php-di.org/doc/performances.html
      *
+     * @param string $cacheNamespace use unique namespace per container when sharing a single APC memory pool to prevent cache collisions
      * @return $this
      */
-    public function enableDefinitionCache() : self
+    public function enableDefinitionCache(string $cacheNamespace = '') : self
     {
         $this->ensureNotLocked();
 
         $this->sourceCache = true;
+        $this->sourceCacheNamespace = $cacheNamespace;
 
         return $this;
     }

--- a/tests/UnitTest/ContainerBuilderTest.php
+++ b/tests/UnitTest/ContainerBuilderTest.php
@@ -61,6 +61,28 @@ class ContainerBuilderTest extends TestCase
     /**
      * @test
      */
+    public function should_allow_to_configure_a_cache_with_a_namespace()
+    {
+        if (! SourceCache::isSupported()) {
+            $this->markTestSkipped('APCu extension is required');
+            return;
+        }
+
+        $namespace = 'staging';
+        $builder = new ContainerBuilder(FakeContainer::class);
+        $builder->enableDefinitionCache($namespace);
+
+        /** @var FakeContainer $container */
+        $container = $builder->build();
+        $source = $container->definitionSource;
+
+        $this->assertInstanceOf(SourceCache::class, $source);
+        $this->assertSame($source->getCacheKey('foo'), SourceCache::CACHE_KEY . $namespace . 'foo');
+    }
+
+    /**
+     * @test
+     */
     public function the_container_should_not_be_wrapped_by_default()
     {
         $builder = new ContainerBuilder(FakeContainer::class);

--- a/tests/UnitTest/Definition/Source/SourceCacheTest.php
+++ b/tests/UnitTest/Definition/Source/SourceCacheTest.php
@@ -90,6 +90,16 @@ class SourceCacheTest extends TestCase
         self::assertSame($definition, $source->getDefinition('foo'));
     }
 
+    /**
+     * @test
+     */
+    public function should_use_namespaced_cache_keys()
+    {
+        $namespace = 'staging';
+        $source = new SourceCache(new DefinitionArray, $namespace);
+        self::assertSame($source->getCacheKey('foo'), SourceCache::CACHE_KEY . $namespace . 'foo');
+    }
+
     private static function assertSavedInCache(string $definitionName, $expectedValue)
     {
         $definition = apcu_fetch(SourceCache::CACHE_KEY . $definitionName);


### PR DESCRIPTION
Prevent cache collisions when sharing a single APC memory pool between multiple DI containers