### PR TITLE
Make Compiler save file atomically

### DIFF
--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Compiler;
 
+use function chmod;
 use DI\Definition\ArrayDefinition;
 use DI\Definition\DecoratorDefinition;
 use DI\Definition\Definition;
@@ -17,8 +18,14 @@ use DI\Definition\StringDefinition;
 use DI\Definition\ValueDefinition;
 use DI\DependencyException;
 use DI\Proxy\ProxyFactory;
+use function dirname;
+use function file_put_contents;
 use InvalidArgumentException;
 use Opis\Closure\SerializableClosure;
+use function rename;
+use function sprintf;
+use function tempnam;
+use function unlink;
 
 /**
  * Compiles the container into PHP code much more optimized for performances.
@@ -172,9 +179,36 @@ class Compiler
         $fileContent = "<?php\n" . $fileContent;
 
         $this->createCompilationDirectory(dirname($fileName));
-        file_put_contents($fileName, $fileContent);
+        $this->writeFileAtomic($fileName, $fileContent);
 
         return $fileName;
+    }
+
+    private function writeFileAtomic(string $fileName, string $content) : int
+    {
+        $tmpFile = tempnam(dirname($fileName), 'swap-compile');
+        if ($tmpFile === false) {
+            throw new InvalidArgumentException(
+                sprintf('Error while creating temporary file in %s', dirname($fileName))
+            );
+        }
+        @chmod($tmpFile, 0666);
+
+        $written = file_put_contents($tmpFile, $content);
+        if ($written === false) {
+            @unlink($tmpFile);
+
+            throw new InvalidArgumentException(sprintf('Error while writing to %s', $tmpFile));
+        }
+
+        @chmod($tmpFile, 0666);
+        $renamed = @rename($tmpFile, $fileName);
+        @unlink($tmpFile);
+        if (!$renamed) {
+            throw new InvalidArgumentException(sprintf('Error while renaming %s to %s', $tmpFile, $fileName));
+        }
+
+        return $written;
     }
 
     /**


### PR DESCRIPTION
As of now compiled container can be broken when concurrently compile container.
This pr add saving compiled content to temporary file and then rename it to destination file.
