### PR TITLE
Fix issue with overriding default value of typed parameters when type is known by the container.

### DIFF
--- a/src/Definition/Resolver/ParameterResolver.php
+++ b/src/Definition/Resolver/ParameterResolver.php
@@ -7,9 +7,9 @@ namespace DI\Definition\Resolver;
 use DI\Definition\Definition;
 use DI\Definition\Exception\InvalidDefinition;
 use DI\Definition\ObjectDefinition\MethodInjection;
+use function DI\get;
 use ReflectionMethod;
 use ReflectionParameter;
-use function DI\get;
 
 /**
  * Resolves parameters for a function call.
@@ -102,6 +102,7 @@ class ParameterResolver
             ) {
                 return $this->definitionResolver->resolve($ref);
             }
+
             return $parameter->getDefaultValue();
         } catch (\ReflectionException $e) {
             throw new InvalidDefinition(sprintf(

--- a/src/Definition/Resolver/ParameterResolver.php
+++ b/src/Definition/Resolver/ParameterResolver.php
@@ -9,6 +9,7 @@ use DI\Definition\Exception\InvalidDefinition;
 use DI\Definition\ObjectDefinition\MethodInjection;
 use ReflectionMethod;
 use ReflectionParameter;
+use function DI\get;
 
 /**
  * Resolves parameters for a function call.
@@ -94,6 +95,13 @@ class ParameterResolver
     private function getParameterDefaultValue(ReflectionParameter $parameter, ReflectionMethod $function)
     {
         try {
+            if (
+                $parameter->hasType()
+                && (($class = $parameter->getClass())) !== null
+                && $this->definitionResolver->isResolvable($ref = get($class->getName()))
+            ) {
+                return $this->definitionResolver->resolve($ref);
+            }
             return $parameter->getDefaultValue();
         } catch (\ReflectionException $e) {
             throw new InvalidDefinition(sprintf(

--- a/tests/UnitTest/Definition/Resolver/ParameterResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/ParameterResolverTest.php
@@ -1,0 +1,268 @@
+<?php
+declare(strict_types=1);
+
+namespace DI\Test\UnitTest\Definition\Resolver;
+
+use DI\Definition\Definition;
+use DI\Definition\Exception\InvalidDefinition;
+use DI\Definition\ObjectDefinition\MethodInjection;
+use DI\Definition\Reference;
+use DI\Definition\Resolver\DefinitionResolver;
+use DI\Definition\Resolver\ParameterResolver;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use function DI\get;
+
+class ParameterResolverTest extends TestCase
+{
+    /**
+     * @var ParameterResolver
+     */
+    private $sut;
+
+    /**
+     * @var MockObject
+     */
+    private $definition;
+
+    /**
+     * @var MockObject
+     */
+    private $definitionMock;
+
+    private $definitionMethod;
+
+    /**
+     * @var MockObject
+     */
+    private $reflectionMethodMock;
+
+    private $reflectionMethod;
+
+    function setUp(): void
+    {
+        $this->definition = $this->createMock(Resolver::class);
+        $this->sut = new ParameterResolver($this->definition);
+        $this->definitionMock = $this->createMock(MethodInjection::class);
+        $this->reflectionMethodMock = $this->createMock(\ReflectionMethod::class);
+    }
+
+    function testShouldReturnParametersWhenMethodIsNull()
+    {
+        $this->assertEquals([], $this->sut->resolveParameters());
+    }
+
+    function testShouldReturnEmptyArrayAndNeverCallDefinitionWhenMethodHasNoParameters()
+    {
+        $mock = $this->createMock(MethodInjection::class);
+        $mock->expects($this->never())
+            ->method('getParameters');
+        $args = $this->sut->resolveParameters($mock, null, $expected = []);
+        $this->assertSame([], $args);
+    }
+
+    function testShouldReturnEmptyArrayWhenParameterIsSetButMethodDoesNotAcceptAny()
+    {
+        $this->expectOnceAndReturn($this->definitionMock, ['foo']);
+        $this->expectOnceAndReturn($this->reflectionMethodMock, []);
+        $args = $this->sut->resolveParameters($this->definitionMock, $this->reflectionMethodMock, $expected = []);
+        $this->assertSame([], $args);
+    }
+
+    function testShouldReturnProvidedParameterInArrayWhenParameterIsSetForMethod()
+    {
+        $this->expectOnceAndReturn($this->definitionMock, ['foo']);
+        $this->expectOnceAndReturn($this->reflectionMethodMock, [new \ReflectionParameter(function ($foo) {}, 'foo')]);
+        $args = $this->sut->resolveParameters($this->definitionMock, $this->reflectionMethodMock, $expected = []);
+        $this->assertEquals(['foo'], $args);
+    }
+
+    function testShouldReturnProvidedValueInArrayWhenParameterIsSetForMethod()
+    {
+        $provided = ['foo' => 'hello'];
+        $this->expectOnceAndReturn($this->definitionMock, ['foo' => 'hello']);
+        $this->expectOnceAndReturn($this->reflectionMethodMock, [new \ReflectionParameter(function ($foo) {}, 'foo')]);
+        $args = $this->sut->resolveParameters($this->definitionMock, $this->reflectionMethodMock, $provided);
+        $this->assertEquals(['hello'], $args);
+    }
+
+    function testShouldUseValueFromMethodInjectionInArrayWhenParameterIsSetForMethod()
+    {
+        $this->expectOnceAndReturn($this->definitionMock, ['hello']);
+        $this->expectOnceAndReturn($this->reflectionMethodMock, [new \ReflectionParameter(function ($foo) {}, 'foo')]);
+        $args = $this->sut->resolveParameters($this->definitionMock, $this->reflectionMethodMock);
+        $this->assertEquals(['hello'], $args);
+    }
+
+    function testShouldSetDefaultValueWhenParameterSupportsIt()
+    {
+        $this->expectOnceAndReturn($this->definitionMock, []);
+        $this->expectOnceAndReturn($this->reflectionMethodMock, [new \ReflectionParameter(function ($param = 1) {}, 'param')]);
+        $args = $this->sut->resolveParameters($this->definitionMock, $this->reflectionMethodMock);
+        $this->assertEquals([1], $args);
+    }
+
+    function testShouldOverrideDefaultFromProvidedValuesValueWhenParameterSupportsIt()
+    {
+        $this->expectOnceAndReturn($this->definitionMock, []);
+        $this->expectOnceAndReturn($this->reflectionMethodMock, [new \ReflectionParameter(function ($param = 1) {}, 'param')]);
+        $args = $this->sut->resolveParameters($this->definitionMock, $this->reflectionMethodMock, ['param' => 34]);
+        $this->assertEquals([34], $args);
+    }
+
+    function testShouldOverrideDefaultFromInjectionValueWhenParameterSupportsIt()
+    {
+        $this->expectOnceAndReturn($this->definitionMock, [2]);
+        $this->expectOnceAndReturn($this->reflectionMethodMock, [new \ReflectionParameter(function ($param = 1) {}, 'param')]);
+        $args = $this->sut->resolveParameters($this->definitionMock, $this->reflectionMethodMock);
+        $this->assertEquals([2], $args);
+    }
+
+    function testShouldSetDefaultValueWhenComplexParameterSupportsIt()
+    {
+        $this->expectOnceAndReturn($this->definitionMock, []);
+        $this->expectOnceAndReturn($this->reflectionMethodMock, [new \ReflectionParameter(function (Resolver $param = null) {}, 'param')]);
+        $args = $this->sut->resolveParameters($this->definitionMock, $this->reflectionMethodMock);
+        $this->assertEquals([null], $args);
+    }
+
+    function testShouldNotOverrideDefaultFromBadProvidedValuesWhenComplexParameterSupportsIt()
+    {
+        $this->expectOnceAndReturn($this->definitionMock, []);
+        $this->expectOnceAndReturn($this->reflectionMethodMock, [new \ReflectionParameter(function (Resolver $param = null) {}, 'param')]);
+        $args = $this->sut->resolveParameters($this->definitionMock, $this->reflectionMethodMock, ['param1' => 34]);
+        $this->assertEquals([null], $args);
+    }
+
+    function testShouldOverrideDefaultFromInjectionValueWhenComplexParameterSupportsIt()
+    {
+        $this->expectOnceAndReturn($this->definitionMock, [new \stdClass]);
+        $this->expectOnceAndReturn($this->reflectionMethodMock, [new \ReflectionParameter(function (Resolver $param = null) {}, 'param')]);
+        $args = $this->sut->resolveParameters($this->definitionMock, $this->reflectionMethodMock);
+        $this->assertEquals([new \stdClass()], $args);
+    }
+
+    function testShouldSetDefaultValueForOptionalParameter()
+    {
+        $callable = function ($param, $optional = 1) {};
+        $this->expectOnceAndReturn($this->definitionMock, [null]);
+        $this->expectOnceAndReturn($this->reflectionMethodMock, [
+            new \ReflectionParameter($callable, 'param'),
+            new \ReflectionParameter($callable, 'optional')
+        ]);
+        $args = $this->sut->resolveParameters($this->definitionMock, $this->reflectionMethodMock);
+        $this->assertEquals([null, 1], $args);
+    }
+
+    function testShouldSetDefaultValueForTypedOptionalParameter()
+    {
+        $callable = function ($param, string $optional = '') {};
+        $this->expectOnceAndReturn($this->definitionMock, [null]);
+        $this->expectOnceAndReturn($this->reflectionMethodMock, [
+            new \ReflectionParameter($callable, 'param'),
+            new \ReflectionParameter($callable, 'optional')
+        ]);
+        $args = $this->sut->resolveParameters($this->definitionMock, $this->reflectionMethodMock);
+        $this->assertEquals([null, ''], $args);
+    }
+
+    function testShouldOverrideDefaultValueForOptionalParameter()
+    {
+        $callable = function ($param, $optional = 1) {};
+        $this->expectOnceAndReturn($this->definitionMock, [null, 4]);
+        $this->expectOnceAndReturn($this->reflectionMethodMock, [
+            new \ReflectionParameter($callable, 'param'),
+            new \ReflectionParameter($callable, 'optional')
+        ]);
+        $args = $this->sut->resolveParameters($this->definitionMock, $this->reflectionMethodMock);
+        $this->assertEquals([null, 4], $args);
+    }
+
+    function testShouldSetDefaultValueForOptionalComplexParameter()
+    {
+        $callable = function ($param, Resolver $optional = null) {};
+        $this->expectOnceAndReturn($this->definitionMock, ['test']);
+        $this->expectOnceAndReturn($this->reflectionMethodMock, [
+            new \ReflectionParameter($callable, 'param'),
+            new \ReflectionParameter($callable, 'optional')
+        ]);
+        $args = $this->sut->resolveParameters($this->definitionMock, $this->reflectionMethodMock);
+        $this->assertEquals(['test', null], $args);
+    }
+
+    function testShouldOverrideDefaultValueForOptionalComplexParameter()
+    {
+        $obj = new Resolver;
+        $callable = function ($param, Resolver $optional = null) {};
+        $this->expectOnceAndReturn($this->definitionMock, ['test', $obj]);
+        $this->expectOnceAndReturn($this->reflectionMethodMock, [
+            new \ReflectionParameter($callable, 'param'),
+            new \ReflectionParameter($callable, 'optional')
+        ]);
+        $args = $this->sut->resolveParameters($this->definitionMock, $this->reflectionMethodMock);
+        $this->assertEquals(['test', $obj], $args);
+    }
+
+    function testShouldOverrideDefaultValueFromResolverForOptionalTypedParameter()
+    {
+        $reference = get(Resolver::class);
+        $ret = new Resolver;
+        $this->definition
+            ->expects($this->once())
+            ->method('isResolvable')
+            ->with($reference)
+            ->willReturn(true);
+        $this->definition
+            ->expects($this->once())
+            ->method('resolve')
+            ->with($reference)
+            ->willReturn($ret);
+        $callable = function ($param, Resolver $optional = null) {};
+        $this->expectOnceAndReturn($this->definitionMock, [null]);
+        $this->expectOnceAndReturn($this->reflectionMethodMock, [
+            new \ReflectionParameter($callable, 'param'),
+            new \ReflectionParameter($callable, 'optional')
+        ]);
+        $args = $this->sut->resolveParameters($this->definitionMock, $this->reflectionMethodMock);
+        $this->assertEquals([null, $ret], $args);
+    }
+
+    function testShouldOverrideDefaultValueFromResolverForOptionalComplexParameter()
+    {
+        $this->definition
+            ->expects($this->never())
+            ->method('isResolvable');
+        $this->definition
+            ->expects($this->never())
+            ->method('resolve');
+        $callable = function ($param, string $optional = '') {};
+        $this->expectOnceAndReturn($this->definitionMock, [null, 'foo']);
+        $this->expectOnceAndReturn($this->reflectionMethodMock, [
+            new \ReflectionParameter($callable, 'param'),
+            new \ReflectionParameter($callable, 'optional')
+        ]);
+        $args = $this->sut->resolveParameters($this->definitionMock, $this->reflectionMethodMock);
+        $this->assertEquals([null, 'foo'], $args);
+    }
+
+    private function expectOnceAndReturn(MockObject $mock, $return)
+    {
+        $mock->expects($this->once())
+            ->method('getParameters')
+            ->willReturn($return);
+    }
+}
+
+class Resolver implements DefinitionResolver
+{
+    public $instance;
+    public function resolve(Definition $definition, array $parameters = [])
+    {
+        return $this->instance;
+    }
+
+    public function isResolvable(Definition $definition, array $parameters = []): bool
+    {
+        return true;
+    }
+}

--- a/tests/UnitTest/Definition/Resolver/ParameterResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/ParameterResolverTest.php
@@ -30,14 +30,10 @@ class ParameterResolverTest extends TestCase
      */
     private $definitionMock;
 
-    private $definitionMethod;
-
     /**
      * @var MockObject
      */
     private $reflectionMethodMock;
-
-    private $reflectionMethod;
 
     function setUp(): void
     {


### PR DESCRIPTION
This pull request will add some more unit test for ParameterResolver class and it will fix an issue with typed parameters when the container knows the specific type which is mentioned in the function parameter. In this case, ParameterResolver will fetch the type from the container instead of setting its value to the default one.

When the type is unknown by the container, it will be forced to its default value.