### PR TITLE
update default cache permissions, and allow users to define their own

### DIFF
--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -98,7 +98,8 @@ class Compiler
         string $className,
         string $parentClassName,
         bool $autowiringEnabled,
-        array $permissions
+        int $filePermission,
+        int $directoryPermission
     ) : string {
         $fileName = rtrim($directory, '/') . '/' . $className . '.php';
 
@@ -158,13 +159,13 @@ class Compiler
 
         $fileContent = "<?php\n" . $fileContent;
 
-        $this->createCompilationDirectory(dirname($fileName), $permissions);
-        $this->writeFileAtomic($fileName, $fileContent, $permissions);
+        $this->createCompilationDirectory(dirname($fileName), $directoryPermission);
+        $this->writeFileAtomic($fileName, $fileContent, $filePermission);
 
         return $fileName;
     }
 
-    private function writeFileAtomic(string $fileName, string $content, array $permissions) : void
+    private function writeFileAtomic(string $fileName, string $content, int $filePermission) : void
     {
         $tmpFile = @tempnam(dirname($fileName), 'swap-compile');
         if ($tmpFile === false) {
@@ -180,7 +181,7 @@ class Compiler
             throw new InvalidArgumentException(sprintf('Error while writing to %s', $tmpFile));
         }
 
-        @chmod($tmpFile, $permissions['file']);
+        @chmod($tmpFile, $filePermission);
         $renamed = @rename($tmpFile, $fileName);
         if (!$renamed) {
             @unlink($tmpFile);
@@ -334,9 +335,9 @@ class Compiler
         return var_export($value, true);
     }
 
-    private function createCompilationDirectory(string $directory, array $permissions) : void
+    private function createCompilationDirectory(string $directory, int $directoryPermission) : void
     {
-        if (!is_dir($directory) && !@mkdir($directory, $permissions['dir'], true) && !is_dir($directory)) {
+        if (!is_dir($directory) && !@mkdir($directory, $directoryPermission, true) && !is_dir($directory)) {
             throw new InvalidArgumentException(sprintf('Compilation directory does not exist and cannot be created: %s.', $directory));
         }
         if (!is_writable($directory)) {

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -76,10 +76,9 @@ class ContainerBuilder
 
     private ?string $compileToDirectory = null;
 
-    private array $permissions = [
-        'file' => 0664,
-        'dir' => 0775
-    ];
+    private int $filePermission = 0664;
+
+    private int $directoryPermission = 0775;
 
     private bool $sourceCache = false;
 
@@ -152,7 +151,8 @@ class ContainerBuilder
                 $containerClass,
                 $this->containerParentClass,
                 $this->useAutowiring,
-                $this->permissions
+                $this->filePermission,
+                $this->directoryPermission
             );
             // Only load the file if it hasn't been already loaded
             // (the container can be created multiple times in the same process)
@@ -209,8 +209,8 @@ class ContainerBuilder
      */
     public function cachePermissions(int $file, int $directory) : self
     {
-        $this->permissions['file'] = $file;
-        $this->permissions['dir'] = $directory;
+        $this->filePermission = $file;
+        $this->directoryPermission = $directory;
         return $this;
     }
 


### PR DESCRIPTION
When you enable compilation in PHP-DI:

```php
$containerBuilder = new ContainerBuilder();
$containerBuilder->enableCompilation('/var/www/cache');
```

Directories are created with permission `0777` and files are created with `0666`. This grants read+write to the `other` group in a linux environment, which is widely accepted as unsafe practice.

It is safer to create directories using `0775` and files with `0664` by default.

To that extent, I believe the compiler should be further enhanced, to allow users to configure permissions for better control over their environments.

This change sets new default permissions, and introduces a new `cachePermissions()` method, which a user can use to override those default permissions:

```php
$containerBuilder = new ContainerBuilder();
$containerBuilder->enableCompilation('/var/www/cache');
$containerBuilder->cachePermissions(0644, 0755);
```