### PR TITLE
adding psr container exception to the ignored errors list

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,5 +10,6 @@ parameters:
     ignoreErrors:
         - '#Access to undefined constant DI\\CompiledContainer::METHOD_MAPPING.#'
         - '#Function apcu_.* not found.#'
+        - '#PHPDoc tag @throws with type Psr\\Container\\ContainerExceptionInterface is not subtype of Throwable#'
     reportUnmatchedIgnoredErrors: false
     inferPrivatePropertyTypeFromConstructor: true


### PR DESCRIPTION
Since phpstan throws an error for a PSR container exception interface we have to add this class to the ignored list.

https://github.com/phpstan/phpstan/issues/1066
https://github.com/php-fig/container/issues/21
