### PR TITLE
Support PHP 8.1 by moving from opis/closure to laravel/serializable-closure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "psr/container": "^1.0",
         "php-di/invoker": "^2.0",
         "php-di/phpdoc-reader": "^2.0.1",
-        "opis/closure": "^3.5.5",
         "laravel/serializable-closure": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "psr/container": "^1.0",
         "php-di/invoker": "^2.0",
         "php-di/phpdoc-reader": "^2.0.1",
-        "opis/closure": "^3.5.5"
+        "opis/closure": "^3.5.5",
+        "laravel/serializable-closure": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.0",

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -21,7 +21,9 @@ use DI\Proxy\ProxyFactory;
 use function dirname;
 use function file_put_contents;
 use InvalidArgumentException;
-use Opis\Closure\SerializableClosure;
+use Laravel\SerializableClosure\Support\ReflectionClosure;
+use Laravel\SerializableClosure\SerializableClosure;
+use Opis\Closure\SerializableClosure as OpisSerializableClosure;
 use function rename;
 use function sprintf;
 use function tempnam;
@@ -401,8 +403,13 @@ PHP;
      */
     private function compileClosure(\Closure $closure) : string
     {
-        $wrapper = new SerializableClosure($closure);
-        $reflector = $wrapper->getReflector();
+        if (PHP_VERSION_ID < 70400) {
+            $wrapper = new OpisSerializableClosure($closure);
+            $reflector = $wrapper->getReflector();
+        } else {
+            $wrapper = new SerializableClosure($closure);
+            $reflector = new ReflectionClosure($closure);
+        }
 
         if ($reflector->getUseVariables()) {
             throw new InvalidDefinition('Cannot compile closures which import variables using the `use` keyword');

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -22,8 +22,6 @@ use function dirname;
 use function file_put_contents;
 use InvalidArgumentException;
 use Laravel\SerializableClosure\Support\ReflectionClosure;
-use Laravel\SerializableClosure\SerializableClosure;
-use Opis\Closure\SerializableClosure as OpisSerializableClosure;
 use function rename;
 use function sprintf;
 use function tempnam;
@@ -399,17 +397,11 @@ PHP;
     }
 
     /**
-     * @throws \DI\Definition\Exception\InvalidDefinition
+     * @throws InvalidDefinition
      */
     private function compileClosure(\Closure $closure) : string
     {
-        if (PHP_VERSION_ID < 70400) {
-            $wrapper = new OpisSerializableClosure($closure);
-            $reflector = $wrapper->getReflector();
-        } else {
-            $wrapper = new SerializableClosure($closure);
-            $reflector = new ReflectionClosure($closure);
-        }
+        $reflector = new ReflectionClosure($closure);
 
         if ($reflector->getUseVariables()) {
             throw new InvalidDefinition('Cannot compile closures which import variables using the `use` keyword');

--- a/tests/IntegrationTest/Definitions/FactoryDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/FactoryDefinitionTest.php
@@ -590,7 +590,7 @@ class FactoryDefinitionTest extends BaseContainerTest
 
     public function test_multiple_closures_on_the_same_line_cannot_be_compiled()
     {
-        $this->markTestSkipped('Opis/closure doesn\'t throw on multiple closures on the same line');
+        $this->markTestSkipped('laravel/serializable-closure doesn\'t throw on multiple closures on the same line');
 
         $this->expectException(InvalidDefinition::class);
         $this->expectExceptionMessage('Cannot compile closures when two closures are defined on the same line');


### PR DESCRIPTION
This is a continuation of #793 with fixed tests and complete removal of opis/closure.