### PR TITLE
Support PHP 8 attributes at the parameter level

### DIFF
--- a/doc/attributes.md
+++ b/doc/attributes.md
@@ -57,15 +57,17 @@ class Example
     private $property3;
 
     /**
-     * Attribute specifying exactly what to inject on the constructor:
+     * The constructor is of course always called, but the
+     * #[Inject] attribute can be used on a parameter
+     * to specify what to inject.
      */
-    #[Inject(['db.host', 'db.name'])]
-    public function __construct($param1, $param2)
+    public function __construct(Foo $foo, #[Inject('db.host')] $dbHost)
     {
     }
 
     /**
-     * Attribute combined with PHP types:
+     * #[Inject] tells PHP-DI to call the method.
+     * By default, PHP-DI uses the PHP types to find the service to inject:
      */
     #[Inject]
     public function method1(Foo $param)
@@ -73,10 +75,20 @@ class Example
     }
 
     /**
+     * #[Inject] can be used at the parameter level to
+     * specify what to inject.
+     * Note: #[Inject] *must be place* on the function too.
+     */
+    #[Inject]
+    public function method2(#[Inject('db.host')] $param)
+    {
+    }
+
+    /**
      * Explicit definition of the entries to inject:
      */
     #[Inject(['db.host', 'db.name'])]
-    public function method2($param1, $param2)
+    public function method3($param1, $param2)
     {
     }
 
@@ -85,7 +97,7 @@ class Example
      * (types are used for the other parameters):
      */
     #[Inject(['param2' => 'db.host'])]
-    public function method3(Foo $param1, $param2)
+    public function method4(Foo $param1, $param2)
     {
     }
 }

--- a/src/Attribute/Inject.php
+++ b/src/Attribute/Inject.php
@@ -16,7 +16,7 @@ use DI\Definition\Exception\InvalidAnnotation;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD | Attribute::TARGET_PARAMETER)]
 final class Inject
 {
     /**

--- a/src/Definition/Source/AttributeBasedAutowiring.php
+++ b/src/Definition/Source/AttributeBasedAutowiring.php
@@ -179,22 +179,10 @@ class AttributeBasedAutowiring implements DefinitionSource, Autowiring
         }
     }
 
-    /**
-     * @throws InvalidAnnotation
-     */
     private function getMethodInjection(ReflectionMethod $method) : ?MethodInjection
     {
         // Look for #[Inject] attribute
-        try {
-            $attribute = $method->getAttributes(Inject::class)[0] ?? null;
-        } catch (Throwable $e) {
-            throw new InvalidAnnotation(sprintf(
-                '#[Inject] annotation on %s::%s() is malformed. %s',
-                $method->getDeclaringClass()->getName(),
-                $method->getName(),
-                $e->getMessage()
-            ), 0, $e);
-        }
+        $attribute = $method->getAttributes(Inject::class)[0] ?? null;
 
         if ($attribute) {
             /** @var Inject $inject */
@@ -228,6 +216,14 @@ class AttributeBasedAutowiring implements DefinitionSource, Autowiring
      */
     private function getMethodParameter(int $parameterIndex, ReflectionParameter $parameter, array $annotationParameters) : ?string
     {
+        // Let's check if this parameter has an #[Inject] attribute
+        $attribute = $parameter->getAttributes(Inject::class)[0] ?? null;
+        if ($attribute) {
+            /** @var Inject $inject */
+            $inject = $attribute->newInstance();
+            return $inject->getName();
+        }
+
         // #[Inject] has definition for this parameter (by index, or by name)
         if (isset($annotationParameters[$parameterIndex])) {
             return $annotationParameters[$parameterIndex];


### PR DESCRIPTION
Here is an example:

```php
class Foo
{
    public function __construct(Foo $foo, #[Inject('db.host')] $dbHost)
    {
        // ...
    }
}