### PR TITLE
Upgrade PHPStan to v0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
 script:
   - if [[ $(phpenv version-name) == '7.2' ]]; then vendor/bin/phpunit --coverage-clover clover.xml ; fi
   - if [[ $(phpenv version-name) != '7.2' ]]; then vendor/bin/phpunit ; fi
-  - if [[ $(phpenv version-name) == '7.2' ]]; then vendor/bin/phpstan analyse -l 5 -c phpstan.neon src ; fi
+  - if [[ $(phpenv version-name) == '7.3' ]]; then vendor/bin/phpstan analyse -l 5 -c phpstan.neon src ; fi
 
 after_script:
   - if [[ $(phpenv version-name) == '7.2' ]]; then php vendor/bin/coveralls -v ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
 script:
   - if [[ $(phpenv version-name) == '7.2' ]]; then vendor/bin/phpunit --coverage-clover clover.xml ; fi
   - if [[ $(phpenv version-name) != '7.2' ]]; then vendor/bin/phpunit ; fi
-  - if [[ $(phpenv version-name) == '7.2' ]]; then vendor/bin/phpstan analyse -l 6 -c phpstan.neon src ; fi
+  - if [[ $(phpenv version-name) == '7.2' ]]; then vendor/bin/phpstan analyse -l 5 -c phpstan.neon src ; fi
 
 after_script:
   - if [[ $(phpenv version-name) == '7.2' ]]; then php vendor/bin/coveralls -v ; fi

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "scripts": {
         "test": "phpunit",
         "format-code": "php-cs-fixer fix --allow-risky=yes",
-        "phpstan": "phpstan analyse -l 6 -c phpstan.neon src"
+        "phpstan": "phpstan analyse -l 5 -c phpstan.neon src"
     },
     "require": {
         "php": ">=7.2.0",
@@ -38,7 +38,7 @@
         "doctrine/annotations": "~1.2",
         "ocramius/proxy-manager": "~2.0.2",
         "friendsofphp/php-cs-fixer": "^2.4",
-        "phpstan/phpstan": "^0.9.2"
+        "phpstan/phpstan": "^0.12"
     },
     "provide": {
         "psr/container-implementation": "^1.0"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,62 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			count: 1
+			path: src\CompiledContainer.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: src\CompiledContainer.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 2
+			path: src\Compiler\Compiler.php
+
+		-
+			message: "#^If condition is always false\\.$#"
+			count: 1
+			path: src\Compiler\Compiler.php
+
+		-
+			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			count: 2
+			path: src\Container.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: src\Container.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: src\ContainerBuilder.php
+
+		-
+			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			count: 1
+			path: src\ContainerBuilder.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: src\Definition\ArrayDefinitionExtension.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition \\(DI\\\\Definition\\\\InstanceDefinition\\) of method DI\\\\Definition\\\\Resolver\\\\InstanceInjector\\:\\:resolve\\(\\) should be compatible with parameter \\$definition \\(DI\\\\Definition\\\\ObjectDefinition\\) of method DI\\\\Definition\\\\Resolver\\\\ObjectCreator\\:\\:resolve\\(\\)$#"
+			count: 1
+			path: src\Definition\Resolver\InstanceInjector.php
+
+		-
+			message: "#^Instanceof between DI\\\\Definition\\\\Definition and DI\\\\Definition\\\\AutowireDefinition will always evaluate to false\\.$#"
+			count: 1
+			path: src\Definition\Source\SourceCache.php
+
+		-
+			message: "#^Parameter \\#1 \\$autoload_function of function spl_autoload_register expects callable\\(string\\)\\: void, ProxyManager\\\\Autoloader\\\\AutoloaderInterface given\\.$#"
+			count: 1
+			path: src\Proxy\ProxyFactory.php
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,11 @@
+includes:
+	- phpstan-baseline.neon
+
 parameters:
 	excludes_analyse:
-		- %rootDir%/../../../src/Compiler/Template.php
+		- src/Compiler/Template.php
 	ignoreErrors:
 		- '#Access to undefined constant DI\\CompiledContainer::METHOD_MAPPING.#'
 		- '#Function apcu_.* not found.#'
 	reportUnmatchedIgnoredErrors: false
+	inferPrivatePropertyTypeFromConstructor: true


### PR DESCRIPTION
Using PHPStan's new `basline` feature, we're able to upgrade to `v0.12` right now and fix the 14 new errors later, as explained in the [first use case](https://medium.com/@ondrejmirtes/phpstans-baseline-feature-lets-you-hold-new-code-to-a-higher-standard-e77d815a5dff#fb25) of the [introduction article](https://medium.com/@ondrejmirtes/phpstans-baseline-feature-lets-you-hold-new-code-to-a-higher-standard-e77d815a5dff) of the baseline feature.

I also decreased the level from `6` to `5`, because `v0.12` introduced a [new level](https://medium.com/@ondrejmirtes/phpstan-0-12-released-f1a88036535d#1d21) that _checks for missing typehints_ which pushed previous level 6 to be level 7 now.
This new level `6` raises ~150 errors, so I think we should skip it for now.