### PR TITLE
adding leading backslash to native constants

### DIFF
--- a/src/Definition/ArrayDefinition.php
+++ b/src/Definition/ArrayDefinition.php
@@ -50,7 +50,7 @@ class ArrayDefinition implements Definition
 
     public function __toString()
     {
-        $str = '[' . PHP_EOL;
+        $str = '[' . \PHP_EOL;
 
         foreach ($this->values as $key => $value) {
             if (is_string($key)) {
@@ -60,12 +60,12 @@ class ArrayDefinition implements Definition
             $str .= '    ' . $key . ' => ';
 
             if ($value instanceof Definition) {
-                $str .= str_replace(PHP_EOL, PHP_EOL . '    ', (string) $value);
+                $str .= str_replace(\PHP_EOL, \PHP_EOL . '    ', (string) $value);
             } else {
                 $str .= var_export($value, true);
             }
 
-            $str .= ',' . PHP_EOL;
+            $str .= ',' . \PHP_EOL;
         }
 
         return $str . ']';

--- a/src/Definition/Dumper/ObjectDefinitionDumper.php
+++ b/src/Definition/Dumper/ObjectDefinitionDumper.php
@@ -35,7 +35,7 @@ class ObjectDefinitionDumper
         $str = sprintf('    class = %s%s', $warning, $className);
 
         // Lazy
-        $str .= PHP_EOL . '    lazy = ' . var_export($definition->isLazy(), true);
+        $str .= \PHP_EOL . '    lazy = ' . var_export($definition->isLazy(), true);
 
         if ($classExist) {
             // Constructor
@@ -48,7 +48,7 @@ class ObjectDefinitionDumper
             $str .= $this->dumpMethods($className, $definition);
         }
 
-        return sprintf('Object (' . PHP_EOL . '%s' . PHP_EOL . ')', $str);
+        return sprintf('Object (' . \PHP_EOL . '%s' . \PHP_EOL . ')', $str);
     }
 
     private function dumpConstructor(string $className, ObjectDefinition $definition) : string
@@ -60,7 +60,7 @@ class ObjectDefinitionDumper
         if ($constructorInjection !== null) {
             $parameters = $this->dumpMethodParameters($className, $constructorInjection);
 
-            $str .= sprintf(PHP_EOL . '    __construct(' . PHP_EOL . '        %s' . PHP_EOL . '    )', $parameters);
+            $str .= sprintf(\PHP_EOL . '    __construct(' . \PHP_EOL . '        %s' . \PHP_EOL . '    )', $parameters);
         }
 
         return $str;
@@ -74,7 +74,7 @@ class ObjectDefinitionDumper
             $value = $propertyInjection->getValue();
             $valueStr = $value instanceof Definition ? (string) $value : var_export($value, true);
 
-            $str .= sprintf(PHP_EOL . '    $%s = %s', $propertyInjection->getPropertyName(), $valueStr);
+            $str .= sprintf(\PHP_EOL . '    $%s = %s', $propertyInjection->getPropertyName(), $valueStr);
         }
 
         return $str;
@@ -87,7 +87,7 @@ class ObjectDefinitionDumper
         foreach ($definition->getMethodInjections() as $methodInjection) {
             $parameters = $this->dumpMethodParameters($className, $methodInjection);
 
-            $str .= sprintf(PHP_EOL . '    %s(' . PHP_EOL . '        %s' . PHP_EOL . '    )', $methodInjection->getMethodName(), $parameters);
+            $str .= sprintf(\PHP_EOL . '    %s(' . \PHP_EOL . '        %s' . \PHP_EOL . '    )', $methodInjection->getMethodName(), $parameters);
         }
 
         return $str;
@@ -130,6 +130,6 @@ class ObjectDefinitionDumper
             $args[] = sprintf('$%s = #UNDEFINED#', $parameter->getName());
         }
 
-        return implode(PHP_EOL . '        ', $args);
+        return implode(\PHP_EOL . '        ', $args);
     }
 }

--- a/src/Definition/EnvironmentVariableDefinition.php
+++ b/src/Definition/EnvironmentVariableDefinition.php
@@ -93,20 +93,20 @@ class EnvironmentVariableDefinition implements Definition
 
     public function __toString()
     {
-        $str = '    variable = ' . $this->variableName . PHP_EOL
+        $str = '    variable = ' . $this->variableName . \PHP_EOL
             . '    optional = ' . ($this->isOptional ? 'yes' : 'no');
 
         if ($this->isOptional) {
             if ($this->defaultValue instanceof Definition) {
                 $nestedDefinition = (string) $this->defaultValue;
-                $defaultValueStr = str_replace(PHP_EOL, PHP_EOL . '    ', $nestedDefinition);
+                $defaultValueStr = str_replace(\PHP_EOL, \PHP_EOL . '    ', $nestedDefinition);
             } else {
                 $defaultValueStr = var_export($this->defaultValue, true);
             }
 
-            $str .= PHP_EOL . '    default = ' . $defaultValueStr;
+            $str .= \PHP_EOL . '    default = ' . $defaultValueStr;
         }
 
-        return sprintf('Environment variable (' . PHP_EOL . '%s' . PHP_EOL . ')', $str);
+        return sprintf('Environment variable (' . \PHP_EOL . '%s' . \PHP_EOL . ')', $str);
     }
 }

--- a/src/Definition/Exception/InvalidDefinition.php
+++ b/src/Definition/Exception/InvalidDefinition.php
@@ -16,7 +16,7 @@ class InvalidDefinition extends \Exception
     public static function create(Definition $definition, string $message, \Exception $previous = null) : self
     {
         return new self(sprintf(
-            '%s' . PHP_EOL . 'Full definition:' . PHP_EOL . '%s',
+            '%s' . \PHP_EOL . 'Full definition:' . \PHP_EOL . '%s',
             $message,
             (string) $definition
         ), 0, $previous);


### PR DESCRIPTION
Currently, PR's code style checking fails due to https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5426

```xml
<?xml version="1.0" encoding="UTF-8"?>
<checkstyle>
  <file name="src/Definition/ArrayDefinition.php">
    <error severity="warning" source="PHP-CS-Fixer.native_constant_invocation" message="Found violation(s) of type: native_constant_invocation"/>
  </file>
  <file name="src/Definition/Dumper/ObjectDefinitionDumper.php">
    <error severity="warning" source="PHP-CS-Fixer.native_constant_invocation" message="Found violation(s) of type: native_constant_invocation"/>
  </file>
  <file name="src/Definition/EnvironmentVariableDefinition.php">
    <error severity="warning" source="PHP-CS-Fixer.native_constant_invocation" message="Found violation(s) of type: native_constant_invocation"/>
  </file>
  <file name="src/Definition/Exception/InvalidDefinition.php">
    <error severity="warning" source="PHP-CS-Fixer.native_constant_invocation" message="Found violation(s) of type: native_constant_invocation"/>
  </file>
</checkstyle>
```