### PR TITLE
Make `injectOn` use the definition cache

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -240,7 +240,14 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
             return $instance;
         }
 
-        $objectDefinition = $this->definitionSource->getDefinition(get_class($instance));
+        $className = get_class($instance);
+
+        // If the class is anonymous don't cache its definition
+        // Checking for anonymous classes is cleaner via Reflection but also less slower
+        $objectDefinition = false !== strpos($className, '@anonymous')
+            ? $this->definitionSource->getDefinition($className)
+            : $this->getDefinition($className);
+
         if (! $objectDefinition instanceof ObjectDefinition) {
             return $instance;
         }

--- a/tests/IntegrationTest/ContainerInjectOnTest.php
+++ b/tests/IntegrationTest/ContainerInjectOnTest.php
@@ -155,4 +155,35 @@ class ContainerInjectOnTest extends BaseContainerTest
         $proxy = $obj->method4Param1;
         self::assertFalse($proxy->isProxyInitialized());
     }
+
+    /**
+     * @dataProvider provideContainer
+     */
+    public function testInjectOnAnonClass(ContainerBuilder $builder)
+    {
+        $obj = new class {
+            /**
+             * @Inject
+             * @var Class2
+             */
+            public $property;
+
+            public $methodParam;
+
+            /**
+             * @Inject
+             */
+            public function setParam(Class2 $param)
+            {
+                $this->methodParam = $param;
+            }
+        };
+
+        $builder->useAnnotations(true);
+        $container = $builder->build();
+        $container->injectOn($obj);
+
+        $this->assertInstanceOf(Class2::class, $obj->property);
+        $this->assertInstanceOf(Class2::class, $obj->methodParam);
+    }
 }


### PR DESCRIPTION
Before this change `injectOn` was not using the Container internal definition cache and insetad solely built on the optional SourceCache mechanism. This is costly for setups with a long-running processes with APCu as every `injectOn` call will lead to a full annotation and autowiring run.

This change makes `injectOn` use the definition cache for all objects of non-anonymous classes. Anonymmous objects are ignored to make sure the cache does not get overloaded with many unusable definitions. It also includes a basic test which tests for minimum compatibility of `injectOn`
with anonymous classes.

This PR is a simpler alternative to #647.