### PR TITLE
Fix write proxies regression

### DIFF
--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -247,7 +247,7 @@ class ContainerBuilder
                 'The proxy directory must be specified if you want to write proxies on disk'
             );
         }
-        $this->proxyDirectory = $proxyDirectory;
+        $this->proxyDirectory = $writeToFile ? $proxyDirectory : null;
 
         return $this;
     }

--- a/tests/UnitTest/ContainerBuilderTest.php
+++ b/tests/UnitTest/ContainerBuilderTest.php
@@ -256,7 +256,7 @@ class ContainerBuilderTest extends TestCase
     public function should_create_proxies()
     {
         $builder = new ContainerBuilder(FakeContainer::class);
-		$builder->writeProxiesToFile(true, 'somedir');
+        $builder->writeProxiesToFile(true, 'somedir');
         $container = $builder->build();
 
         $this->assertSame('somedir', self::getProperty($container->proxyFactory, 'proxyDirectory'));
@@ -268,7 +268,7 @@ class ContainerBuilderTest extends TestCase
     public function should_not_create_proxies()
     {
         $builder = new ContainerBuilder(FakeContainer::class);
-		$builder->writeProxiesToFile(false, 'somedir');
+        $builder->writeProxiesToFile(false, 'somedir');
         $container = $builder->build();
 
         $this->assertNull(self::getProperty($container->proxyFactory, 'proxyDirectory'));


### PR DESCRIPTION
Fixes the `ContainerBuilder->writeToProxies` regression introduced in 7.0 (see #866).
