### PR TITLE
Enum value definitions

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -51,7 +51,8 @@ return $config->setRules([
     'single_line_throw' => false,
     'php_unit_method_casing' => false,
     'blank_line_between_import_groups' => false,
-        'global_namespace_import' => false,
+    'global_namespace_import' => false,
+    'nullable_type_declaration_for_default_null_value' => false,
 ])
     ->setRiskyAllowed(true)
     ->setFinder($finder);

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -362,6 +362,9 @@ class Compiler
         if ($value instanceof \Closure) {
             return true;
         }
+        if ($value instanceof \UnitEnum) {
+            return true;
+        }
         if (is_object($value)) {
             return 'An object was found but objects cannot be compiled';
         }

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -362,7 +362,8 @@ class Compiler
         if ($value instanceof \Closure) {
             return true;
         }
-        if ($value instanceof \UnitEnum) {
+        /** @psalm-suppress UndefinedClass */
+        if ((\PHP_VERSION_ID >= 80100) && ($value instanceof \UnitEnum)) {
             return true;
         }
         if (is_object($value)) {

--- a/tests/IntegrationTest/Definitions/ObjectDefinition/Enum1.php
+++ b/tests/IntegrationTest/Definitions/ObjectDefinition/Enum1.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\IntegrationTest\Definitions\ObjectDefinition;
+
+enum Enum1
+{
+    case Foo;
+    case Bar;
+    Case Baz;
+}

--- a/tests/IntegrationTest/Definitions/ObjectDefinition/Enum2.php
+++ b/tests/IntegrationTest/Definitions/ObjectDefinition/Enum2.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\IntegrationTest\Definitions\ObjectDefinition;
+
+enum Enum2: string
+{
+    case Foo = 'foo';
+    case Bar = 'bar';
+    Case Baz = 'baz';
+}

--- a/tests/IntegrationTest/Definitions/ValueDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/ValueDefinitionTest.php
@@ -6,6 +6,8 @@ namespace DI\Test\IntegrationTest\Definitions;
 
 use DI\ContainerBuilder;
 use DI\Test\IntegrationTest\BaseContainerTest;
+use DI\Test\IntegrationTest\Definitions\ObjectDefinition\Enum1;
+use DI\Test\IntegrationTest\Definitions\ObjectDefinition\Enum2;
 use stdClass;
 
 /**
@@ -43,5 +45,27 @@ class ValueDefinitionTest extends BaseContainerTest
 
         self::assertEntryIsCompiled($container, 'closure');
         $this->assertEquals('foo', call_user_func($container->get('closure')));
+    }
+
+    /**
+     * @dataProvider provideContainer
+     */
+    public function test_enum_value_definitions(ContainerBuilder $builder)
+    {
+        if (PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped("PHP 8.1 required for enum value definitions");
+        }
+
+        $builder->addDefinitions([
+            'unit_enum'   => Enum1::Foo,
+            'backed_enum' => Enum2::Bar,
+        ]);
+        $container = $builder->build();
+
+        self::assertEntryIsCompiled($container, 'unit_enum');
+        $this->assertEquals(Enum1::Foo, $container->get('unit_enum'));
+
+        self::assertEntryIsCompiled($container, 'backed_enum');
+        $this->assertEquals(Enum2::Bar, $container->get('backed_enum'));
     }
 }


### PR DESCRIPTION
PHP 8.1 added native enumerations, but currently using an enum case as a value definition generates an error when attempting to compile the container: `An object was found but objects cannot be compiled`. This change simply allows objects which are enum cases to be compiled. I've also added tests for enum cases as value definitions.