### PR TITLE
ContainerBuilder.php: use generics for typehints

### DIFF
--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -31,12 +31,14 @@ use Psr\Container\ContainerInterface;
  *
  * @since  3.2
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ *
+ * @template T of Container
  */
 class ContainerBuilder
 {
     /**
      * Name of the container class, used to create the container.
-     * @var string
+     * @var class-string<T>
      */
     private $containerClass;
 
@@ -114,7 +116,7 @@ class ContainerBuilder
     }
 
     /**
-     * @param string $containerClass Name of the container class, used to create the container.
+     * @param class-string<T> $containerClass Name of the container class, used to create the container.
      */
     public function __construct(string $containerClass = Container::class)
     {
@@ -124,7 +126,7 @@ class ContainerBuilder
     /**
      * Build and return a container.
      *
-     * @return Container
+     * @return T
      */
     public function build()
     {
@@ -204,7 +206,7 @@ class ContainerBuilder
      * @see https://php-di.org/doc/performances.html
      *
      * @param string $directory Directory in which to put the compiled container.
-     * @param string $containerClass Name of the compiled class. Customize only if necessary.
+     * @param class-string<T> $containerClass Name of the compiled class. Customize only if necessary.
      * @param string $containerParentClass Name of the compiled container parent class. Customize only if necessary.
      */
     public function enableCompilation(


### PR DESCRIPTION
The type of container that is actually built may be more specialized
than the Container base class. As such, make sure we use the proper
return typehints.

I found this issue while testing extensions of the Container class to
support a resettable interface, as an alternative solution to #821.
This typing issue would arise for anyone trying to extend Container.

This issue also exists in the v7 branch (with a handful of fairly
straightforward conflicts from current master). If you would prefer
that I target the v7 branch instead, I'd be happy to make that change.