### PR TITLE
Allow `new Container()` with definitions

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -45,6 +45,7 @@ title: Documentation index
 * [Migration from PHP-DI 3.x to 4.0](migration/4.0.md)
 * [Migration from PHP-DI 4.x to 5.0](migration/5.0.md)
 * [Migration from PHP-DI 5.x to 6.0](migration/6.0.md)
+* [Migration from PHP-DI 6.x to 7.0](migration/7.0.md)
 
 ### Internals
 

--- a/doc/container-configuration.md
+++ b/doc/container-configuration.md
@@ -5,15 +5,23 @@ current_menu: container-configuration
 
 # Configuring the container
 
-## Development environment
+## Getting started
 
-PHP-DI's container is preconfigured for "plug and play", i.e. development environment. You can start using it simply like so:
+PHP-DI's container is preconfigured for "plug and play". You can start using it simply like so:
 
 ```php
 $container = new Container();
 ```
 
-By default, PHP-DI will have [Autowiring](definition.md) enabled ([annotations](annotations.md) are disabled by default).
+By default, [Autowiring](definition.md) will be enabled. [Annotations](annotations.md) are disabled by default.
+
+To register [definitions using an array](php-definitions.md):
+
+```php
+$container = new DI\Container([
+    // place your definitions here
+]);
+```
 
 To change options on the container you can use the `ContainerBuilder` class:
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -18,7 +18,7 @@ Install PHP-DI with [Composer](http://getcomposer.org/doc/00-intro.md):
 composer require php-di/php-di
 ```
 
-PHP-DI requires PHP 7.2 or above.
+PHP-DI 7 requires PHP 8.0 or above.
 
 ## Basic usage
 

--- a/doc/migration/7.0.md
+++ b/doc/migration/7.0.md
@@ -13,6 +13,26 @@ This guide will help you migrate from a 6.x version to 7.0. It will only explain
 
 PHP-DI now requires PHP 8.0 or greater. If you are using an older version, you can of course still use PHP-DI 6.
 
+## Container creation
+
+The container can now be created with sane defaults without using the `ContainerBuilder` class:
+
+```php
+$container = new \DI\Container();
+
+// With definitions:
+$container = new \DI\Container([
+    \Psr\Log\LoggerInterface::class => get(MyLogger::class),
+]);
+```
+
+Related to that: `\DI\ContainerBuilder::buildDevContainer()` method is now obsolete and has been removed. Replace it with:
+
+```diff
+- $container = \DI\ContainerBuilder::buildDevContainer();
++ $container = new \DI\Container();
+```
+
 ## PHPdoc types are ignored by `@Inject`
 
 Now that PHP 7.4 and up supports typed properties, PHP-DI will stop reading types from phpdoc.

--- a/doc/php-definitions.md
+++ b/doc/php-definitions.md
@@ -10,9 +10,16 @@ On top of [autowiring](autowiring.md) and [annotations](annotations.md), you can
 You can register that configuration as an array:
 
 ```php
+$container = new DI\Container([
+    // place your definitions here
+]);
+
+// or using the container builder class:
+// ...
 $containerBuilder->addDefinitions([
     // place your definitions here
 ]);
+// ...
 ```
 
 Or by putting it into a file returning an array:

--- a/src/Container.php
+++ b/src/Container.php
@@ -70,7 +70,7 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
 
     public static function create(
         array $definitions
-    ): static {
+    ) : static {
         $source = new SourceChain([new ReflectionBasedAutowiring]);
         $source->setMutableDefinitionSource(new DefinitionArray($definitions, new ReflectionBasedAutowiring));
 
@@ -88,7 +88,7 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
      * @param ContainerInterface $wrapperContainer If the container is wrapped by another container.
      */
     public function __construct(
-        array|MutableDefinitionSource $definitions = [],
+        array | MutableDefinitionSource $definitions = [],
         ProxyFactory $proxyFactory = null,
         ContainerInterface $wrapperContainer = null
     ) {

--- a/src/Container.php
+++ b/src/Container.php
@@ -68,6 +68,15 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
 
     protected ProxyFactory $proxyFactory;
 
+    public static function create(
+        array $definitions
+    ): static {
+        $source = new SourceChain([new ReflectionBasedAutowiring]);
+        $source->setMutableDefinitionSource(new DefinitionArray($definitions, new ReflectionBasedAutowiring));
+
+        return new static($definitions);
+    }
+
     /**
      * Use `$container = new Container()` if you want a container with the default configuration.
      *
@@ -79,13 +88,17 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
      * @param ContainerInterface $wrapperContainer If the container is wrapped by another container.
      */
     public function __construct(
-        MutableDefinitionSource $definitionSource = null,
+        array|MutableDefinitionSource $definitions = [],
         ProxyFactory $proxyFactory = null,
         ContainerInterface $wrapperContainer = null
     ) {
-        $this->delegateContainer = $wrapperContainer ?: $this;
+        if (is_array($definitions)) {
+            $this->definitionSource = $this->createDefaultDefinitionSource($definitions);
+        } else {
+            $this->definitionSource = $definitions;
+        }
 
-        $this->definitionSource = $definitionSource ?: $this->createDefaultDefinitionSource();
+        $this->delegateContainer = $wrapperContainer ?: $this;
         $this->proxyFactory = $proxyFactory ?: new ProxyFactory;
         $this->definitionResolver = new ResolverDispatcher($this->delegateContainer, $this->proxyFactory);
 
@@ -371,10 +384,11 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
         return $this->invoker;
     }
 
-    private function createDefaultDefinitionSource() : SourceChain
+    private function createDefaultDefinitionSource(array $definitions) : SourceChain
     {
-        $source = new SourceChain([new ReflectionBasedAutowiring]);
-        $source->setMutableDefinitionSource(new DefinitionArray([], new ReflectionBasedAutowiring));
+        $autowiring = new ReflectionBasedAutowiring;
+        $source = new SourceChain([$autowiring]);
+        $source->setMutableDefinitionSource(new DefinitionArray($definitions, $autowiring));
 
         return $source;
     }

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -80,14 +80,6 @@ class ContainerBuilder
     protected string $sourceCacheNamespace = '';
 
     /**
-     * Build a container configured for the dev environment.
-     */
-    public static function buildDevContainer() : Container
-    {
-        return new Container;
-    }
-
-    /**
      * @param string $containerClass Name of the container class, used to create the container.
      * @psalm-param class-string<Container> $containerClass
      */

--- a/tests/IntegrationTest/DelegateContainerTest.php
+++ b/tests/IntegrationTest/DelegateContainerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Test\IntegrationTest;
 
+use DI\Container;
 use DI\ContainerBuilder;
 use function DI\get;
 use function DI\string;
@@ -18,7 +19,7 @@ class DelegateContainerTest extends BaseContainerTest
      */
     public function test_alias_to_dependency_in_delegate_container(ContainerBuilder $subContainerBuilder)
     {
-        $rootContainer = ContainerBuilder::buildDevContainer();
+        $rootContainer = new Container;
         $value = new \stdClass();
         $rootContainer->set('bar', $value);
 
@@ -36,8 +37,9 @@ class DelegateContainerTest extends BaseContainerTest
      */
     public function test_string_expression_using_dependency_in_delegate_container(ContainerBuilder $subContainerBuilder)
     {
-        $rootContainer = ContainerBuilder::buildDevContainer();
-        $rootContainer->set('bar', 'hello');
+        $rootContainer = new Container([
+            'bar' => 'hello',
+        ]);
 
         $subContainerBuilder->wrapContainer($rootContainer);
         $subContainerBuilder->addDefinitions([
@@ -53,9 +55,10 @@ class DelegateContainerTest extends BaseContainerTest
      */
     public function test_with_container_call(ContainerBuilder $subContainerBuilder)
     {
-        $rootContainer = ContainerBuilder::buildDevContainer();
         $value = new \stdClass();
-        $rootContainer->set('stdClass', $value);
+        $rootContainer = new Container([
+            'stdClass' => $value,
+        ]);
 
         $subContainerBuilder->wrapContainer($rootContainer);
         $subContainer = $subContainerBuilder->build();

--- a/tests/UnitTest/ContainerBuilderTest.php
+++ b/tests/UnitTest/ContainerBuilderTest.php
@@ -249,12 +249,4 @@ class ContainerBuilderTest extends TestCase
 
         $builder->addDefinitions([]);
     }
-
-    /**
-     * @test
-     */
-    public function dev_container_configuration_should_be_identical_to_creating_a_new_container_from_defaults()
-    {
-        self::assertEquals(new Container, ContainerBuilder::buildDevContainer());
-    }
 }

--- a/tests/UnitTest/ContainerGetTest.php
+++ b/tests/UnitTest/ContainerGetTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Test\UnitTest;
 
+use DI\Container;
 use DI\ContainerBuilder;
 use DI\Test\UnitTest\Fixtures\PassByReferenceDependency;
 use PHPUnit\Framework\TestCase;
@@ -18,7 +19,7 @@ class ContainerGetTest extends TestCase
 {
     public function testSetGet()
     {
-        $container = ContainerBuilder::buildDevContainer();
+        $container = new Container;
         $dummy = new stdClass();
         $container->set('key', $dummy);
         $this->assertSame($dummy, $container->get('key'));
@@ -27,7 +28,7 @@ class ContainerGetTest extends TestCase
     public function testGetNotFound()
     {
         $this->expectException('DI\NotFoundException');
-        $container = ContainerBuilder::buildDevContainer();
+        $container = new Container;
         $container->get('key');
     }
 
@@ -36,20 +37,20 @@ class ContainerGetTest extends TestCase
         $closure = function () {
             return 'hello';
         };
-        $container = ContainerBuilder::buildDevContainer();
+        $container = new Container;
         $container->set('key', $closure);
         $this->assertEquals('hello', $container->get('key'));
     }
 
     public function testGetWithClassName()
     {
-        $container = ContainerBuilder::buildDevContainer();
+        $container = new Container;
         $this->assertInstanceOf('stdClass', $container->get('stdClass'));
     }
 
     public function testGetResolvesEntryOnce()
     {
-        $container = ContainerBuilder::buildDevContainer();
+        $container = new Container;
         $this->assertSame($container->get('stdClass'), $container->get('stdClass'));
     }
 
@@ -58,7 +59,7 @@ class ContainerGetTest extends TestCase
      */
     public function testPassByReferenceParameter()
     {
-        $container = ContainerBuilder::buildDevContainer();
+        $container = new Container;
         $object = $container->get(PassByReferenceDependency::class);
         $this->assertInstanceOf(PassByReferenceDependency::class, $object);
     }

--- a/tests/UnitTest/ContainerTest.php
+++ b/tests/UnitTest/ContainerTest.php
@@ -19,4 +19,15 @@ class ContainerTest extends TestCase
     {
         self::assertInstanceOf(Container::class, new Container); // Should not be an error
     }
+    /**
+     * @test
+     */
+    public function canBeBuiltWithDefinitionArray()
+    {
+        $container = new Container([
+            'foo' => 'bar',
+        ]);
+        self::assertInstanceOf(Container::class, $container);
+        self::assertEquals('bar', $container->get('foo'));
+    }
 }

--- a/website/home_modules.twig
+++ b/website/home_modules.twig
@@ -12,7 +12,7 @@
                 Just create the container and you are good to go thanks to autowiring.
             </p>
 
-<pre><code class="php">$container = ContainerBuilder::buildDevContainer();
+<pre><code class="php">$container = new Container();
 
 $home = $container->get(HomeController::class);
 </code></pre>


### PR DESCRIPTION
Pull request for PHP-DI 7.

Finally, we'll be able to get started with PHP-DI without having to use the ContainerBuilder:

```php
$container = new DI\Container([
    // place your definitions here
]);
```

`ContainerBuilder::buildDevContainer()` has also been removed.
