### PR TITLE
feat: php-cs-fixer - removing deprecations

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -15,9 +15,14 @@ return $config->setRules([
     '@Symfony' => true,
     '@Symfony:risky' => true,
     'array_syntax' => ['syntax' => 'short'],
-    'braces' => [
-        'allow_single_line_closure' => true,
-    ],
+    'single_space_around_construct' => true,
+    'control_structure_braces' => true,
+    'control_structure_continuation_position' => true,
+    'declare_parentheses' => true,
+    'no_multiple_statements_per_line' => true,
+    'braces_position' => true,
+    'statement_indentation' => true,
+    'no_extra_blank_lines' => true,
     'concat_space' => [
         'spacing' => 'one',
     ],


### PR DESCRIPTION
```
1. Detected deprecations in use:
- Rule "braces" is deprecated. Use "single_space_around_construct", "control_structure_braces", "control_structure_continuation_position", "declare_parentheses", "no_multiple_statements_per_line", "curly_braces_position", "statement_indentation" and "no_extra_blank_lines" instead.
```

```
2. Detected deprecations in use:
- Rule "curly_braces_position" is deprecated. Use "braces_position" instead.
```