### PR TITLE
tempnam, suppress notice to support streams

### DIFF
--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -185,7 +185,7 @@ class Compiler
 
     private function writeFileAtomic(string $fileName, string $content) : int
     {
-        $tmpFile = tempnam(dirname($fileName), 'swap-compile');
+        $tmpFile = @tempnam(dirname($fileName), 'swap-compile');
         if ($tmpFile === false) {
             throw new InvalidArgumentException(
                 sprintf('Error while creating temporary file in %s', dirname($fileName))


### PR DESCRIPTION
From the PHP manual on tempnam function:

> Note: If PHP cannot create a file in the specified dir parameter, it falls back on the system default.

When using custom streams as compilation paths, such as using vfsStream for testing purposes, tempnam will resort to default system temp dir and will raise a the notice:

> tempnam(): file created in the system's temporary directory

This was introduced in PHP 7.1.0, more information of this can be found here: https://www.php.net/manual/en/function.tempnam.php#97086

The fix simply silences the notice because temp file creation is checked right below