### PR TITLE
Correct type hints to prevent tooling like PHPStan from raising issues.

### DIFF
--- a/src/Definition/Helper/CreateDefinitionHelper.php
+++ b/src/Definition/Helper/CreateDefinitionHelper.php
@@ -104,7 +104,7 @@ class CreateDefinitionHelper implements DefinitionHelper
      * Can be used multiple times to declare multiple calls.
      *
      * @param string $method       Name of the method to call.
-     * @param mixed $parameters Parameters to use for calling the method.
+     * @param mixed ...$parameters Parameters to use for calling the method.
      *
      * @return $this
      */

--- a/src/Definition/Helper/CreateDefinitionHelper.php
+++ b/src/Definition/Helper/CreateDefinitionHelper.php
@@ -68,7 +68,7 @@ class CreateDefinitionHelper implements DefinitionHelper
      * This method takes a variable number of arguments, example:
      *     ->constructor($param1, $param2, $param3)
      *
-     * @param mixed[] $parameters Parameters to use for calling the constructor of the class.
+     * @param mixed $parameters Parameters to use for calling the constructor of the class.
      *
      * @return $this
      */
@@ -104,7 +104,7 @@ class CreateDefinitionHelper implements DefinitionHelper
      * Can be used multiple times to declare multiple calls.
      *
      * @param string $method       Name of the method to call.
-     * @param mixed[] $parameters Parameters to use for calling the method.
+     * @param mixed $parameters Parameters to use for calling the method.
      *
      * @return $this
      */

--- a/src/Definition/Helper/CreateDefinitionHelper.php
+++ b/src/Definition/Helper/CreateDefinitionHelper.php
@@ -68,7 +68,7 @@ class CreateDefinitionHelper implements DefinitionHelper
      * This method takes a variable number of arguments, example:
      *     ->constructor($param1, $param2, $param3)
      *
-     * @param mixed $parameters Parameters to use for calling the constructor of the class.
+     * @param mixed ...$parameters Parameters to use for calling the constructor of the class.
      *
      * @return $this
      */


### PR DESCRIPTION
This PR allows people who use PHPStan in their tool chain to use named arguments when calling the `method` and `constructor` methods of `CreateDefinitionHelper`.

See https://github.com/PHP-DI/PHP-DI/issues/840