### PR TITLE
Add autowiring-support for PHP7.4 typed properties

### DIFF
--- a/tests/UnitTest/Definition/Source/AnnotationBasedAutowiringTest.php
+++ b/tests/UnitTest/Definition/Source/AnnotationBasedAutowiringTest.php
@@ -16,6 +16,8 @@ use DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixture3;
 use DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixture4;
 use DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixture5;
 use DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixtureChild;
+use DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixtureScalarTypedProperty;
+use DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixtureTypedProperties;
 use DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationInjectableFixture;
 use PHPUnit\Framework\TestCase;
 
@@ -61,6 +63,30 @@ class AnnotationBasedAutowiringTest extends TestCase
         $this->expectException('DI\Definition\Exception\InvalidAnnotation');
         $this->expectExceptionMessage('@Inject found on property DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixture4::property but unable to guess what to inject, use a @var annotation');
         (new AnnotationBasedAutowiring)->autowire(AnnotationFixture4::class);
+    }
+
+    public function testTypedProperty()
+    {
+        if (PHP_VERSION_ID < 70400) {
+            $this->markTestSkipped('Typed properties support requires PHP7.4');
+        }
+
+        $definition = (new AnnotationBasedAutowiring)->autowire(AnnotationFixtureTypedProperties::class);
+
+        $this->assertNotHasPropertyInjection($definition, 'typeAndNoInject');
+        $this->assertHasPropertyInjection($definition, 'typedAndInject', AnnotationFixture2::class);
+        $this->assertHasPropertyInjection($definition, 'typedAndVar', AnnotationFixture3::class);
+        $this->assertHasPropertyInjection($definition, 'typedAndNamed', 'name');
+    }
+
+    public function testScalarTypedPropertiesFail()
+    {
+        if (PHP_VERSION_ID < 70400) {
+            $this->markTestSkipped('Typed properties support requires PHP7.4');
+        }
+
+        $this->expectException(\DI\Definition\Exception\InvalidAnnotation::class);
+        (new AnnotationBasedAutowiring)->autowire(AnnotationFixtureScalarTypedProperty::class);
     }
 
     public function testConstructor()
@@ -254,11 +280,21 @@ class AnnotationBasedAutowiringTest extends TestCase
         return null;
     }
 
-    private function assertHasPropertyInjection(ObjectDefinition $definition, $propertyName)
+    private function assertHasPropertyInjection(ObjectDefinition $definition, $propertyName, ?string $expectedType = null)
     {
         $propertyInjections = $definition->getPropertyInjections();
         foreach ($propertyInjections as $propertyInjection) {
             if ($propertyInjection->getPropertyName() === $propertyName) {
+
+                if ($expectedType !== null) {
+                    $this->assertInstanceOf(Reference::class, $propertyInjection->getValue());
+                    $this->assertEquals(
+                        $expectedType,
+                        $propertyInjection->getValue()->getTargetEntryName(),
+                        'Property injected with the right type'
+                    );
+                }
+
                 return;
             }
         }

--- a/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixtureScalarTypedProperty.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixtureScalarTypedProperty.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\UnitTest\Definition\Source\Fixtures;
+
+class AnnotationFixtureScalarTypedProperty
+{
+    /**
+     * @Inject
+     */
+    protected int $scalarTypeAndInject;
+}

--- a/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixtureTypedProperties.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixtureTypedProperties.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\UnitTest\Definition\Source\Fixtures;
+
+class AnnotationFixtureTypedProperties
+{
+    protected AnnotationFixture2 $typedButNoInject;
+
+    /**
+     * @Inject
+     */
+    protected AnnotationFixture2 $typedAndInject;
+
+    /**
+     * @Inject
+     * @var AnnotationFixture3
+     */
+    protected AnnotationFixture2 $typedAndVar;
+
+    /**
+     * @Inject("name")
+     */
+    protected AnnotationFixture2 $typedAndNamed;
+}


### PR DESCRIPTION
The current implementation prioritizes `@var` and the `name` property of the `@Inject` annotation over the type of the property. This allows to still inject custom-named entries into the properties even in the presence of types.

Fixes #707 