### PR TITLE
Update tests for phpunit 10 compatibility

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,7 @@
         </testsuite>
         <testsuite name="integration">
             <directory>./tests/IntegrationTest/</directory>
+            <exclude>./tests/IntegrationTest/BaseContainerTest.php</exclude>
         </testsuite>
     </testsuites>
 

--- a/tests/IntegrationTest/BaseContainerTest.php
+++ b/tests/IntegrationTest/BaseContainerTest.php
@@ -32,7 +32,7 @@ abstract class BaseContainerTest extends TestCase
         parent::setUp();
     }
 
-    public function provideContainer() : array
+    public static function provideContainer() : array
     {
         // Clear all files
         array_map('unlink', glob(self::COMPILATION_DIR . '/*'));

--- a/tests/IntegrationTest/Definitions/FactoryDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/FactoryDefinitionTest.php
@@ -39,7 +39,7 @@ class FactoryDefinitionTest extends BaseContainerTest
         $this->assertEquals('bar', $container->get('factory'));
     }
 
-    public function provideCallables(): array
+    public static function provideCallables(): array
     {
         $callables = [
             'closure' => function () {
@@ -57,7 +57,7 @@ class FactoryDefinitionTest extends BaseContainerTest
 
         $testCases = [];
         foreach ($callables as $callableName => $callable) {
-            foreach ($this->provideContainer() as $containerName => $container) {
+            foreach (self::provideContainer() as $containerName => $container) {
                 $testCases[$containerName . ' - ' . $callableName] = [$callable, clone $container[0]];
             }
         }


### PR DESCRIPTION
I propose this patch because it landed into Debian as https://sources.debian.org/src/php-di/7.0.5-1/debian/patches/0002-Ajust-tests-for-phpunit-10.patch/

I understand that currently phpunit 10 can not be run because of `mnapoli/phpunit-easymock` but all the content still makes sense. As providers should have been static since quite some phpunit versions. Only enforced now. (we run the test suite with phpunit 10 at Debian it works great)