### PR TITLE
Mention that DI\get() can also be used to map interfaces

### DIFF
--- a/doc/php-definitions.md
+++ b/doc/php-definitions.md
@@ -367,6 +367,15 @@ return [
 ];
 ```
 
+You can use aliases to map interfaces to implementation obtaining the same object when requesting/injecting the class or the interface
+
+```php
+return [
+    // mapping an interface to an implementation (autowire the MyLogger class if not otherwise defined)
+    'LoggerInterface' => DI\get('MyLogger'),
+];
+```
+
 ### Environment variables
 
 You can get an environment variable's value using the `DI\env()` helper:


### PR DESCRIPTION
I've been using `DI\get` to map interface to implementation but documentation only mention `DI\create` and `DI\autowire` for this purpose.
The advantage of using `DI\get` is that when requesting either the class or the interface mapped to it, only one object will be created by the container and returned.
When autowiring is enabled, that just means using `get` instead of `autowire` if there are no other configuration for the entry.

This just adds to the documentation that `get` can be used for mapping interfaces to implementation using roughly the same wording as for `create` and `autowire`.
Please let me know if the changes are capturing this well enough.