### PR TITLE
Hint on variadic parameters for `addDefinitions`

### DIFF
--- a/doc/php-definitions.md
+++ b/doc/php-definitions.md
@@ -28,6 +28,17 @@ return [
 $containerBuilder->addDefinitions('config.php');
 ```
 
+The _addDefinitions_ method is variadic, so it accepts multiple definition files:
+
+```php
+$containerBuilder->addDefinitions( ...[
+    'config.php', 
+    'actions.php'
+]);
+```
+
+
+
 ## A word about lazy loading
 
 PHP-DI loads the definitions you have written and uses them like instructions on how to create objects.


### PR DESCRIPTION
Basic example in docs shows one definition file passed to _addDefinitions_, so one might be tempted to call _addDefinitions_ repeatedly. By using variadic parameters with `...`, adding a bunch of definition files becomes possible.