### PR TITLE
adds windows-latest to github action tests and corrects PHP_EOL to \n…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,20 @@ on:
 jobs:
 
     tests:
-        name: Tests - PHP ${{ matrix.php }} ${{ matrix.dependency-version }}
-        runs-on: ubuntu-latest
+        name: Tests ${{ matrix.os }} - PHP ${{ matrix.php }}
         timeout-minutes: 15
         strategy:
             matrix:
+                os: [ubuntu-latest, windows-latest]
                 php: [ '8.0', '8.1', '8.2', '8.3' ]
-                dependency-version: [ '' ]
-                include:
-                    -   php: '8.0'
-                        dependency-version: '--prefer-lowest'
+        runs-on: ${{ matrix.os }}        
         steps:
+            -   name: Set git to use LF
+                run: |
+                    git config --global core.autocrlf input
+                    git config --global core.eol lf
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v4
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
@@ -32,19 +33,15 @@ jobs:
                     coverage: none
                     # Enable apcu
                     extensions: apcu
-                    ini-values: apc.enable_cli=1
+                    ini-values: apc.enable_cli=1, opcache.enable=1, opcache.jit=tracing, opcache.jit_buffer_size=128M
             -   name: Cache Composer dependencies
-                uses: actions/cache@v2
+                uses: actions/cache@v4
                 with:
                     path: ~/.composer/cache
                     key: php-${{ matrix.php }}-composer-locked-${{ hashFiles('composer.lock') }}
                     restore-keys: php-${{ matrix.php }}-composer-locked-
             -   name: Install PHP dependencies
