### PR TITLE
Fix public readonly property injection

### DIFF
--- a/src/Compiler/ObjectCreationCompiler.php
+++ b/src/Compiler/ObjectCreationCompiler.php
@@ -57,10 +57,10 @@ class ObjectCreationCompiler
 
                 $propertyClassName = $propertyInjection->getClassName() ?: $className;
                 $property = new ReflectionProperty($propertyClassName, $propertyInjection->getPropertyName());
-                if ($property->isPublic()) {
+                if ($property->isPublic() && !(\PHP_VERSION_ID >= 80100 && $property->isReadOnly())) {
                     $code[] = sprintf('$object->%s = %s;', $propertyInjection->getPropertyName(), $value);
                 } else {
-                    // Private/protected property
+                    // Private/protected/readonly property
                     $code[] = sprintf(
                         '\DI\Definition\Resolver\ObjectCreator::setPrivatePropertyValue(%s, $object, \'%s\', %s);',
                         var_export($propertyInjection->getClassName(), true),

--- a/src/Definition/Resolver/ObjectCreator.php
+++ b/src/Definition/Resolver/ObjectCreator.php
@@ -199,7 +199,7 @@ class ObjectCreator implements DefinitionResolver
         $className = $className ?: $object::class;
 
         $property = new ReflectionProperty($className, $propertyName);
-        if (! $property->isPublic()) {
+        if (! $property->isPublic() && \PHP_VERSION_ID < 80100) {
             $property->setAccessible(true);
         }
         $property->setValue($object, $propertyValue);


### PR DESCRIPTION
The compiler tries to initialize all public properties directly inside the compiled container, however readonly properties do not support writing from an outside scope.

Additionally, I noticed a small room for a performance improvement: `ReflectionProperty::setAccessible()` doesn't have to be invoked as of PHP 8.1 (https://wiki.php.net/rfc/make-reflection-setaccessible-no-op), so I fixed it as well in a separate commit.