### PR TITLE
Fix typos

### DIFF
--- a/doc/scopes.md
+++ b/doc/scopes.md
@@ -19,7 +19,7 @@ Before:
 ```php
 return [
     Form::class => create()
-        ->scope(Scope::PROTOTYPE), // a new form is created everytime it is injected
+        ->scope(Scope::PROTOTYPE), // a new form is created every time it is injected
 ];
 
 class Service

--- a/website/less/algolia.less
+++ b/website/less/algolia.less
@@ -36,7 +36,7 @@
 .algolia-docsearch-suggestion--highlight {
     color: @link-color;
 }
-/* Highligted search terms in the main category headers */
+/* Highlighted search terms in the main category headers */
 .algolia-docsearch-suggestion--category-header .algolia-docsearch-suggestion--highlight  {
     background-color: transparent;
 }


### PR DESCRIPTION
Fixes the two typos from #838 that were not about `invokable` -> `invocable`.