### PR TITLE
Add support for compilation of the short closures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "psr/container": "^1.0",
         "php-di/invoker": "^2.0",
         "php-di/phpdoc-reader": "^2.0.1",
-        "nikic/php-parser": "^2.0|^3.0|^4.0",
         "opis/closure": "^3.5"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
         "psr/container": "^1.0",
         "php-di/invoker": "^2.0",
         "php-di/phpdoc-reader": "^2.0.1",
-        "jeremeamia/superclosure": "^2.0",
-        "nikic/php-parser": "^2.0|^3.0|^4.0"
+        "nikic/php-parser": "^2.0|^3.0|^4.0",
+        "opis/closure": "^3.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -18,9 +18,7 @@ use DI\Definition\ValueDefinition;
 use DI\DependencyException;
 use DI\Proxy\ProxyFactory;
 use InvalidArgumentException;
-use PhpParser\Node\Expr\Closure;
-use SuperClosure\Analyzer\AstAnalyzer;
-use SuperClosure\Exception\ClosureAnalysisException;
+use Opis\Closure\SerializableClosure;
 
 /**
  * Compiles the container into PHP code much more optimized for performances.
@@ -365,35 +363,28 @@ PHP;
         return true;
     }
 
+    /**
+     * @throws \DI\Definition\Exception\InvalidDefinition
+     */
     private function compileClosure(\Closure $closure) : string
     {
-        $closureAnalyzer = new AstAnalyzer;
+        $wrapper = new SerializableClosure($closure);
+        $reflector = $wrapper->getReflector();
 
-        try {
-            $closureData = $closureAnalyzer->analyze($closure);
-        } catch (ClosureAnalysisException $e) {
-            if (stripos($e->getMessage(), 'Two closures were declared on the same line') !== false) {
-                throw new InvalidDefinition('Cannot compile closures when two closures are defined on the same line', 0, $e);
-            }
-
-            throw $e;
-        }
-
-        /** @var Closure $ast */
-        $ast = $closureData['ast'];
-
-        // Force all closures to be static (add the `static` keyword), i.e. they can't use
-        // $this, which makes sense since their code is copied into another class.
-        $ast->static = true;
-
-        // Check if the closure imports variables with `use`
-        if (! empty($ast->uses)) {
+        if ($reflector->getUseVariables()) {
             throw new InvalidDefinition('Cannot compile closures which import variables using the `use` keyword');
         }
 
-        $code = (new \PhpParser\PrettyPrinter\Standard)->prettyPrint([$ast]);
+        if (
+            $reflector->isBindingRequired()
+            // todo: there is a bug in opis/closure isScopeRequired()
+            // https://github.com/opis/closure/issues/52
+            || ($reflector->isScopeRequired() && $reflector->getClosureScopeClass())
+        ) {
+            throw new InvalidDefinition('Cannot compile closures which use $this or self/static/parent references');
+        }
 
-        // Trim spaces and the last `;`
+        $code = ($reflector->isStatic() ? '' : 'static ') . $reflector->getCode();
         $code = trim($code, "\t\n\r;");
 
         return $code;

--- a/tests/IntegrationTest/Definitions/FactoryDefinition/fn.inc
+++ b/tests/IntegrationTest/Definitions/FactoryDefinition/fn.inc
@@ -1,0 +1,7 @@
+<?php
+
+// This is a separated file so that it doesn't break php linter on php < 7.4
+
+return [
+    'factory' => fn () => new stdClass(),
+];


### PR DESCRIPTION
Fixes #711, #706.

It replaces jeremeamia/superclosure with opis/closure and drops nikic/php-parser dependency.

There are two problems with this:

1. looks like there is a bug regarding the detection of scope references usage – it treats `static` variable definition as a scope reference. See https://github.com/opis/closure/issues/52 for details.

2. it doesn't throw an exception on multiple closures defined on the same line. Just silently returns the code of the first one.

If anyone has free time – please create PRs in opis/closure to fix the problems.

I haven't tested this with real container definitions, so feel free to test and report issues.