### PR TITLE
Ability to specify PSR-3 logger to log an autowire hit

### DIFF
--- a/doc/autowiring.md
+++ b/doc/autowiring.md
@@ -47,6 +47,15 @@ As you can imagine, it's very simple, doesn't require any configuration, and it 
 $containerBuilder->useAutowiring(false);
 ```
 
+It may be helpful not to disable autowiring but have logs about autowiring made a hit. You can enable logging using the container builder:
+
+```php
+// of course, you can use any other PSR-3 logger, Monolog is just an example
+$logger = new \Monolog\Logger('php-di');
+
+$containerBuilder->setLogger($logger, \Psr\Log\LogLevel::INFO);
+```
+
 ## Limitations
 
 PHP-DI won't be able to resolve cases like this:

--- a/src/Definition/Source/AttributeBasedAutowiring.php
+++ b/src/Definition/Source/AttributeBasedAutowiring.php
@@ -28,6 +28,8 @@ use Throwable;
  */
 class AttributeBasedAutowiring implements DefinitionSource, Autowiring
 {
+    use LogeableSource;
+
     /**
      * @throws InvalidAttribute
      */
@@ -38,6 +40,8 @@ class AttributeBasedAutowiring implements DefinitionSource, Autowiring
         if (!class_exists($className) && !interface_exists($className)) {
             return $definition;
         }
+
+        $this->logger?->log($this->logLevel, sprintf('Autowiring %s', $name));
 
         $definition = $definition ?: new ObjectDefinition($name);
 

--- a/src/Definition/Source/LogeableSource.php
+++ b/src/Definition/Source/LogeableSource.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Definition\Source;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+trait LogeableSource
+{
+    protected ?LoggerInterface $logger = null;
+
+    /** @psalm-var LogLevel::* */
+    protected ?string $logLevel = null;
+
+    /**
+     * @psalm-param LogLevel::* $logLevel
+     * @throws \InvalidArgumentException in case of invalid log level
+     */
+    public function setLogger(LoggerInterface $logger, string $logLevel = LogLevel::DEBUG): self
+    {
+        $allowedLogLevels = [
+            LogLevel::DEBUG,
+            LogLevel::INFO,
+            LogLevel::NOTICE,
+            LogLevel::WARNING,
+            LogLevel::ERROR,
+            LogLevel::CRITICAL,
+            LogLevel::ALERT,
+            LogLevel::EMERGENCY,
+        ];
+        if (!in_array($logLevel, $allowedLogLevels, true)) {
+            throw new \InvalidArgumentException(sprintf('Invalid log level "%s"', $logLevel));
+        }
+
+        $this->logger = $logger;
+        $this->logLevel = $logLevel;
+
+        return $this;
+    }
+}

--- a/src/Definition/Source/ReflectionBasedAutowiring.php
+++ b/src/Definition/Source/ReflectionBasedAutowiring.php
@@ -16,6 +16,8 @@ use ReflectionNamedType;
  */
 class ReflectionBasedAutowiring implements DefinitionSource, Autowiring
 {
+    use LogeableSource;
+
     public function autowire(string $name, ObjectDefinition $definition = null) : ObjectDefinition|null
     {
         $className = $definition ? $definition->getClassName() : $name;
@@ -23,6 +25,8 @@ class ReflectionBasedAutowiring implements DefinitionSource, Autowiring
         if (!class_exists($className) && !interface_exists($className)) {
             return $definition;
         }
+
+        $this->logger?->log($this->logLevel, sprintf('Autowiring %s', $name));
 
         $definition = $definition ?: new ObjectDefinition($name);
 

--- a/tests/UnitTest/ContainerBuilderTest.php
+++ b/tests/UnitTest/ContainerBuilderTest.php
@@ -14,6 +14,7 @@ use DI\Test\UnitTest\Fixtures\FakeContainer;
 use EasyMock\EasyMock;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * @covers \DI\ContainerBuilder
@@ -233,6 +234,9 @@ class ContainerBuilderTest extends TestCase
         $this->assertSame($builder, $result);
 
         $result = $builder->wrapContainer($this->easyMock(ContainerInterface::class));
+        $this->assertSame($builder, $result);
+
+        $result = $builder->setLogger($this->easyMock(LoggerInterface::class));
         $this->assertSame($builder, $result);
     }
 

--- a/tests/UnitTest/ContainerBuilderTest.php
+++ b/tests/UnitTest/ContainerBuilderTest.php
@@ -12,6 +12,7 @@ use DI\Definition\ValueDefinition;
 use DI\Test\IntegrationTest\BaseContainerTest;
 use DI\Test\UnitTest\Fixtures\FakeContainer;
 use EasyMock\EasyMock;
+use Generator;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -243,15 +244,16 @@ class ContainerBuilderTest extends TestCase
     /**
      * Ensure the ContainerBuilder cannot be modified after the container has been built.
      * @test
+     * @dataProvider modifyMethods
      */
-    public function should_throw_if_modified_after_building_a_container()
+    public function should_throw_if_modified_after_building_a_container(string $modifyMethod, mixed ...$args)
     {
         $this->expectException('LogicException');
         $this->expectExceptionMessage('The ContainerBuilder cannot be modified after the container has been built');
         $builder = new ContainerBuilder();
         $builder->build();
 
-        $builder->addDefinitions([]);
+        $builder->$modifyMethod(...$args);
     }
 
     /**
@@ -276,5 +278,17 @@ class ContainerBuilderTest extends TestCase
         $container = $builder->build();
 
         $this->assertNull(self::getProperty($container->proxyFactory, 'proxyDirectory'));
+    }
+
+    public function modifyMethods(): Generator
+    {
+        yield 'enable-compilation' => ['enableCompilation', 'foo', 'bar', 'baz'];
+        yield 'use-autowiring' => ['useAutowiring', false];
+        yield 'use-attributes' => ['useAttributes', false];
+        yield 'write-proxies-to-file' => ['writeProxiesToFile', false, 'somedir'];
+        yield 'wrap-container' => ['wrapContainer', $this->easyMock(ContainerInterface::class)];
+        yield 'add-definitions' => ['addDefinitions', ['foo' => 'bar']];
+        yield 'enable-definition-cache' => ['enableDefinitionCache', 'someNS'];
+        yield 'set-logger' => ['setLogger', $this->easyMock(LoggerInterface::class)];
     }
 }

--- a/tests/UnitTest/Definition/Source/ReflectionBasedAutowiringTest.php
+++ b/tests/UnitTest/Definition/Source/ReflectionBasedAutowiringTest.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace DI\Test\UnitTest\Definition\Source;
 
 use DI\Definition\Reference;
+use Generator;
 use PHPUnit\Framework\TestCase;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\ObjectDefinition\MethodInjection;
 use DI\Definition\Source\ReflectionBasedAutowiring;
 use DI\Test\UnitTest\Definition\Source\Fixtures\AutowiringFixture;
 use DI\Test\UnitTest\Definition\Source\Fixtures\AutowiringFixtureChild;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 /**
  * @covers \DI\Definition\Source\ReflectionBasedAutowiring
@@ -51,5 +54,46 @@ class ReflectionBasedAutowiringTest extends TestCase
 
         $param1 = $parameters[0];
         $this->assertEquals(new Reference(AutowiringFixture::class), $param1);
+    }
+
+    public function testAutowireHitLoggedAtDefaultLogLevel(): void
+    {
+        $class = AutowiringFixture::class;
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects($this->once())
+            ->method('log')
+            // Log level is set to debug by default
+            ->with(LogLevel::DEBUG, "Autowiring {$class}");
+
+        $autowiring = (new ReflectionBasedAutowiring())->setLogger($loggerMock);
+
+        $autowiring->autowire($class);
+    }
+
+    /** @dataProvider availableLogLevels */
+    public function testAutowireHitLogged(string $logLevel): void
+    {
+        $class = AutowiringFixture::class;
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects($this->once())
+            ->method('log')
+            ->with($logLevel, "Autowiring {$class}");
+
+        $autowiring = (new ReflectionBasedAutowiring())->setLogger($loggerMock, $logLevel);
+
+        $autowiring->autowire($class);
+    }
+
+    /** @return Generator<string> */
+    public function availableLogLevels(): Generator
+    {
+        yield 'debug' => [LogLevel::DEBUG];
+        yield 'info' => [LogLevel::INFO];
+        yield 'notice' => [LogLevel::NOTICE];
+        yield 'warning' => [LogLevel::WARNING];
+        yield 'error' => [LogLevel::ERROR];
+        yield 'critical' => [LogLevel::CRITICAL];
+        yield 'alert' => [LogLevel::ALERT];
+        yield 'emergency' => [LogLevel::EMERGENCY];
     }
 }


### PR DESCRIPTION
The issue is described here https://github.com/PHP-DI/PHP-DI/issues/608
------

Because autowiring is not a cheap operation and can be significantly optimized by compiling container - I, as a developer, want to know for what class autowiring happened.

To solve this, currently, there is only one option - disable autowiring and try to fix an exception in classes that weren't specified to autowire in the container definitions. In some cases, it's not a good solution.

This PR provides a new option to solve this - provide a logger and log autowiring hit, so I, as a developer, can smoothly fix it without production being broken.