### PR TITLE
Makes serializable closure work with PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "psr/container": "^1.0",
         "php-di/invoker": "^2.0",
         "php-di/phpdoc-reader": "^2.0.1",
-        "opis/closure": "^3.5.5"
+        "opis/closure": "^3.5.5",
+        "laravel/serializable-closure": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.0",

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -21,7 +21,9 @@ use DI\Proxy\ProxyFactory;
 use function dirname;
 use function file_put_contents;
 use InvalidArgumentException;
-use Opis\Closure\SerializableClosure;
+use Laravel\SerializableClosure\Support\ReflectionClosure;
+use Laravel\SerializableClosure\SerializableClosure;
+use Opis\Closure\SerializableClosure as OpisSerializableClosure;
 use function rename;
 use function sprintf;
 use function tempnam;
@@ -401,8 +403,13 @@ PHP;
      */
     private function compileClosure(\Closure $closure) : string
     {
-        $wrapper = new SerializableClosure($closure);
-        $reflector = $wrapper->getReflector();
+        if (PHP_VERSION_ID < 70400) {
+            $wrapper = new OpisSerializableClosure($closure);
+            $reflector = $wrapper->getReflector();
+        } else {
+            $wrapper = new SerializableClosure($closure);
+            $reflector = new ReflectionClosure($closure);
+        }
 
         if ($reflector->getUseVariables()) {
             throw new InvalidDefinition('Cannot compile closures which import variables using the `use` keyword');


### PR DESCRIPTION
This pull request makes PHP DI support PHP 8.1 regarding serializable closures. Waiting for a stable version of Laravel Serializable Closures.