### PR TITLE
Make Container return template type with conditional return type

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -118,6 +118,7 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
      * @param string|class-string<T> $id Entry name or a class name.
      *
      * @return mixed|T
+     * @psalm-return ($id is class-string<T> ? T : mixed)
      * @throws DependencyException Error while resolving the entry.
      * @throws NotFoundException No entry found for the given name.
      */
@@ -165,6 +166,7 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
      *                                           array will be resolved using the container.
      *
      * @return mixed|T
+     * @psalm-return ($id is class-string<T> ? T : mixed)
      * @throws InvalidArgumentException The name parameter must be of type string.
      * @throws DependencyException Error while resolving the entry.
      * @throws NotFoundException No entry found for the given name.
@@ -204,6 +206,7 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
      * @template T
      * @param object|T $instance Object to perform injection upon
      * @return object|T $instance Returns the same instance
+     * @psalm-return T
      * @throws InvalidArgumentException
      * @throws DependencyException Error while injecting dependencies
      */


### PR DESCRIPTION
Generally when we pass a class name to a container we expect only objects of that class to be returned, not mixed.

In particular, PHPStan normalizes the `T|mixed` type to `mixed`, so the old type would not work.

Conditional return types notation is supported by both Psalm and PHPStan and provides a more appropriate type for both.

- https://psalm.dev/docs/annotating_code/type_syntax/conditional_types/
- https://phpstan.org/blog/phpstan-1-6-0-with-conditional-return-types

I've been using this patch for over a year now and it's working fine with PHPStan in our application.