### PR TITLE
allow casting env variables

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "scripts": {
-        "test": "phpunit",
+        "test": "DI_INT_ENV=123 DI_FLOAT_ENV=12.3 DI_STRING_ENV=hello DI_BOOL_TRUE_ENV=1 DI_BOOL_FALSE_ENV=0 phpunit",
         "format-code": "php-cs-fixer fix --allow-risky=yes"
     },
     "require": {

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DI\Compiler;
 
-use function chmod;
 use DI\Definition\ArrayDefinition;
+use DI\Definition\Castable;
 use DI\Definition\DecoratorDefinition;
 use DI\Definition\Definition;
 use DI\Definition\EnvironmentVariableDefinition;
@@ -18,10 +18,12 @@ use DI\Definition\StringDefinition;
 use DI\Definition\ValueDefinition;
 use DI\DependencyException;
 use DI\Proxy\ProxyFactory;
-use function dirname;
-use function file_put_contents;
 use InvalidArgumentException;
 use Laravel\SerializableClosure\Support\ReflectionClosure;
+
+use function chmod;
+use function dirname;
+use function file_put_contents;
 use function rename;
 use function sprintf;
 use function tempnam;
@@ -222,9 +224,10 @@ class Compiler
                 $variableName = $this->compileValue($definition->getVariableName());
                 $isOptional = $this->compileValue($definition->isOptional());
                 $defaultValue = $this->compileValue($definition->getDefaultValue());
+                $cast = $definition->getCast();
                 $code = <<<PHP
                             \$value = \$_ENV[$variableName] ?? \$_SERVER[$variableName] ?? getenv($variableName);
-                            if (false !== \$value) return \$value;
+                            if (false !== \$value) return ({$cast}) \$value;
                             if (!$isOptional) {
                                 throw new \DI\Definition\Exception\InvalidDefinition("The environment variable '{$definition->getVariableName()}' has not been defined");
                             }

--- a/src/Definition/Castable.php
+++ b/src/Definition/Castable.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Definition;
+
+interface Castable {
+    public function asInt(): static;
+    public function asFloat(): static;
+    public function asBool(): static;
+
+    public function getCast(): string;
+}

--- a/src/Definition/EnvironmentVariableDefinition.php
+++ b/src/Definition/EnvironmentVariableDefinition.php
@@ -10,10 +10,12 @@ namespace DI\Definition;
  *
  * @author James Harris <james.harris@icecave.com.au>
  */
-class EnvironmentVariableDefinition implements Definition
+class EnvironmentVariableDefinition implements Definition, Castable
 {
     /** Entry name. */
     private string $name = '';
+
+    private string $type = 'string';
 
     /**
      * @param string $variableName The name of the environment variable
@@ -83,5 +85,28 @@ class EnvironmentVariableDefinition implements Definition
         }
 
         return sprintf('Environment variable (' . \PHP_EOL . '%s' . \PHP_EOL . ')', $str);
+    }
+
+    public function asInt(): static
+    {
+        $this->type = 'int';
+        return $this;
+    }
+
+    public function asFloat(): static
+    {
+        $this->type = 'float';
+        return $this;
+    }
+
+    public function asBool(): static
+    {
+        $this->type = 'bool';
+        return $this;
+    }
+
+    public function getCast(): string
+    {
+        return $this->type;
     }
 }

--- a/src/Definition/Resolver/EnvironmentVariableResolver.php
+++ b/src/Definition/Resolver/EnvironmentVariableResolver.php
@@ -7,6 +7,7 @@ namespace DI\Definition\Resolver;
 use DI\Definition\Definition;
 use DI\Definition\EnvironmentVariableDefinition;
 use DI\Definition\Exception\InvalidDefinition;
+use PhpParser\Node\Expr\Cast;
 
 /**
  * Resolves a environment variable definition to a value.
@@ -37,7 +38,12 @@ class EnvironmentVariableResolver implements DefinitionResolver
         $value = call_user_func($this->variableReader, $definition->getVariableName());
 
         if (false !== $value) {
-            return $value;
+            return match($definition->getCast()) {
+                'int' => (int) $value,
+                'float' => (float) $value,
+                'bool' => (bool) $value,
+                default => $value,
+            };
         }
 
         if (!$definition->isOptional()) {

--- a/tests/IntegrationTest/Definitions/EnvironmentVariableDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/EnvironmentVariableDefinitionTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace DI\Test\IntegrationTest\Definitions;
 
 use DI\ContainerBuilder;
-use DI\Test\IntegrationTest\BaseContainerTest;
 use DI\Definition\Exception\InvalidDefinition;
+use DI\Test\IntegrationTest\BaseContainerTest;
 
 /**
  * Test environment variable definitions.
@@ -19,7 +19,7 @@ class EnvironmentVariableDefinitionTest extends BaseContainerTest
     public function test_existing_env_variable(ContainerBuilder $builder)
     {
         $expectedValue = getenv('USER');
-        if (! $expectedValue) {
+        if (!$expectedValue) {
             $this->markTestSkipped(
                 'This test relies on the presence of the USER environment variable.'
             );
@@ -32,6 +32,34 @@ class EnvironmentVariableDefinitionTest extends BaseContainerTest
 
         self::assertEntryIsCompiled($container, 'var');
         self::assertEquals($expectedValue, $container->get('var'));
+    }
+
+    /**
+     * @dataProvider provideContainer
+     */
+    public function test_cast(ContainerBuilder $builder)
+    {
+        $expectedValues = [
+            'int' => (int) getenv('DI_INT_ENV'),
+            'float' => (float) getenv('DI_FLOAT_ENV'),
+            'string' => (string) getenv('DI_STRING_ENV'),
+            'bool_true' => (bool) getenv('DI_BOOL_TRUE_ENV'),
+            'bool_false' => (bool) getenv('DI_BOOL_FALSE_ENV'),
+        ];
+
+        $builder->addDefinitions([
+            'int' => \DI\env('DI_INT_ENV')->asInt(),
+            'float' => \DI\env('DI_FLOAT_ENV')->asFloat(),
+            'string' => \DI\env('DI_STRING_ENV'),
+            'bool_true' => \DI\env('DI_BOOL_TRUE_ENV')->asBool(),
+            'bool_false' => \DI\env('DI_BOOL_FALSE_ENV')->asBool(),
+        ]);
+        $container = $builder->build();
+
+        foreach($expectedValues as $name => $expectedValue) {
+            self::assertEntryIsCompiled($container, $name);
+            self::assertSame($expectedValue, $container->get($name));
+        }
     }
 
     /**


### PR DESCRIPTION
This closes #878 by adding the ability to do `\DI\env('MY_ENV_VAR')->asInt()` and have the (compiled) container cast the value to the expected type.