### PR TITLE
[v7] Remove non-analyzed vendor directory from Psalm ignores

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -7,9 +7,8 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
 >
     <projectFiles>
-        <directory name="src" />
+        <directory name="src"/>
         <ignoreFiles>
-            <directory name="vendor" />
             <file name="src/Compiler/Template.php"/>
         </ignoreFiles>
     </projectFiles>


### PR DESCRIPTION
Only `src/` is analyzed.