### PR TITLE
add strict types in Template.php

### DIFF
--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -155,7 +155,7 @@ class Compiler
         require __DIR__ . '/Template.php';
         $fileContent = ob_get_clean();
 
-        $fileContent = "<?php\n" . $fileContent;
+        $fileContent = "<?php declare(strict_types=1)\n" . $fileContent;
 
         $this->createCompilationDirectory(dirname($fileName));
         $this->writeFileAtomic($fileName, $fileContent);


### PR DESCRIPTION
When add declare(strict_types=1) everywhere in https://github.com/PHP-DI/PHP-DI/issues/496 forgot to add Template.php
The problem occurs when using the enableCompilation method
fix issue https://github.com/PHP-DI/PHP-DI/issues/845