### PR TITLE
Fix PHP-CS-Fixer Build

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -46,6 +46,7 @@ return (new PhpCsFixer\Config)
         'native_function_invocation' => false,
         'single_line_throw' => false,
         'blank_line_between_import_groups' => false,
+        'global_namespace_import' => false,
     ])
     ->setRiskyAllowed(true)
     ->setFinder($finder);


### PR DESCRIPTION
Since [PHP-CS-Fixer v3.13.0](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.13.0) was released, this repository's CI is failing.
It is caused by `global_namespace_import` rule added to `@Symfony` ruleset.

This PR disables `global_namespace_import` rule and makes CI green.