### PR TITLE
Get env vars from $_ENV and $_SERVER in compiled container

### DIFF
--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -244,7 +244,7 @@ class Compiler
                 $isOptional = $this->compileValue($definition->isOptional());
                 $defaultValue = $this->compileValue($definition->getDefaultValue());
                 $code = <<<PHP
-        \$value = getenv($variableName);
+        \$value = \$_ENV[$variableName] ?? \$_SERVER[$variableName] ?? getenv($variableName);
         if (false !== \$value) return \$value;
         if (!$isOptional) {
             throw new \DI\Definition\Exception\InvalidDefinition("The environment variable '{$definition->getVariableName()}' has not been defined");


### PR DESCRIPTION
Closes #776 

Brings the compiled container in line with the non-compiled environment variable resolver (#757). Uses thread-safe `$_ENV` and `$_SERVER` in preference to `getenv`.

I couldn't see any tests relating specifically to this part but happy to add one if needed.