-                if: matrix.php != '8.1'
-                run: composer update ${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress --no-suggest
-            -   name: 'Install PHP dependencies on PHP 8.1 (TODO: remove that)'
-                if: matrix.php == '8.1'
-                run: composer update --ignore-platform-reqs ${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress --no-suggest
+                run: composer update ${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress
             -   name: PHPUnit
                 run: vendor/bin/phpunit
 
@@ -53,15 +50,15 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v4
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.0
+                    php-version: 8.3
                     tools: composer:v2, cs2pr
                     coverage: none
             -   name: Cache Composer dependencies
-                uses: actions/cache@v2
+                uses: actions/cache@v4
                 with:
                     path: ~/.composer/cache
                     key: php-composer-locked-${{ hashFiles('composer.lock') }}
@@ -75,15 +72,15 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v4
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.0
+                    php-version: 8.3
                     tools: composer:v2, cs2pr
                     coverage: none
             -   name: Cache Composer dependencies
-                uses: actions/cache@v2
+                uses: actions/cache@v4
                 with:
                     path: ~/.composer/cache
                     key: php-composer-locked-${{ hashFiles('composer.lock') }}

--- a/src/Definition/ArrayDefinition.php
+++ b/src/Definition/ArrayDefinition.php
@@ -42,7 +42,7 @@ class ArrayDefinition implements Definition
 
     public function __toString() : string
     {
-        $str = '[' . \PHP_EOL;
+        $str = '[' . "\n";
 
         foreach ($this->values as $key => $value) {
             if (is_string($key)) {
@@ -52,12 +52,12 @@ class ArrayDefinition implements Definition
             $str .= '    ' . $key . ' => ';
 
             if ($value instanceof Definition) {
-                $str .= str_replace(\PHP_EOL, \PHP_EOL . '    ', (string) $value);
+                $str .= str_replace("\n", "\n" . '    ', (string) $value);
             } else {
                 $str .= var_export($value, true);
             }
 
-            $str .= ',' . \PHP_EOL;
+            $str .= ',' . "\n";
         }
 
         return $str . ']';

--- a/src/Definition/Dumper/ObjectDefinitionDumper.php
+++ b/src/Definition/Dumper/ObjectDefinitionDumper.php
@@ -35,7 +35,7 @@ class ObjectDefinitionDumper
         $str = sprintf('    class = %s%s', $warning, $className);
 
         // Lazy
-        $str .= \PHP_EOL . '    lazy = ' . var_export($definition->isLazy(), true);
+        $str .= "\n" . '    lazy = ' . var_export($definition->isLazy(), true);
 
         if ($classExist) {
             // Constructor
@@ -48,7 +48,7 @@ class ObjectDefinitionDumper
             $str .= $this->dumpMethods($className, $definition);
         }
 
-        return sprintf('Object (' . \PHP_EOL . '%s' . \PHP_EOL . ')', $str);
+        return sprintf('Object (' . "\n" . '%s' . "\n" . ')', $str);
     }
 
     /**
@@ -63,7 +63,7 @@ class ObjectDefinitionDumper
         if ($constructorInjection !== null) {
             $parameters = $this->dumpMethodParameters($className, $constructorInjection);
 
-            $str .= sprintf(\PHP_EOL . '    __construct(' . \PHP_EOL . '        %s' . \PHP_EOL . '    )', $parameters);
+            $str .= sprintf("\n" . '    __construct(' . "\n" . '        %s' . "\n" . '    )', $parameters);
         }
 
         return $str;
@@ -77,7 +77,7 @@ class ObjectDefinitionDumper
             $value = $propertyInjection->getValue();
             $valueStr = $value instanceof Definition ? (string) $value : var_export($value, true);
 
-            $str .= sprintf(\PHP_EOL . '    $%s = %s', $propertyInjection->getPropertyName(), $valueStr);
+            $str .= sprintf("\n" . '    $%s = %s', $propertyInjection->getPropertyName(), $valueStr);
         }
 
         return $str;
@@ -93,7 +93,7 @@ class ObjectDefinitionDumper
         foreach ($definition->getMethodInjections() as $methodInjection) {
             $parameters = $this->dumpMethodParameters($className, $methodInjection);
 
-            $str .= sprintf(\PHP_EOL . '    %s(' . \PHP_EOL . '        %s' . \PHP_EOL . '    )', $methodInjection->getMethodName(), $parameters);
+            $str .= sprintf("\n" . '    %s(' . "\n" . '        %s' . "\n" . '    )', $methodInjection->getMethodName(), $parameters);
         }
 
         return $str;
@@ -139,6 +139,6 @@ class ObjectDefinitionDumper
             $args[] = sprintf('$%s = #UNDEFINED#', $parameter->getName());
         }
 
-        return implode(\PHP_EOL . '        ', $args);
+        return implode("\n" . '        ', $args);
     }
 }

--- a/src/Definition/EnvironmentVariableDefinition.php
+++ b/src/Definition/EnvironmentVariableDefinition.php
@@ -68,20 +68,20 @@ class EnvironmentVariableDefinition implements Definition
 
     public function __toString() : string
     {
-        $str = '    variable = ' . $this->variableName . \PHP_EOL
+        $str = '    variable = ' . $this->variableName . "\n"
             . '    optional = ' . ($this->isOptional ? 'yes' : 'no');
 
         if ($this->isOptional) {
             if ($this->defaultValue instanceof Definition) {
                 $nestedDefinition = (string) $this->defaultValue;
-                $defaultValueStr = str_replace(\PHP_EOL, \PHP_EOL . '    ', $nestedDefinition);
+                $defaultValueStr = str_replace("\n", "\n" . '    ', $nestedDefinition);
             } else {
                 $defaultValueStr = var_export($this->defaultValue, true);
             }
 
-            $str .= \PHP_EOL . '    default = ' . $defaultValueStr;
+            $str .= "\n" . '    default = ' . $defaultValueStr;
         }
 
-        return sprintf('Environment variable (' . \PHP_EOL . '%s' . \PHP_EOL . ')', $str);
+        return sprintf('Environment variable (' . "\n" . '%s' . "\n" . ')', $str);
     }
 }

--- a/src/Definition/Exception/InvalidDefinition.php
+++ b/src/Definition/Exception/InvalidDefinition.php
@@ -17,7 +17,7 @@ class InvalidDefinition extends \Exception implements ContainerExceptionInterfac
     public static function create(Definition $definition, string $message, \Exception $previous = null) : self
     {
         return new self(sprintf(
-            '%s' . \PHP_EOL . 'Full definition:' . \PHP_EOL . '%s',
+            '%s' . "\n" . 'Full definition:' . "\n" . '%s',
             $message,
             (string) $definition
         ), 0, $previous);


### PR DESCRIPTION
+ bumped actions to v4 to avoid warnings

Corrected PHP_EOL to \n, because [of ](https://github.com/PHP-DI/PHP-DI/pull/276) was not a proper fix for that.
