### PR TITLE
Add functionality to reset container entries

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -229,6 +229,31 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
     }
 
     /**
+     * Test if the entry given by $name has been initialized in the container.
+     *
+     * @param string $name Entry name or a class name.
+     * @return bool Whether or not the entry is initialized.
+     */
+    public function initialized(string $name) : bool
+    {
+        return array_key_exists($name, $this->resolvedEntries);
+    }
+
+    /**
+     * Unset the entry given by $name in the container.
+     *
+     * A subsequent call to get() will create a new instance of this entry,
+     * according to its definition (if it has one). This can be useful to
+     * release resources that are no longer in use or that need to be reset.
+     *
+     * @param string $name Entry name or a class name.
+     */
+    public function reset(string $name) : void
+    {
+        unset($this->resolvedEntries[$name]);
+    }
+
+    /**
      * Inject all dependencies on an existing instance.
      *
      * @template T

--- a/tests/IntegrationTest/ContainerInitializedTest.php
+++ b/tests/IntegrationTest/ContainerInitializedTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\IntegrationTest;
+
+use DI\ContainerBuilder;
+use stdClass;
+use TypeError;
+
+/**
+ * Tests the initialized() method of the container.
+ */
+class ContainerInitializedTest extends BaseContainerTest
+{
+    /**
+     * @dataProvider provideContainer
+     */
+    public function test_not_initialized_by_definition(ContainerBuilder $builder)
+    {
+        $builder->addDefinitions([
+            'foo' => 'bar',
+        ]);
+
+        // Unlike has(), entries are not initialized by definitions
+        self::assertFalse($builder->build()->initialized('foo'));
+    }
+
+    /**
+     * @dataProvider provideContainer
+     */
+    public function test_initialized_by_definition_after_get(ContainerBuilder $builder)
+    {
+        $builder->addDefinitions([
+            'foo' => 'bar',
+        ]);
+        $container = $builder->build();
+        $container->get('foo');
+
+        // Only once we get the entry for the first time is it initialized
+        self::assertTrue($container->initialized('foo'));
+    }
+
+    /**
+     * @dataProvider provideContainer
+     */
+    public function test_initialized_when_set_directly(ContainerBuilder $builder)
+    {
+        $container = $builder->build();
+        $container->set('foo', 'bar');
+
+        // The entry is also initialized if set directly
+        self::assertTrue($container->initialized('foo'));
+    }
+
+    /**
+     * @dataProvider provideContainer
+     */
+    public function test_not_initialized_when_unknown(ContainerBuilder $builder)
+    {
+        // Entry is not initialized in a default container
+        self::assertFalse($builder->build()->initialized('foo'));
+    }
+
+    /**
+     * @test
+     * @dataProvider provideContainer
+     */
+    public function fails_with_non_string_parameter(ContainerBuilder $builder)
+    {
+        $this->expectException(TypeError::class);
+        $builder->build()->initialized(new stdClass);
+    }
+}

--- a/tests/IntegrationTest/ContainerResetTest.php
+++ b/tests/IntegrationTest/ContainerResetTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\IntegrationTest;
+
+use DI\ContainerBuilder;
+use stdClass;
+use TypeError;
+
+/**
+ * Tests the reset() method of the container.
+ */
+class ContainerResetTest extends BaseContainerTest
+{
+    /**
+     * @dataProvider provideContainer
+     */
+    public function test_reset_with_definition(ContainerBuilder $builder)
+    {
+        $builder->addDefinitions([
+            'foo' => 'bar',
+        ]);
+        $container = $builder->build();
+
+        // Sanity check the state of the entry prior to reset
+        self::assertTrue($container->has('foo'));
+        self::assertFalse($container->initialized('foo'));
+
+        // Now initialize the entry, and sanity check the state again
+        self::assertSame('bar', $container->get('foo'));
+        self::assertTrue($container->has('foo'));
+        self::assertTrue($container->initialized('foo'));
+
+        // Then reset the entry
+        $container->reset('foo');
+
+        // It should still be gettable, but it is no longer initialized
+        self::assertTrue($container->has('foo'));
+        self::assertFalse($container->initialized('foo'));
+        self::assertSame('bar', $container->get('foo'));
+    }
+
+    /**
+     * @dataProvider provideContainer
+     */
+    public function test_reset_when_set_directly(ContainerBuilder $builder)
+    {
+        $container = $builder->build();
+        $container->set('foo', 'bar');
+
+        // After resetting an entry that does not have a definition (i.e. it is
+        // only set directly), it is no longer gettable.
+        $container->reset('foo');
+        self::assertFalse($container->has('foo'));
+    }
+
+    /**
+     * @test
+     * @dataProvider provideContainer
+     */
+    public function fails_with_non_string_parameter(ContainerBuilder $builder)
+    {
+        $this->expectException(TypeError::class);
+        $builder->build()->reset(new stdClass);
+    }
+}


### PR DESCRIPTION
The purpose of this change is to improve the support for resource
management and introspection of the `Container` class by adding the
following methods:

* `Container::reset` - unsets an entry in the container

* `Container::initialized` - checks if an entry is initialized

These method names were chosen for consistency with the same features
in Symfony's Dependency Injection component.

The idea here is that if you have an entry in the container that is no
longer needed (say, for example, a database connection), then you can
remove the entry from the container with `reset` to free the resource.
If it is needed again later, no extra work is needed to `get` it from
the container according to its definition, and a new instance will be
constructed.

The `initialized` method is related in the sense that there is no
existing way to see if an entry is present in the container. It is
distinct from the `has` method, which only reports if an entry _can_
be supplied by the container, not if it _has_. You may have some logic
that depends on if a resource has been allocated yet (i.e. before the
first `get` or after `reset`).

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->

Two practical use cases:

1. A long-running API service has a database connection in its container. After a call to the API completes, the database connection is closed to free up resources and ensure that the connection does not time out. Because the database connection in the container is now invalid, careful measures need to be put in place to ensure that a reconnection to the database is performed before the object in the container is used on the next API call. This essentially removes the "on demand" aspect of the database connection, because the call may not even need a database connection. By using `Container::reset`, no special reconnection scaffolding is needed; the container will automatically create a new database connection regardless of where or when the next `Container::get` call is made.

2. A logging mechanism for the same API service will log certain properties of the database connection after each call. If no database connection has been opened, then no connection should be made to avoid unnecessary resource consumption. Without the introspection provided by `Container::initialized`, there is no way to determine if a connection has already been opened through the container interface.