### PR TITLE
Unset from entriesBeingResolved when using set()

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -301,6 +301,7 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
         } else {
             $this->resolvedEntries[$name] = $value;
         }
+        unset($this->entriesBeingResolved[$name]);
     }
 
     /**


### PR DESCRIPTION
There is an array `entriesBeingResolved` being used to check for circular dependencies and infinite loops. However this array does not change when an entry is being explicitly set using `set()`. When an entry is given a value, it should be considered resolved.

The proposed change will unset the entry in `entriesBeingResolved` when using `set()`

Closes #823 