### PR TITLE
Atomic creation of compilation directory

### DIFF
--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -358,7 +358,7 @@ PHP;
 
     private function createCompilationDirectory(string $directory)
     {
-        if (!is_dir($directory) && !@mkdir($directory, 0777, true)) {
+        if (!is_dir($directory) && !@mkdir($directory, 0777, true) && !is_dir($directory)) {
             throw new InvalidArgumentException(sprintf('Compilation directory does not exist and cannot be created: %s.', $directory));
         }
         if (!is_writable($directory)) {


### PR DESCRIPTION
closes #785

Added additional check for whether the directory exists. This way, if the `mkdir()` fails, but the directory does exists afterwards (was presumably created by another script running at the same time), no exception is thrown.