### PR TITLE
Add docs for cache namespace feature

### DIFF
--- a/doc/performances.md
+++ b/doc/performances.md
@@ -133,6 +133,11 @@ if (/* is production */) {
 }
 ```
 
+You can also pass an optional namespace argument to `enableDefinitionCache('my-namespace')` which will add the provided namespace to all PHP-DI cache keys. This is helpful to prevent cache collisions when sharing a single APCu memory pool between multiple DI containers. Here is an example of a PHP-DI cache key for a class named `MyClass` with, and without, a namespace:
+
+- With namespace:  `php-di.definitions.my-namespaceMyClass`
+- No namespace:    `php-di.definitions.MyClass`
+
 Heads up:
 
 - do not use a cache in a development environment, else changes you make to the definitions (annotations, configuration files, etc.) may not be taken into account


### PR DESCRIPTION
I don't see the `cacheNamespace` argument mentioned anywhere in the docs for `enableDefinitionCache()`, that was added with #698. The only reason I found it is because I was having cache collisions and looked at the source code where I noticed this nice feature already exists.  So this commit adds a paragraph to the docs about the cache namespace feature.