### PR TITLE
downgraded default value resolver priority

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -413,8 +413,8 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
                 new DefinitionParameterResolver($this->definitionResolver),
                 new NumericArrayResolver,
                 new AssociativeArrayResolver,
-                new DefaultValueResolver,
                 new TypeHintContainerResolver($this->delegateContainer),
+                new DefaultValueResolver,
             ]);
 
             $this->invoker = new Invoker($parameterResolver, $this);


### PR DESCRIPTION
In the current implementation, the default value is resolved first, instead of calling the factory, for example:
My change downgrades the call to get the default value


class OptionalDependency{}

class Service{
    public function call(OptionalDependency $op = null){ }
}

$builder = new ContainerBuilder();

$builder->addDefinitions([
    OptionalDependency::class => function(){

   }
]);

$container = $builder->build();
$container->call('OptionalDependency::call');
