### PR TITLE
Document inability to autowire php-internal classes

### DIFF
--- a/doc/autowiring.md
+++ b/doc/autowiring.md
@@ -70,3 +70,7 @@ class Database
 - `setLogger()` will not be called
 
 For those classes, you will need to use `DI\autowire()` in [PHP definitions](php-definitions.md) to declare explicitly what to inject.
+
+PHP-DI is also unable to use Reflection on any PHP-internal classes like such that provide access to extension capabilities.
+Examples include `Memcached`, `Gearman`, any `Curl*` classes, anything from the SPL classes like `RecursiveIteratorIterator`, and so on.
+If you want to instantiate any class provided by the PHP engine or an extension, you have to provide explicit constructor parameters to PHP-DI.


### PR DESCRIPTION
closes #470

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->

I believe nobody came up with a proper solution in the discussion of that ticket, so the lowest common denominator is to document more explicitly what PHP-DI expects the user to do.