### PR TITLE
Add note about class import on upgrade guide

### DIFF
--- a/doc/migration/7.0.md
+++ b/doc/migration/7.0.md
@@ -90,6 +90,7 @@ class Example
     }
 }
 ```
+*Note: remember to import the attribute class via `use DI\Attribute\Inject;`.*
 
 Read more about attributes in the PHP-DI documentation: [PHP-DI attributes](../attributes.md).
 


### PR DESCRIPTION
I propose to add this note to the upgrade guide. While performing the upgrade, I missed that step. I also missed it on the [Attributes Doc Page](https://php-di.org/doc/attributes.html) until I saw that note at the bottom. 

Considering Attributes are relatively new to PHP, it might not be known to everyone that the class used in attributes need to be imported. PHPDocs annotations didn’t required a class to be imported. 

Plus, the error message I got in my case wasn’t referring an “unknown class `Import`” or similar. It was a message about the injected property being accessed before initialization, which just meant the injection wasn’t working. 