### PR TITLE
ci: github actions - PHP 8.2 & 8.3 pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         timeout-minutes: 15
         strategy:
             matrix:
-                php: [ '8.0', '8.1' ]
+                php: [ '8.0', '8.1', '8.2', '8.3' ]
                 dependency-version: [ '' ]
                 include:
                     -   php: '8.0'


### PR DESCRIPTION
This PR enables CI pipelines for PHP 8.2 and 8.3, 

https://www.php.net/supported-versions.php
https://www.php.net/releases/index.php 

<img width="485" alt="image" src="https://github.com/PHP-DI/PHP-DI/assets/1732227/36f4451b-c2f9-45aa-8139-108cf5e72a73">

