### PR TITLE
Make InvalidDefinition exception implement ContainerExceptionInterface

### DIFF
--- a/src/Definition/Exception/InvalidDefinition.php
+++ b/src/Definition/Exception/InvalidDefinition.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace DI\Definition\Exception;
 
 use DI\Definition\Definition;
+use Psr\Container\ContainerExceptionInterface;
 
 /**
  * Invalid DI definitions.
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class InvalidDefinition extends \Exception
+class InvalidDefinition extends \Exception implements ContainerExceptionInterface
 {
     public static function create(Definition $definition, string $message, \Exception $previous = null) : self
     {

--- a/tests/IntegrationTest/ContainerPsrCompatabilityTest.php
+++ b/tests/IntegrationTest/ContainerPsrCompatabilityTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\IntegrationTest;
+
+use DI\ContainerBuilder;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Container\ContainerExceptionInterface;
+use DI\Test\IntegrationTest\Fixtures\Class1;
+
+class ContainerPsrCompatabilityTest extends BaseContainerTest
+{
+    /**
+     * @dataProvider provideContainer
+     */
+    public function testNotFound(ContainerBuilder $builder)
+    {
+        $this->expectException(NotFoundExceptionInterface::class);
+        $builder->build()->get('key');
+    }
+
+    /**
+     * @dataProvider provideContainer
+     */
+    public function testUnresolvable(ContainerBuilder $builder)
+    {
+        $this->expectException(ContainerExceptionInterface::class);
+        $builder->build()->get(Class1::class);
+    }
+}


### PR DESCRIPTION
I've fixed the issue described in #772 in the most intrusive way I was able to find.

Another approach would be to catch `InvalidDefinition` in `Container` and rethrow `DependencyException` by wrapping the previous exception, however, this would break the backward compatibility of `Container` because it would throw an exception of different implementation (if users of `Container` class catch `InvalidDefinition` and we change the exception type we throw new exception type would bot be caught).

Fixes #772 