### PR TITLE
ContainerBuilder: template on container class

### DIFF
--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -31,18 +31,20 @@ use Psr\Container\ContainerInterface;
  *
  * @since  3.2
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ *
+ * @template ContainerClass of Container
  */
 class ContainerBuilder
 {
     /**
      * Name of the container class, used to create the container.
-     * @var class-string<Container>
+     * @var class-string<ContainerClass>
      */
     private string $containerClass;
 
     /**
      * Name of the container parent class, used on compiled container.
-     * @var class-string<Container>
+     * @var class-string<ContainerClass>
      */
     private string $containerParentClass;
 
@@ -77,8 +79,7 @@ class ContainerBuilder
     protected string $sourceCacheNamespace = '';
 
     /**
-     * @param string $containerClass Name of the container class, used to create the container.
-     * @psalm-param class-string<Container> $containerClass
+     * @param class-string<ContainerClass> $containerClass Name of the container class, used to create the container.
      */
     public function __construct(string $containerClass = Container::class)
     {
@@ -88,7 +89,7 @@ class ContainerBuilder
     /**
      * Build and return a container.
      *
-     * @return Container
+     * @return ContainerClass
      */
     public function build()
     {
@@ -165,10 +166,12 @@ class ContainerBuilder
      *
      * @see https://php-di.org/doc/performances.html
      *
+     * @template T of CompiledContainer
      * @param string $directory Directory in which to put the compiled container.
      * @param string $containerClass Name of the compiled class. Customize only if necessary.
-     * @param string $containerParentClass Name of the compiled container parent class. Customize only if necessary.
-     * @psalm-param class-string<CompiledContainer> $containerParentClass
+     * @param class-string<T> $containerParentClass Name of the compiled container parent class. Customize only if necessary.
+     *
+     * @return self<T>
      */
     public function enableCompilation(
         string $directory,
@@ -178,7 +181,6 @@ class ContainerBuilder
         $this->ensureNotLocked();
 
         $this->compileToDirectory = $directory;
-        /** @var class-string<Container> */
         $this->containerClass = $containerClass;
         $this->containerParentClass = $containerParentClass;
 


### PR DESCRIPTION
This is a change to docstrings only.

The type of container that is actually built by the ContainerBuilder can be more specialized than the Container base class. This can occur in two scenarios:

1. Using the `$containerClass` argument of the constructor. Note that this class must still inherit from Container.

2. Using the `$containerParentClass` argument of `enableCompilation`. Note that this class must still inherit from CompiledContainer.

Below is an enumeration of all possible template configurations:

```php
new ContainerBuilder(); // ContainerBuilder<Container>
new ContainerBuilder(MyContainer::class); // ContainerBuilder<MyContainer>
$builder->enableCompilation(...); // ContainerBuilder<CompiledContainer>
$builder->enableCompilation(..., MyCompiledContainer::class); // ContainerBuilder<MyCompiledContainer>
```

This should fix many static analysis errors for users that specify a custom container class. Note that when the default arguments are used, the original behavior is recovered.

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
