### PR TITLE
Replace deprecated SimpleAnnotationReader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require-dev": {
         "phpunit/phpunit": "^8.5",
         "mnapoli/phpunit-easymock": "^1.2",
-        "doctrine/annotations": "~1.2",
+        "doctrine/annotations": "^1.10",
         "ocramius/proxy-manager": "~2.0.2",
         "friendsofphp/php-cs-fixer": "^2.4",
         "phpstan/phpstan": "^0.12"
@@ -43,7 +43,7 @@
         "psr/container-implementation": "^1.0"
     },
     "suggest": {
-        "doctrine/annotations": "Install it if you want to use annotations (version ~1.2)",
+        "doctrine/annotations": "Install it if you want to use annotations (version ^1.10)",
         "ocramius/proxy-manager": "Install it if you want to use lazy injection (version ~2.0)"
     }
 }

--- a/src/Definition/Source/AnnotationBasedAutowiring.php
+++ b/src/Definition/Source/AnnotationBasedAutowiring.php
@@ -12,6 +12,7 @@ use DI\Definition\ObjectDefinition\MethodInjection;
 use DI\Definition\ObjectDefinition\PropertyInjection;
 use DI\Definition\Reference;
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\DocParser;
 use Doctrine\Common\Annotations\Reader;
 use InvalidArgumentException;
@@ -254,6 +255,7 @@ class AnnotationBasedAutowiring implements DefinitionSource, Autowiring
         if ($this->annotationReader === null) {
             $docParser = new DocParser();
             $docParser->setIgnoreNotImportedAnnotations(true);
+            AnnotationRegistry::registerLoader('class_exists');
             $this->annotationReader = new AnnotationReader($docParser);
         }
 

--- a/src/Definition/Source/AnnotationBasedAutowiring.php
+++ b/src/Definition/Source/AnnotationBasedAutowiring.php
@@ -11,9 +11,9 @@ use DI\Definition\ObjectDefinition;
 use DI\Definition\ObjectDefinition\MethodInjection;
 use DI\Definition\ObjectDefinition\PropertyInjection;
 use DI\Definition\Reference;
-use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\DocParser;
 use Doctrine\Common\Annotations\Reader;
-use Doctrine\Common\Annotations\SimpleAnnotationReader;
 use InvalidArgumentException;
 use PhpDocReader\PhpDocReader;
 use ReflectionClass;
@@ -252,9 +252,9 @@ class AnnotationBasedAutowiring implements DefinitionSource, Autowiring
     public function getAnnotationReader()
     {
         if ($this->annotationReader === null) {
-            AnnotationRegistry::registerLoader('class_exists');
-            $this->annotationReader = new SimpleAnnotationReader();
-            $this->annotationReader->addNamespace('DI\Annotation');
+            $docParser = new DocParser();
+            $docParser->setIgnoreNotImportedAnnotations(true);
+            $this->annotationReader = new AnnotationReader($docParser);
         }
 
         return $this->annotationReader;

--- a/tests/IntegrationTest/ContainerInjectOnTest.php
+++ b/tests/IntegrationTest/ContainerInjectOnTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Test\IntegrationTest;
 
+use DI\Annotation\Inject;
 use DI\ContainerBuilder;
 use DI\Test\IntegrationTest\Fixtures\Class1;
 use DI\Test\IntegrationTest\Fixtures\Class2;

--- a/tests/PerformanceTest/composer.json
+++ b/tests/PerformanceTest/composer.json
@@ -12,7 +12,7 @@
         "psr/container": "^1.0",
         "php-di/invoker": "^2.0",
         "php-di/phpdoc-reader": "^2.0.1",
-        "doctrine/annotations": "~1.2",
+        "doctrine/annotations": "^1.10",
         "roave/better-reflection": "^1.2.0"
     }
 }

--- a/tests/UnitTest/Annotation/Fixtures/Injectable1.php
+++ b/tests/UnitTest/Annotation/Fixtures/Injectable1.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DI\Test\UnitTest\Annotation\Fixtures;
 
