### PR TITLE
Add @template return types for better autocomplete/static analysis

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -117,11 +117,12 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
     /**
      * Returns an entry of the container by its name.
      *
-     * @param string $name Entry name or a class name.
+     * @template T
+     * @param string|class-string<T> $name Entry name or a class name.
      *
      * @throws DependencyException Error while resolving the entry.
      * @throws NotFoundException No entry found for the given name.
-     * @return mixed
+     * @return mixed|T
      */
     public function get($name)
     {
@@ -165,15 +166,16 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
      *
      * This method makes the container behave like a factory.
      *
-     * @param string $name       Entry name or a class name.
-     * @param array  $parameters Optional parameters to use to build the entry. Use this to force specific parameters
-     *                           to specific values. Parameters not defined in this array will be resolved using
-     *                           the container.
+     * @template T
+     * @param string|class-string<T> $name       Entry name or a class name.
+     * @param array                  $parameters Optional parameters to use to build the entry. Use this to force
+     *                                           specific parameters to specific values. Parameters not defined in this
+     *                                           array will be resolved using the container.
      *
      * @throws InvalidArgumentException The name parameter must be of type string.
      * @throws DependencyException Error while resolving the entry.
      * @throws NotFoundException No entry found for the given name.
-     * @return mixed
+     * @return mixed|T
      */
     public function make($name, array $parameters = [])
     {
@@ -229,10 +231,11 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
     /**
      * Inject all dependencies on an existing instance.
      *
-     * @param object $instance Object to perform injection upon
+     * @template T
+     * @param object|T $instance Object to perform injection upon
      * @throws InvalidArgumentException
      * @throws DependencyException Error while injecting dependencies
-     * @return object $instance Returns the same instance
+     * @return object|T $instance Returns the same instance
      */
     public function injectOn($instance)
     {


### PR DESCRIPTION
PhpStorm now supports Psalm-style [class string](https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#class-string-interface-string) and [template](https://psalm.dev/docs/annotating_code/templated_annotations/) annotations ([announcement](https://blog.jetbrains.com/phpstorm/2021/07/phpstorm-2021-2-release/)). This works by default without needing to install or run Psalm on the project separately.

By adding template annotations to `get`, `make` and `injectOn` methods, we can get autocomplete without any inline docblocks or extra metadata files. 

I think by keeping the existing type annotations and just unioning the new template types, it should work fine with IDEs that don't support this syntax (note I haven't tested on any other IDEs).