+use DI\Annotation\Injectable;
+
 /**
  * @Injectable
  */

--- a/tests/UnitTest/Annotation/Fixtures/Injectable2.php
+++ b/tests/UnitTest/Annotation/Fixtures/Injectable2.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DI\Test\UnitTest\Annotation\Fixtures;
 
+use DI\Annotation\Injectable;
+
 /**
  * @Injectable(lazy=true)
  */

--- a/tests/UnitTest/Annotation/Fixtures/MixedAnnotationsFixture.php
+++ b/tests/UnitTest/Annotation/Fixtures/MixedAnnotationsFixture.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Test\UnitTest\Annotation\Fixtures;
 
+use DI\Annotation\Inject;
 use Foo\Bar\SomeUnknownImportedAnnotation;
 
 class MixedAnnotationsFixture

--- a/tests/UnitTest/Annotation/InjectTest.php
+++ b/tests/UnitTest/Annotation/InjectTest.php
@@ -113,7 +113,7 @@ class InjectTest extends TestCase
     }
 
     /**
-     * Inject annotation should work even if not imported.
+     * Inject annotation without import does not work any more!
      */
     public function testNonImportedAnnotation()
     {
@@ -122,7 +122,7 @@ class InjectTest extends TestCase
         /** @var $annotation Inject */
         $annotation = $this->annotationReader->getPropertyAnnotation($property, Inject::class);
 
-        $this->assertInstanceOf(Inject::class, $annotation);
+        $this->assertNull($annotation);
     }
 
     /**

--- a/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixture3.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixture3.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DI\Test\UnitTest\Definition\Source\Fixtures;
 
+use DI\Annotation\Inject;
+
 class AnnotationFixture3
 {
     /**

--- a/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixture4.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixture4.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DI\Test\UnitTest\Definition\Source\Fixtures;
 
+use DI\Annotation\Inject;
+
 class AnnotationFixture4
 {
     /**

--- a/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixtureScalarTypedProperty.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixtureScalarTypedProperty.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DI\Test\UnitTest\Definition\Source\Fixtures;
 
+use DI\Annotation\Inject;
+
 class AnnotationFixtureScalarTypedProperty
 {
     /**

--- a/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixtureTypedProperties.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AnnotationFixtureTypedProperties.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DI\Test\UnitTest\Definition\Source\Fixtures;
 
+use DI\Annotation\Inject;
+
 class AnnotationFixtureTypedProperties
 {
     protected AnnotationFixture2 $typedButNoInject;

--- a/tests/UnitTest/Definition/Source/Fixtures/AnnotationInjectableFixture.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AnnotationInjectableFixture.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DI\Test\UnitTest\Definition\Source\Fixtures;
 
+use DI\Annotation\Injectable;
+
 /**
  * @Injectable(lazy=true)
  */

--- a/tests/UnitTest/Fixtures/Class1CircularDependencies.php
+++ b/tests/UnitTest/Fixtures/Class1CircularDependencies.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DI\Test\UnitTest\Fixtures;
 
+use DI\Annotation\Inject;
+
 /**
  * Fixture class for testing circular dependencies.
  */

--- a/tests/UnitTest/Fixtures/Class2CircularDependencies.php
+++ b/tests/UnitTest/Fixtures/Class2CircularDependencies.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DI\Test\UnitTest\Fixtures;
 
+use DI\Annotation\Inject;
+
 /**
  * Fixture class for testing circular dependencies.
  */


### PR DESCRIPTION
The `SimpleAnnotationReader` of doctrine is deprecated / removed
in future versions. See also:

https://github.com/doctrine/annotations/issues/87

It is replaced with the `AnnotationReader`.

This is a breaking change because annotations without proper
namespacing are no longer supported!

I also looked for a backwards compatible solution but I could not find one that made sense :( 

Drupal for example seems to have copied the source of the `SimpleAnnotationReader` into their own project: https://www.drupal.org/project/drupal/issues/2631202
