### PR TITLE
Added "Interface" suffix to interface names

### DIFF
--- a/doc/php-definitions.md
+++ b/doc/php-definitions.md
@@ -230,10 +230,10 @@ Please note:
 If you want to reuse the same factory for creating different entries, you might want to retrieve the name of the entry that is currently being resolved. You can do this by injecting the `DI\Factory\RequestedEntry` object using a type-hint:
 
 ```php
-use DI\Factory\RequestedEntry;
+use DI\Factory\RequestedEntryInterface;
 
 return [
-    'Foo' => function (RequestedEntry $entry) {
+    'Foo' => function (RequestedEntryInterface $entry) {
         // $entry->getName() contains the requested name
         $class = $entry->getName();
         return new $class();

--- a/src/CompiledContainer.php
+++ b/src/CompiledContainer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace DI;
 
 use DI\Compiler\RequestedEntryHolder;
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\Definition\Exception\InvalidDefinition;
 use DI\Invoker\FactoryParameterResolver;
 use Invoker\Exception\NotCallableException;
@@ -76,7 +76,7 @@ abstract class CompiledContainer extends Container
         return parent::has($id);
     }
 
-    protected function setDefinition(string $name, Definition $definition) : void
+    protected function setDefinition(string $name, DefinitionInterface $definition) : void
     {
         // It needs to be forbidden because that would mean get() must go through the definitions
         // every time, which kinds of defeats the performance gains of the compiled container

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -7,7 +7,7 @@ namespace DI\Compiler;
 use function chmod;
 use DI\Definition\ArrayDefinition;
 use DI\Definition\DecoratorDefinition;
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\Definition\EnvironmentVariableDefinition;
 use DI\Definition\Exception\InvalidDefinition;
 use DI\Definition\FactoryDefinition;
@@ -194,7 +194,7 @@ class Compiler
      * @throws DependencyException
      * @throws InvalidDefinition
      */
-    private function compileDefinition(string $entryName, Definition $definition) : string
+    private function compileDefinition(string $entryName, DefinitionInterface $definition) : string
     {
         // Generate a unique method name
         $methodName = 'get' . (++$this->methodMappingCounter);
@@ -249,7 +249,7 @@ class Compiler
                 break;
             case $definition instanceof DecoratorDefinition:
                 $decoratedDefinition = $definition->getDecoratedDefinition();
-                if (! $decoratedDefinition instanceof Definition) {
+                if (! $decoratedDefinition instanceof DefinitionInterface) {
                     if (! $definition->getName()) {
                         throw new InvalidDefinition('Decorators cannot be nested in another definition');
                     }
@@ -307,7 +307,7 @@ class Compiler
             throw new InvalidDefinition($errorMessage);
         }
 
-        if ($value instanceof Definition) {
+        if ($value instanceof DefinitionInterface) {
             // Give it an arbitrary unique name
             $subEntryName = 'subEntry' . (++$this->subEntryCounter);
             // Compile the sub-definition in another method
@@ -358,7 +358,7 @@ class Compiler
             return 'Decorators cannot be nested in another definition';
         }
         // All other definitions are compilable
-        if ($value instanceof Definition) {
+        if ($value instanceof DefinitionInterface) {
             return true;
         }
         if ($value instanceof \Closure) {

--- a/src/Compiler/RequestedEntryHolder.php
+++ b/src/Compiler/RequestedEntryHolder.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace DI\Compiler;
 
-use DI\Factory\RequestedEntry;
+use DI\Factory\RequestedEntryInterface;
 
 /**
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class RequestedEntryHolder implements RequestedEntry
+class RequestedEntryHolder implements RequestedEntryInterface
 {
     public function __construct(
         private string $name,

--- a/src/Container.php
+++ b/src/Container.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace DI;
 
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\Definition\Exception\InvalidDefinition;
 use DI\Definition\FactoryDefinition;
-use DI\Definition\Helper\DefinitionHelper;
+use DI\Definition\Helper\DefinitionHelperInterface;
 use DI\Definition\InstanceDefinition;
 use DI\Definition\ObjectDefinition;
-use DI\Definition\Resolver\DefinitionResolver;
+use DI\Definition\Resolver\DefinitionResolverInterface;
 use DI\Definition\Resolver\ResolverDispatcher;
 use DI\Definition\Source\DefinitionArray;
 use DI\Definition\Source\MutableDefinitionSource;
@@ -45,12 +45,12 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
 
     private MutableDefinitionSource $definitionSource;
 
-    private DefinitionResolver $definitionResolver;
+    private DefinitionResolverInterface $definitionResolver;
 
     /**
      * Map of definitions that are already fetched (local cache).
      *
-     * @var array<Definition|null>
+     * @var array<DefinitionInterface|null>
      */
     private array $fetchedDefinitions = [];
 
@@ -140,7 +140,7 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
         return $value;
     }
 
-    private function getDefinition(string $name) : ?Definition
+    private function getDefinition(string $name) : ?DefinitionInterface
     {
         // Local cache that avoids fetching the same definition twice
         if (!array_key_exists($name, $this->fetchedDefinitions)) {
@@ -249,11 +249,11 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
      * Define an object or a value in the container.
      *
      * @param string $name Entry name
-     * @param mixed|DefinitionHelper $value Value, use definition helpers to define objects
+     * @param mixed|DefinitionHelperInterface $value Value, use definition helpers to define objects
      */
     public function set(string $name, mixed $value) : void
     {
-        if ($value instanceof DefinitionHelper) {
+        if ($value instanceof DefinitionHelperInterface) {
             $value = $value->getDefinition($name);
         } elseif ($value instanceof \Closure) {
             $value = new FactoryDefinition($name, $value);
@@ -261,7 +261,7 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
 
         if ($value instanceof ValueDefinition) {
             $this->resolvedEntries[$name] = $value->getValue();
-        } elseif ($value instanceof Definition) {
+        } elseif ($value instanceof DefinitionInterface) {
             $value->setName($name);
             $this->setDefinition($name, $value);
         } else {
@@ -296,7 +296,7 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
     public function debugEntry(string $name) : string
     {
         $definition = $this->definitionSource->getDefinition($name);
-        if ($definition instanceof Definition) {
+        if ($definition instanceof DefinitionInterface) {
             return (string) $definition;
         }
 
@@ -338,7 +338,7 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
      *
      * @throws DependencyException Error while resolving the entry.
      */
-    private function resolveDefinition(Definition $definition, array $parameters = []) : mixed
+    private function resolveDefinition(DefinitionInterface $definition, array $parameters = []) : mixed
     {
         $entryName = $definition->getName();
 
@@ -358,7 +358,7 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
         return $value;
     }
 
-    protected function setDefinition(string $name, Definition $definition) : void
+    protected function setDefinition(string $name, DefinitionInterface $definition) : void
     {
         // Clear existing entry if it exists
         if (array_key_exists($name, $this->resolvedEntries)) {

--- a/src/Definition/ArrayDefinition.php
+++ b/src/Definition/ArrayDefinition.php
@@ -10,7 +10,7 @@ namespace DI\Definition;
  * @since 5.0
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class ArrayDefinition implements Definition
+class ArrayDefinition implements DefinitionInterface
 {
     /** Entry name. */
     private string $name = '';
@@ -51,7 +51,7 @@ class ArrayDefinition implements Definition
 
             $str .= '    ' . $key . ' => ';
 
-            if ($value instanceof Definition) {
+            if ($value instanceof DefinitionInterface) {
                 $str .= str_replace(\PHP_EOL, \PHP_EOL . '    ', (string) $value);
             } else {
                 $str .= var_export($value, true);

--- a/src/Definition/ArrayDefinitionExtension.php
+++ b/src/Definition/ArrayDefinitionExtension.php
@@ -12,7 +12,7 @@ use DI\Definition\Exception\InvalidDefinition;
  * @since 5.0
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class ArrayDefinitionExtension extends ArrayDefinition implements ExtendsPreviousDefinition
+class ArrayDefinitionExtension extends ArrayDefinition implements ExtendsPreviousDefinitionInterface
 {
     private ?ArrayDefinition $subDefinition = null;
 
@@ -25,7 +25,7 @@ class ArrayDefinitionExtension extends ArrayDefinition implements ExtendsPreviou
         return array_merge($this->subDefinition->getValues(), parent::getValues());
     }
 
-    public function setExtendedDefinition(Definition $definition) : void
+    public function setExtendedDefinition(DefinitionInterface $definition) : void
     {
         if (! $definition instanceof ArrayDefinition) {
             throw new InvalidDefinition(sprintf(

--- a/src/Definition/DecoratorDefinition.php
+++ b/src/Definition/DecoratorDefinition.php
@@ -10,16 +10,16 @@ namespace DI\Definition;
  * @since 5.0
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class DecoratorDefinition extends FactoryDefinition implements Definition, ExtendsPreviousDefinition
+class DecoratorDefinition extends FactoryDefinition implements DefinitionInterface, ExtendsPreviousDefinitionInterface
 {
-    private ?Definition $decorated = null;
+    private ?DefinitionInterface $decorated = null;
 
-    public function setExtendedDefinition(Definition $definition) : void
+    public function setExtendedDefinition(DefinitionInterface $definition) : void
     {
         $this->decorated = $definition;
     }
 
-    public function getDecoratedDefinition() : ?Definition
+    public function getDecoratedDefinition() : ?DefinitionInterface
     {
         return $this->decorated;
     }

--- a/src/Definition/DefinitionInterface.php
+++ b/src/Definition/DefinitionInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Definition;
 
-use DI\Factory\RequestedEntry;
+use DI\Factory\RequestedEntryInterface;
 
 /**
  * Definition.
@@ -13,7 +13,7 @@ use DI\Factory\RequestedEntry;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-interface Definition extends RequestedEntry, \Stringable
+interface DefinitionInterface extends RequestedEntryInterface, \Stringable
 {
     /**
      * Returns the name of the entry in the container.

--- a/src/Definition/Dumper/ObjectDefinitionDumper.php
+++ b/src/Definition/Dumper/ObjectDefinitionDumper.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Definition\Dumper;
 
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\ObjectDefinition\MethodInjection;
 use ReflectionException;
@@ -75,7 +75,7 @@ class ObjectDefinitionDumper
 
         foreach ($definition->getPropertyInjections() as $propertyInjection) {
             $value = $propertyInjection->getValue();
-            $valueStr = $value instanceof Definition ? (string) $value : var_export($value, true);
+            $valueStr = $value instanceof DefinitionInterface ? (string) $value : var_export($value, true);
 
             $str .= sprintf(\PHP_EOL . '    $%s = %s', $propertyInjection->getPropertyName(), $valueStr);
         }
@@ -113,7 +113,7 @@ class ObjectDefinitionDumper
         foreach ($methodReflection->getParameters() as $index => $parameter) {
             if (array_key_exists($index, $definitionParameters)) {
                 $value = $definitionParameters[$index];
-                $valueStr = $value instanceof Definition ? (string) $value : var_export($value, true);
+                $valueStr = $value instanceof DefinitionInterface ? (string) $value : var_export($value, true);
 
                 $args[] = sprintf('$%s = %s', $parameter->getName(), $valueStr);
 

--- a/src/Definition/EnvironmentVariableDefinition.php
+++ b/src/Definition/EnvironmentVariableDefinition.php
@@ -10,7 +10,7 @@ namespace DI\Definition;
  *
  * @author James Harris <james.harris@icecave.com.au>
  */
-class EnvironmentVariableDefinition implements Definition
+class EnvironmentVariableDefinition implements DefinitionInterface
 {
     /** Entry name. */
     private string $name = '';
@@ -72,7 +72,7 @@ class EnvironmentVariableDefinition implements Definition
             . '    optional = ' . ($this->isOptional ? 'yes' : 'no');
 
         if ($this->isOptional) {
-            if ($this->defaultValue instanceof Definition) {
+            if ($this->defaultValue instanceof DefinitionInterface) {
                 $nestedDefinition = (string) $this->defaultValue;
                 $defaultValueStr = str_replace(\PHP_EOL, \PHP_EOL . '    ', $nestedDefinition);
             } else {

--- a/src/Definition/Exception/InvalidDefinition.php
+++ b/src/Definition/Exception/InvalidDefinition.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Definition\Exception;
 
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use Psr\Container\ContainerExceptionInterface;
 
 /**
@@ -14,7 +14,7 @@ use Psr\Container\ContainerExceptionInterface;
  */
 class InvalidDefinition extends \Exception implements ContainerExceptionInterface
 {
-    public static function create(Definition $definition, string $message, \Exception $previous = null) : self
+    public static function create(DefinitionInterface $definition, string $message, \Exception $previous = null) : self
     {
         return new self(sprintf(
             '%s' . \PHP_EOL . 'Full definition:' . \PHP_EOL . '%s',

--- a/src/Definition/ExtendsPreviousDefinitionInterface.php
+++ b/src/Definition/ExtendsPreviousDefinitionInterface.php
@@ -9,7 +9,7 @@ namespace DI\Definition;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-interface ExtendsPreviousDefinition extends Definition
+interface ExtendsPreviousDefinitionInterface extends DefinitionInterface
 {
-    public function setExtendedDefinition(Definition $definition) : void;
+    public function setExtendedDefinition(DefinitionInterface $definition) : void;
 }

--- a/src/Definition/FactoryDefinition.php
+++ b/src/Definition/FactoryDefinition.php
@@ -9,7 +9,7 @@ namespace DI\Definition;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class FactoryDefinition implements Definition
+class FactoryDefinition implements DefinitionInterface
 {
     /**
      * Entry name.

--- a/src/Definition/Helper/CreateDefinitionHelper.php
+++ b/src/Definition/Helper/CreateDefinitionHelper.php
@@ -14,7 +14,7 @@ use DI\Definition\ObjectDefinition\PropertyInjection;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class CreateDefinitionHelper implements DefinitionHelper
+class CreateDefinitionHelper implements DefinitionHelperInterface
 {
     private const DEFINITION_CLASS = ObjectDefinition::class;
 

--- a/src/Definition/Helper/DefinitionHelperInterface.php
+++ b/src/Definition/Helper/DefinitionHelperInterface.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace DI\Definition\Helper;
 
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 
 /**
  * Helps defining container entries.
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-interface DefinitionHelper
+interface DefinitionHelperInterface
 {
     /**
      * @param string $entryName Container entry name
      */
-    public function getDefinition(string $entryName) : Definition;
+    public function getDefinition(string $entryName) : DefinitionInterface;
 }

--- a/src/Definition/Helper/FactoryDefinitionHelper.php
+++ b/src/Definition/Helper/FactoryDefinitionHelper.php
@@ -12,7 +12,7 @@ use DI\Definition\FactoryDefinition;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class FactoryDefinitionHelper implements DefinitionHelper
+class FactoryDefinitionHelper implements DefinitionHelperInterface
 {
     /**
      * @var callable

--- a/src/Definition/InstanceDefinition.php
+++ b/src/Definition/InstanceDefinition.php
@@ -10,7 +10,7 @@ namespace DI\Definition;
  * @since  5.0
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class InstanceDefinition implements Definition
+class InstanceDefinition implements DefinitionInterface
 {
     /**
      * @param object $instance Instance on which to inject dependencies.

--- a/src/Definition/ObjectDefinition.php
+++ b/src/Definition/ObjectDefinition.php
@@ -15,7 +15,7 @@ use ReflectionClass;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class ObjectDefinition implements Definition
+class ObjectDefinition implements DefinitionInterface
 {
     /**
      * Entry name (most of the time, same as $classname).

--- a/src/Definition/ObjectDefinition/MethodInjection.php
+++ b/src/Definition/ObjectDefinition/MethodInjection.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace DI\Definition\ObjectDefinition;
 
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 
 /**
  * Describe an injection in an object method.
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class MethodInjection implements Definition
+class MethodInjection implements DefinitionInterface
 {
     /**
      * @param mixed[] $parameters

--- a/src/Definition/Reference.php
+++ b/src/Definition/Reference.php
@@ -11,7 +11,7 @@ use Psr\Container\ContainerInterface;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class Reference implements Definition, SelfResolvingDefinition
+class Reference implements DefinitionInterface, SelfResolvingDefinition
 {
     /** Entry name. */
     private string $name = '';

--- a/src/Definition/Resolver/ArrayResolver.php
+++ b/src/Definition/Resolver/ArrayResolver.php
@@ -5,25 +5,25 @@ declare(strict_types=1);
 namespace DI\Definition\Resolver;
 
 use DI\Definition\ArrayDefinition;
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\DependencyException;
 use Exception;
 
 /**
  * Resolves an array definition to a value.
  *
- * @template-implements DefinitionResolver<ArrayDefinition>
+ * @template-implements DefinitionResolverInterface<ArrayDefinition>
  *
  * @since 5.0
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class ArrayResolver implements DefinitionResolver
+class ArrayResolver implements DefinitionResolverInterface
 {
     /**
-     * @param DefinitionResolver $definitionResolver Used to resolve nested definitions.
+     * @param DefinitionResolverInterface $definitionResolver Used to resolve nested definitions.
      */
     public function __construct(
-        private DefinitionResolver $definitionResolver
+        private DefinitionResolverInterface $definitionResolver
     ) {
     }
 
@@ -36,13 +36,13 @@ class ArrayResolver implements DefinitionResolver
      *
      * @param ArrayDefinition $definition
      */
-    public function resolve(Definition $definition, array $parameters = []) : array
+    public function resolve(DefinitionInterface $definition, array $parameters = []) : array
     {
         $values = $definition->getValues();
 
         // Resolve nested definitions
         array_walk_recursive($values, function (& $value, $key) use ($definition) {
-            if ($value instanceof Definition) {
+            if ($value instanceof DefinitionInterface) {
                 $value = $this->resolveDefinition($value, $definition, $key);
             }
         });
@@ -50,7 +50,7 @@ class ArrayResolver implements DefinitionResolver
         return $values;
     }
 
-    public function isResolvable(Definition $definition, array $parameters = []) : bool
+    public function isResolvable(DefinitionInterface $definition, array $parameters = []) : bool
     {
         return true;
     }
@@ -58,7 +58,7 @@ class ArrayResolver implements DefinitionResolver
     /**
      * @throws DependencyException
      */
-    private function resolveDefinition(Definition $value, ArrayDefinition $definition, int|string $key) : mixed
+    private function resolveDefinition(DefinitionInterface $value, ArrayDefinition $definition, int|string $key) : mixed
     {
         try {
             return $this->definitionResolver->resolve($value);

--- a/src/Definition/Resolver/DecoratorResolver.php
+++ b/src/Definition/Resolver/DecoratorResolver.php
@@ -5,29 +5,29 @@ declare(strict_types=1);
 namespace DI\Definition\Resolver;
 
 use DI\Definition\DecoratorDefinition;
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\Definition\Exception\InvalidDefinition;
 use Psr\Container\ContainerInterface;
 
 /**
  * Resolves a decorator definition to a value.
  *
- * @template-implements DefinitionResolver<DecoratorDefinition>
+ * @template-implements DefinitionResolverInterface<DecoratorDefinition>
  *
  * @since 5.0
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class DecoratorResolver implements DefinitionResolver
+class DecoratorResolver implements DefinitionResolverInterface
 {
     /**
      * The resolver needs a container. This container will be passed to the factory as a parameter
      * so that the factory can access other entries of the container.
      *
-     * @param DefinitionResolver $definitionResolver Used to resolve nested definitions.
+     * @param DefinitionResolverInterface $definitionResolver Used to resolve nested definitions.
      */
     public function __construct(
-        private ContainerInterface $container,
-        private DefinitionResolver $definitionResolver
+        private ContainerInterface          $container,
+        private DefinitionResolverInterface $definitionResolver
     ) {
     }
 
@@ -38,7 +38,7 @@ class DecoratorResolver implements DefinitionResolver
      *
      * @param DecoratorDefinition $definition
      */
-    public function resolve(Definition $definition, array $parameters = []) : mixed
+    public function resolve(DefinitionInterface $definition, array $parameters = []) : mixed
     {
         $callable = $definition->getCallable();
 
@@ -51,7 +51,7 @@ class DecoratorResolver implements DefinitionResolver
 
         $decoratedDefinition = $definition->getDecoratedDefinition();
 
-        if (! $decoratedDefinition instanceof Definition) {
+        if (! $decoratedDefinition instanceof DefinitionInterface) {
             if (! $definition->getName()) {
                 throw new InvalidDefinition('Decorators cannot be nested in another definition');
             }
@@ -67,7 +67,7 @@ class DecoratorResolver implements DefinitionResolver
         return $callable($decorated, $this->container);
     }
 
-    public function isResolvable(Definition $definition, array $parameters = []) : bool
+    public function isResolvable(DefinitionInterface $definition, array $parameters = []) : bool
     {
         return true;
     }

--- a/src/Definition/Resolver/DefinitionResolverInterface.php
+++ b/src/Definition/Resolver/DefinitionResolverInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Definition\Resolver;
 
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\Definition\Exception\InvalidDefinition;
 use DI\DependencyException;
 
@@ -14,14 +14,14 @@ use DI\DependencyException;
  * @since 4.0
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  *
- * @template T of Definition
+ * @template T of DefinitionInterface
  */
-interface DefinitionResolver
+interface DefinitionResolverInterface
 {
     /**
      * Resolve a definition to a value.
      *
-     * @param Definition $definition Object that defines how the value should be obtained.
+     * @param DefinitionInterface $definition Object that defines how the value should be obtained.
      * @psalm-param T $definition
      * @param array      $parameters Optional parameters to use to build the entry.
      * @return mixed Value obtained from the definition.
@@ -29,14 +29,14 @@ interface DefinitionResolver
      * @throws InvalidDefinition If the definition cannot be resolved.
      * @throws DependencyException
      */
-    public function resolve(Definition $definition, array $parameters = []) : mixed;
+    public function resolve(DefinitionInterface $definition, array $parameters = []) : mixed;
 
     /**
      * Check if a definition can be resolved.
      *
-     * @param Definition $definition Object that defines how the value should be obtained.
+     * @param DefinitionInterface $definition Object that defines how the value should be obtained.
      * @psalm-param T $definition
      * @param array      $parameters Optional parameters to use to build the entry.
      */
-    public function isResolvable(Definition $definition, array $parameters = []) : bool;
+    public function isResolvable(DefinitionInterface $definition, array $parameters = []) : bool;
 }

--- a/src/Definition/Resolver/EnvironmentVariableResolver.php
+++ b/src/Definition/Resolver/EnvironmentVariableResolver.php
@@ -4,25 +4,25 @@ declare(strict_types=1);
 
 namespace DI\Definition\Resolver;
 
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\Definition\EnvironmentVariableDefinition;
 use DI\Definition\Exception\InvalidDefinition;
 
 /**
  * Resolves a environment variable definition to a value.
  *
- * @template-implements DefinitionResolver<EnvironmentVariableDefinition>
+ * @template-implements DefinitionResolverInterface<EnvironmentVariableDefinition>
  *
  * @author James Harris <james.harris@icecave.com.au>
  */
-class EnvironmentVariableResolver implements DefinitionResolver
+class EnvironmentVariableResolver implements DefinitionResolverInterface
 {
     /** @var callable */
     private $variableReader;
 
     public function __construct(
-        private DefinitionResolver $definitionResolver,
-        $variableReader = null
+        private DefinitionResolverInterface $definitionResolver,
+                                            $variableReader = null
     ) {
         $this->variableReader = $variableReader ?? [$this, 'getEnvVariable'];
     }
@@ -32,7 +32,7 @@ class EnvironmentVariableResolver implements DefinitionResolver
      *
      * @param EnvironmentVariableDefinition $definition
      */
-    public function resolve(Definition $definition, array $parameters = []) : mixed
+    public function resolve(DefinitionInterface $definition, array $parameters = []) : mixed
     {
         $value = call_user_func($this->variableReader, $definition->getVariableName());
 
@@ -50,14 +50,14 @@ class EnvironmentVariableResolver implements DefinitionResolver
         $value = $definition->getDefaultValue();
 
         // Nested definition
-        if ($value instanceof Definition) {
+        if ($value instanceof DefinitionInterface) {
             return $this->definitionResolver->resolve($value);
         }
 
         return $value;
     }
 
-    public function isResolvable(Definition $definition, array $parameters = []) : bool
+    public function isResolvable(DefinitionInterface $definition, array $parameters = []) : bool
     {
         return true;
     }

--- a/src/Definition/Resolver/FactoryResolver.php
+++ b/src/Definition/Resolver/FactoryResolver.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Definition\Resolver;
 
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\Definition\Exception\InvalidDefinition;
 use DI\Definition\FactoryDefinition;
 use DI\Invoker\FactoryParameterResolver;
@@ -20,12 +20,12 @@ use Psr\Container\ContainerInterface;
 /**
  * Resolves a factory definition to a value.
  *
- * @template-implements DefinitionResolver<FactoryDefinition>
+ * @template-implements DefinitionResolverInterface<FactoryDefinition>
  *
  * @since 4.0
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class FactoryResolver implements DefinitionResolver
+class FactoryResolver implements DefinitionResolverInterface
 {
     private ?Invoker $invoker = null;
 
@@ -34,8 +34,8 @@ class FactoryResolver implements DefinitionResolver
      * so that the factory can access other entries of the container.
      */
     public function __construct(
-        private ContainerInterface $container,
-        private DefinitionResolver $resolver,
+        private ContainerInterface          $container,
+        private DefinitionResolverInterface $resolver,
     ) {
     }
 
@@ -46,7 +46,7 @@ class FactoryResolver implements DefinitionResolver
      *
      * @param FactoryDefinition $definition
      */
-    public function resolve(Definition $definition, array $parameters = []) : mixed
+    public function resolve(DefinitionInterface $definition, array $parameters = []) : mixed
     {
         if (! $this->invoker) {
             $parameterResolver = new ResolverChain([
@@ -91,7 +91,7 @@ class FactoryResolver implements DefinitionResolver
         }
     }
 
-    public function isResolvable(Definition $definition, array $parameters = []) : bool
+    public function isResolvable(DefinitionInterface $definition, array $parameters = []) : bool
     {
         return true;
     }
@@ -101,7 +101,7 @@ class FactoryResolver implements DefinitionResolver
         $resolved = [];
         foreach ($params as $key => $value) {
             // Nested definitions
-            if ($value instanceof Definition) {
+            if ($value instanceof DefinitionInterface) {
                 $value = $this->resolver->resolve($value);
             }
             $resolved[$key] = $value;

--- a/src/Definition/Resolver/InstanceInjector.php
+++ b/src/Definition/Resolver/InstanceInjector.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Definition\Resolver;
 
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\Definition\InstanceDefinition;
 use DI\DependencyException;
 use Psr\Container\NotFoundExceptionInterface;
@@ -12,12 +12,12 @@ use Psr\Container\NotFoundExceptionInterface;
 /**
  * Injects dependencies on an existing instance.
  *
- * @template-implements DefinitionResolver<InstanceDefinition>
+ * @template-implements DefinitionResolverInterface<InstanceDefinition>
  *
  * @since 5.0
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class InstanceInjector extends ObjectCreator implements DefinitionResolver
+class InstanceInjector extends ObjectCreator implements DefinitionResolverInterface
 {
     /**
      * Injects dependencies on an existing instance.
@@ -25,7 +25,7 @@ class InstanceInjector extends ObjectCreator implements DefinitionResolver
      * @param InstanceDefinition $definition
      * @psalm-suppress ImplementedParamTypeMismatch
      */
-    public function resolve(Definition $definition, array $parameters = []) : ?object
+    public function resolve(DefinitionInterface $definition, array $parameters = []) : ?object
     {
         /** @psalm-suppress InvalidCatch */
         try {
@@ -43,7 +43,7 @@ class InstanceInjector extends ObjectCreator implements DefinitionResolver
         return $definition;
     }
 
-    public function isResolvable(Definition $definition, array $parameters = []) : bool
+    public function isResolvable(DefinitionInterface $definition, array $parameters = []) : bool
     {
         return true;
     }

--- a/src/Definition/Resolver/ObjectCreator.php
+++ b/src/Definition/Resolver/ObjectCreator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Definition\Resolver;
 
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\Definition\Exception\InvalidDefinition;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\ObjectDefinition\PropertyInjection;
@@ -19,22 +19,22 @@ use ReflectionProperty;
 /**
  * Create objects based on an object definition.
  *
- * @template-implements DefinitionResolver<ObjectDefinition>
+ * @template-implements DefinitionResolverInterface<ObjectDefinition>
  *
  * @since 4.0
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class ObjectCreator implements DefinitionResolver
+class ObjectCreator implements DefinitionResolverInterface
 {
     private ParameterResolver $parameterResolver;
 
     /**
-     * @param DefinitionResolver $definitionResolver Used to resolve nested definitions.
+     * @param DefinitionResolverInterface $definitionResolver Used to resolve nested definitions.
      * @param ProxyFactory       $proxyFactory       Used to create proxies for lazy injections.
      */
     public function __construct(
-        private DefinitionResolver $definitionResolver,
-        private ProxyFactory $proxyFactory
+        private DefinitionResolverInterface $definitionResolver,
+        private ProxyFactory                $proxyFactory
     ) {
         $this->parameterResolver = new ParameterResolver($definitionResolver);
     }
@@ -46,7 +46,7 @@ class ObjectCreator implements DefinitionResolver
      *
      * @param ObjectDefinition $definition
      */
-    public function resolve(Definition $definition, array $parameters = []) : ?object
+    public function resolve(DefinitionInterface $definition, array $parameters = []) : ?object
     {
         // Lazy?
         if ($definition->isLazy()) {
@@ -62,7 +62,7 @@ class ObjectCreator implements DefinitionResolver
      *
      * @param ObjectDefinition $definition
      */
-    public function isResolvable(Definition $definition, array $parameters = []) : bool
+    public function isResolvable(DefinitionInterface $definition, array $parameters = []) : bool
     {
         return $definition->isInstantiable();
     }
@@ -176,7 +176,7 @@ class ObjectCreator implements DefinitionResolver
 
         $value = $propertyInjection->getValue();
 
-        if ($value instanceof Definition) {
+        if ($value instanceof DefinitionInterface) {
             try {
                 $value = $this->definitionResolver->resolve($value);
             } catch (DependencyException $e) {

--- a/src/Definition/Resolver/ParameterResolver.php
+++ b/src/Definition/Resolver/ParameterResolver.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Definition\Resolver;
 
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\Definition\Exception\InvalidDefinition;
 use DI\Definition\ObjectDefinition\MethodInjection;
 use ReflectionMethod;
@@ -19,10 +19,10 @@ use ReflectionParameter;
 class ParameterResolver
 {
     /**
-     * @param DefinitionResolver $definitionResolver Will be used to resolve nested definitions.
+     * @param DefinitionResolverInterface $definitionResolver Will be used to resolve nested definitions.
      */
     public function __construct(
-        private DefinitionResolver $definitionResolver,
+        private DefinitionResolverInterface $definitionResolver,
     ) {
     }
 
@@ -65,7 +65,7 @@ class ParameterResolver
             }
 
             // Nested definitions
-            if ($value instanceof Definition) {
+            if ($value instanceof DefinitionInterface) {
                 // If the container cannot produce the entry, we can use the default parameter value
                 if ($parameter->isOptional() && ! $this->definitionResolver->isResolvable($value)) {
                     $value = $this->getParameterDefaultValue($parameter, $method);

--- a/src/Definition/Resolver/ResolverDispatcher.php
+++ b/src/Definition/Resolver/ResolverDispatcher.php
@@ -6,7 +6,7 @@ namespace DI\Definition\Resolver;
 
 use DI\Definition\ArrayDefinition;
 use DI\Definition\DecoratorDefinition;
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\Definition\EnvironmentVariableDefinition;
 use DI\Definition\Exception\InvalidDefinition;
 use DI\Definition\FactoryDefinition;
@@ -24,7 +24,7 @@ use Psr\Container\ContainerInterface;
  * @since 5.0
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class ResolverDispatcher implements DefinitionResolver
+class ResolverDispatcher implements DefinitionResolverInterface
 {
     private ?ArrayResolver $arrayResolver = null;
     private ?FactoryResolver $factoryResolver = null;
@@ -42,13 +42,13 @@ class ResolverDispatcher implements DefinitionResolver
     /**
      * Resolve a definition to a value.
      *
-     * @param Definition $definition Object that defines how the value should be obtained.
+     * @param DefinitionInterface $definition Object that defines how the value should be obtained.
      * @param array      $parameters Optional parameters to use to build the entry.
      *
      * @return mixed Value obtained from the definition.
      * @throws InvalidDefinition If the definition cannot be resolved.
      */
-    public function resolve(Definition $definition, array $parameters = []) : mixed
+    public function resolve(DefinitionInterface $definition, array $parameters = []) : mixed
     {
         // Special case, tested early for speed
         if ($definition instanceof SelfResolvingDefinition) {
@@ -60,7 +60,7 @@ class ResolverDispatcher implements DefinitionResolver
         return $definitionResolver->resolve($definition, $parameters);
     }
 
-    public function isResolvable(Definition $definition, array $parameters = []) : bool
+    public function isResolvable(DefinitionInterface $definition, array $parameters = []) : bool
     {
         // Special case, tested early for speed
         if ($definition instanceof SelfResolvingDefinition) {
@@ -77,7 +77,7 @@ class ResolverDispatcher implements DefinitionResolver
      *
      * @throws \RuntimeException No definition resolver was found for this type of definition.
      */
-    private function getDefinitionResolver(Definition $definition) : DefinitionResolver
+    private function getDefinitionResolver(DefinitionInterface $definition) : DefinitionResolverInterface
     {
         switch (true) {
             case $definition instanceof ObjectDefinition:

--- a/src/Definition/Source/DefinitionArray.php
+++ b/src/Definition/Source/DefinitionArray.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Definition\Source;
 
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 
 /**
  * Reads DI definitions from a PHP array.
@@ -55,7 +55,7 @@ class DefinitionArray implements DefinitionSource, MutableDefinitionSource
         $this->wildcardDefinitions = null;
     }
 
-    public function addDefinition(Definition $definition) : void
+    public function addDefinition(DefinitionInterface $definition) : void
     {
         $this->definitions[$definition->getName()] = $definition;
 
@@ -63,7 +63,7 @@ class DefinitionArray implements DefinitionSource, MutableDefinitionSource
         $this->wildcardDefinitions = null;
     }
 
-    public function getDefinition(string $name) : Definition|null
+    public function getDefinition(string $name) : DefinitionInterface|null
     {
         // Look for the definition by name
         if (array_key_exists($name, $this->definitions)) {

--- a/src/Definition/Source/DefinitionFile.php
+++ b/src/Definition/Source/DefinitionFile.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Definition\Source;
 
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 
 /**
  * Reads DI definitions from a file returning a PHP array.
@@ -26,7 +26,7 @@ class DefinitionFile extends DefinitionArray
         parent::__construct([], $autowiring);
     }
 
-    public function getDefinition(string $name) : Definition|null
+    public function getDefinition(string $name) : DefinitionInterface|null
     {
         $this->initialize();
 

--- a/src/Definition/Source/DefinitionNormalizer.php
+++ b/src/Definition/Source/DefinitionNormalizer.php
@@ -7,10 +7,10 @@ namespace DI\Definition\Source;
 use DI\Definition\ArrayDefinition;
 use DI\Definition\AutowireDefinition;
 use DI\Definition\DecoratorDefinition;
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\Definition\Exception\InvalidDefinition;
 use DI\Definition\FactoryDefinition;
-use DI\Definition\Helper\DefinitionHelper;
+use DI\Definition\Helper\DefinitionHelperInterface;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\ValueDefinition;
 
@@ -37,15 +37,15 @@ class DefinitionNormalizer
      *
      * @throws InvalidDefinition
      */
-    public function normalizeRootDefinition(mixed $definition, string $name, array $wildcardsReplacements = null) : Definition
+    public function normalizeRootDefinition(mixed $definition, string $name, array $wildcardsReplacements = null) : DefinitionInterface
     {
-        if ($definition instanceof DefinitionHelper) {
+        if ($definition instanceof DefinitionHelperInterface) {
             $definition = $definition->getDefinition($name);
         } elseif (is_array($definition)) {
             $definition = new ArrayDefinition($definition);
         } elseif ($definition instanceof \Closure) {
             $definition = new FactoryDefinition($name, $definition);
-        } elseif (! $definition instanceof Definition) {
+        } elseif (! $definition instanceof DefinitionInterface) {
             $definition = new ValueDefinition($definition);
         }
 
@@ -84,7 +84,7 @@ class DefinitionNormalizer
     {
         $name = '<nested definition>';
 
-        if ($definition instanceof DefinitionHelper) {
+        if ($definition instanceof DefinitionHelperInterface) {
             $definition = $definition->getDefinition($name);
         } elseif (is_array($definition)) {
             $definition = new ArrayDefinition($definition);
@@ -100,7 +100,7 @@ class DefinitionNormalizer
             $definition = $this->autowiring->autowire($name, $definition);
         }
 
-        if ($definition instanceof Definition) {
+        if ($definition instanceof DefinitionInterface) {
             $definition->setName($name);
 
             // Recursively traverse nested definitions

--- a/src/Definition/Source/DefinitionSource.php
+++ b/src/Definition/Source/DefinitionSource.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Definition\Source;
 
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\Definition\Exception\InvalidDefinition;
 
 /**
@@ -19,10 +19,10 @@ interface DefinitionSource
      *
      * @throws InvalidDefinition An invalid definition was found.
      */
-    public function getDefinition(string $name) : Definition|null;
+    public function getDefinition(string $name) : DefinitionInterface|null;
 
     /**
-     * @return array<string,Definition> Definitions indexed by their name.
+     * @return array<string,DefinitionInterface> Definitions indexed by their name.
      */
     public function getDefinitions() : array;
 }

--- a/src/Definition/Source/MutableDefinitionSource.php
+++ b/src/Definition/Source/MutableDefinitionSource.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Definition\Source;
 
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 
 /**
  * Describes a definition source to which we can add new definitions.
@@ -13,5 +13,5 @@ use DI\Definition\Definition;
  */
 interface MutableDefinitionSource extends DefinitionSource
 {
-    public function addDefinition(Definition $definition) : void;
+    public function addDefinition(DefinitionInterface $definition) : void;
 }

--- a/src/Definition/Source/SourceCache.php
+++ b/src/Definition/Source/SourceCache.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace DI\Definition\Source;
 
 use DI\Definition\AutowireDefinition;
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\Definition\ObjectDefinition;
 
 /**
@@ -23,7 +23,7 @@ class SourceCache implements DefinitionSource, MutableDefinitionSource
     ) {
     }
 
-    public function getDefinition(string $name) : Definition|null
+    public function getDefinition(string $name) : DefinitionInterface|null
     {
         $definition = apcu_fetch($this->getCacheKey($name));
 
@@ -59,12 +59,12 @@ class SourceCache implements DefinitionSource, MutableDefinitionSource
         return self::CACHE_KEY . $this->cacheNamespace . $name;
     }
 
-    public function addDefinition(Definition $definition) : void
+    public function addDefinition(DefinitionInterface $definition) : void
     {
         throw new \LogicException('You cannot set a definition at runtime on a container that has caching enabled. Doing so would risk caching the definition for the next execution, where it might be different. You can either put your definitions in a file, remove the cache or ->set() a raw value directly (PHP object, string, int, ...) instead of a PHP-DI definition.');
     }
 
-    private function shouldBeCached(Definition $definition = null) : bool
+    private function shouldBeCached(DefinitionInterface $definition = null) : bool
     {
         return
             // Cache missing definitions

--- a/src/Definition/Source/SourceChain.php
+++ b/src/Definition/Source/SourceChain.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DI\Definition\Source;
 
-use DI\Definition\Definition;
-use DI\Definition\ExtendsPreviousDefinition;
+use DI\Definition\DefinitionInterface;
+use DI\Definition\ExtendsPreviousDefinitionInterface;
 
 /**
  * Manages a chain of other definition sources.
@@ -28,7 +28,7 @@ class SourceChain implements DefinitionSource, MutableDefinitionSource
      * @param int $startIndex Use this parameter to start looking from a specific
      *                        point in the source chain.
      */
-    public function getDefinition(string $name, int $startIndex = 0) : Definition|null
+    public function getDefinition(string $name, int $startIndex = 0) : DefinitionInterface|null
     {
         $count = count($this->sources);
         for ($i = $startIndex; $i < $count; ++$i) {
@@ -37,7 +37,7 @@ class SourceChain implements DefinitionSource, MutableDefinitionSource
             $definition = $source->getDefinition($name);
 
             if ($definition) {
-                if ($definition instanceof ExtendsPreviousDefinition) {
+                if ($definition instanceof ExtendsPreviousDefinitionInterface) {
                     $this->resolveExtendedDefinition($definition, $i);
                 }
 
@@ -60,7 +60,7 @@ class SourceChain implements DefinitionSource, MutableDefinitionSource
         return array_combine($allNames, $allValues);
     }
 
-    public function addDefinition(Definition $definition) : void
+    public function addDefinition(DefinitionInterface $definition) : void
     {
         if (! $this->mutableSource) {
             throw new \LogicException("The container's definition source has not been initialized correctly");
@@ -69,7 +69,7 @@ class SourceChain implements DefinitionSource, MutableDefinitionSource
         $this->mutableSource->addDefinition($definition);
     }
 
-    private function resolveExtendedDefinition(ExtendsPreviousDefinition $definition, int $currentIndex)
+    private function resolveExtendedDefinition(ExtendsPreviousDefinitionInterface $definition, int $currentIndex)
     {
         // Look in the next sources only (else infinite recursion, and we can only extend
         // entries defined in the previous definition files - a previous == next here because

--- a/src/Definition/StringDefinition.php
+++ b/src/Definition/StringDefinition.php
@@ -14,7 +14,7 @@ use Psr\Container\NotFoundExceptionInterface;
  * @since 5.0
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class StringDefinition implements Definition, SelfResolvingDefinition
+class StringDefinition implements DefinitionInterface, SelfResolvingDefinition
 {
     /** Entry name. */
     private string $name = '';

--- a/src/Definition/ValueDefinition.php
+++ b/src/Definition/ValueDefinition.php
@@ -11,7 +11,7 @@ use Psr\Container\ContainerInterface;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class ValueDefinition implements Definition, SelfResolvingDefinition
+class ValueDefinition implements DefinitionInterface, SelfResolvingDefinition
 {
     /**
      * Entry name.

--- a/src/Factory/RequestedEntryInterface.php
+++ b/src/Factory/RequestedEntryInterface.php
@@ -14,7 +14,7 @@ namespace DI\Factory;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-interface RequestedEntry
+interface RequestedEntryInterface
 {
     /**
      * Returns the name of the entry that was requested by the container.

--- a/src/Invoker/DefinitionParameterResolver.php
+++ b/src/Invoker/DefinitionParameterResolver.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace DI\Invoker;
 
-use DI\Definition\Definition;
-use DI\Definition\Helper\DefinitionHelper;
-use DI\Definition\Resolver\DefinitionResolver;
+use DI\Definition\DefinitionInterface;
+use DI\Definition\Helper\DefinitionHelperInterface;
+use DI\Definition\Resolver\DefinitionResolverInterface;
 use Invoker\ParameterResolver\ParameterResolver;
 use ReflectionFunctionAbstract;
 
@@ -19,7 +19,7 @@ use ReflectionFunctionAbstract;
 class DefinitionParameterResolver implements ParameterResolver
 {
     public function __construct(
-        private DefinitionResolver $definitionResolver
+        private DefinitionResolverInterface $definitionResolver
     ) {
     }
 
@@ -34,11 +34,11 @@ class DefinitionParameterResolver implements ParameterResolver
         }
 
         foreach ($providedParameters as $key => $value) {
-            if ($value instanceof DefinitionHelper) {
+            if ($value instanceof DefinitionHelperInterface) {
                 $value = $value->getDefinition('');
             }
 
-            if (! $value instanceof Definition) {
+            if (! $value instanceof DefinitionInterface) {
                 continue;
             }
 

--- a/src/Invoker/FactoryParameterResolver.php
+++ b/src/Invoker/FactoryParameterResolver.php
@@ -56,7 +56,7 @@ class FactoryParameterResolver implements ParameterResolver
 
             if ($parameterClass === 'Psr\Container\ContainerInterface') {
                 $resolvedParameters[$index] = $this->container;
-            } elseif ($parameterClass === 'DI\Factory\RequestedEntry') {
+            } elseif ($parameterClass === 'DI\Factory\RequestedEntryInterface') {
                 // By convention the second parameter is the definition
                 $resolvedParameters[$index] = $providedParameters[1];
             } elseif ($this->container->has($parameterClass)) {

--- a/tests/IntegrationTest/Definitions/FactoryDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/FactoryDefinitionTest.php
@@ -7,7 +7,7 @@ namespace DI\Test\IntegrationTest\Definitions;
 use Closure;
 use DI\ContainerBuilder;
 use DI\Definition\Exception\InvalidDefinition;
-use DI\Factory\RequestedEntry;
+use DI\Factory\RequestedEntryInterface;
 use DI\Test\IntegrationTest\BaseContainerTest;
 use DI\Test\UnitTest\Definition\Resolver\Fixture\NoConstructor;
 use Psr\Container\ContainerInterface;
@@ -185,7 +185,7 @@ class FactoryDefinitionTest extends BaseContainerTest
     public function test_requested_entry_gets_injected_with_typehint(ContainerBuilder $builder)
     {
         $builder->addDefinitions([
-            'foobar' => function (RequestedEntry $entry) {
+            'foobar' => function (RequestedEntryInterface $entry) {
                 return $entry->getName();
             },
         ]);
@@ -217,7 +217,7 @@ class FactoryDefinitionTest extends BaseContainerTest
     public function test_container_and_requested_entry_get_injected_in_arbitrary_position_via_typehint(ContainerBuilder $builder)
     {
         $builder->addDefinitions([
-            'factory' => function (stdClass $stdClass, RequestedEntry $e, ContainerInterface $c) {
+            'factory' => function (stdClass $stdClass, RequestedEntryInterface $e, ContainerInterface $c) {
                 return [$stdClass, $e, $c];
             },
         ]);
@@ -225,7 +225,7 @@ class FactoryDefinitionTest extends BaseContainerTest
         $factory = $builder->build()->get('factory');
 
         $this->assertInstanceOf('stdClass', $factory[0]);
-        $this->assertInstanceOf(RequestedEntry::class, $factory[1]);
+        $this->assertInstanceOf(RequestedEntryInterface::class, $factory[1]);
         $this->assertInstanceOf(ContainerInterface::class, $factory[2]);
     }
 
@@ -347,7 +347,7 @@ class FactoryDefinitionTest extends BaseContainerTest
         $factory = $builder->build()->get('factory');
 
         $this->assertInstanceOf(ContainerInterface::class, $factory[0]);
-        $this->assertInstanceOf(RequestedEntry::class, $factory[1]);
+        $this->assertInstanceOf(RequestedEntryInterface::class, $factory[1]);
         $this->assertInstanceOf('stdClass', $factory[2]);
         $this->assertEquals('Bar', $factory[3]);
     }
@@ -359,7 +359,7 @@ class FactoryDefinitionTest extends BaseContainerTest
     {
         $builder->addDefinitions([
             'secret' => 'Bar',
-            'factory' => factory(function (stdClass $object, RequestedEntry $requestedEntry, $value, ContainerInterface $container) {
+            'factory' => factory(function (stdClass $object, RequestedEntryInterface $requestedEntry, $value, ContainerInterface $container) {
                 return [$object, $requestedEntry, $value, $container];
             })->parameter('value', get('secret')),
         ]);
@@ -367,7 +367,7 @@ class FactoryDefinitionTest extends BaseContainerTest
         $factory = $builder->build()->get('factory');
 
         $this->assertInstanceOf('stdClass', $factory[0]);
-        $this->assertInstanceOf(RequestedEntry::class, $factory[1]);
+        $this->assertInstanceOf(RequestedEntryInterface::class, $factory[1]);
         $this->assertEquals('Bar', $factory[2]);
         $this->assertInstanceOf(ContainerInterface::class, $factory[3]);
     }

--- a/tests/UnitTest/Definition/DecoratorDefinitionTest.php
+++ b/tests/UnitTest/Definition/DecoratorDefinitionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace DI\Test\UnitTest\Definition;
 
 use DI\Definition\DecoratorDefinition;
-use DI\Definition\ExtendsPreviousDefinition;
+use DI\Definition\ExtendsPreviousDefinitionInterface;
 use DI\Definition\ValueDefinition;
 use PHPUnit\Framework\TestCase;
 
@@ -43,7 +43,7 @@ class DecoratorDefinitionTest extends TestCase
     {
         $definition = new DecoratorDefinition('foo', function () {
         });
-        $this->assertInstanceOf(ExtendsPreviousDefinition::class, $definition);
+        $this->assertInstanceOf(ExtendsPreviousDefinitionInterface::class, $definition);
 
         $subDefinition = new ValueDefinition('bar');
         $definition->setExtendedDefinition($subDefinition);

--- a/tests/UnitTest/Definition/Resolver/ArrayResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/ArrayResolverTest.php
@@ -8,7 +8,7 @@ use DI\Definition\Reference;
 use DI\Definition\ArrayDefinition;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\Resolver\ArrayResolver;
-use DI\Definition\Resolver\DefinitionResolver;
+use DI\Definition\Resolver\DefinitionResolverInterface;
 use EasyMock\EasyMock;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -21,13 +21,13 @@ class ArrayResolverTest extends TestCase
 {
     use EasyMock;
 
-    private MockObject|DefinitionResolver $parentResolver;
+    private MockObject|DefinitionResolverInterface $parentResolver;
 
     private ArrayResolver $resolver;
 
     public function setUp(): void
     {
-        $this->parentResolver = $this->easyMock(DefinitionResolver::class);
+        $this->parentResolver = $this->easyMock(DefinitionResolverInterface::class);
         $this->resolver = new ArrayResolver($this->parentResolver);
     }
 

--- a/tests/UnitTest/Definition/Resolver/DecoratorResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/DecoratorResolverTest.php
@@ -6,7 +6,7 @@ namespace DI\Test\UnitTest\Definition\Resolver;
 
 use DI\Definition\DecoratorDefinition;
 use DI\Definition\Resolver\DecoratorResolver;
-use DI\Definition\Resolver\DefinitionResolver;
+use DI\Definition\Resolver\DefinitionResolverInterface;
 use DI\Definition\ValueDefinition;
 use EasyMock\EasyMock;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -23,12 +23,12 @@ class DecoratorResolverTest extends TestCase
 
     private DecoratorResolver $resolver;
 
-    private MockObject|DefinitionResolver $parentResolver;
+    private MockObject|DefinitionResolverInterface $parentResolver;
 
     public function setUp(): void
     {
         $container = $this->easyMock(ContainerInterface::class);
-        $this->parentResolver = $this->easyMock(DefinitionResolver::class);
+        $this->parentResolver = $this->easyMock(DefinitionResolverInterface::class);
         $this->resolver = new DecoratorResolver($container, $this->parentResolver);
     }
 

--- a/tests/UnitTest/Definition/Resolver/EnvironmentVariableResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/EnvironmentVariableResolverTest.php
@@ -6,7 +6,7 @@ namespace DI\Test\UnitTest\Definition\Resolver;
 
 use DI\Definition\Reference;
 use DI\Definition\EnvironmentVariableDefinition;
-use DI\Definition\Resolver\DefinitionResolver;
+use DI\Definition\Resolver\DefinitionResolverInterface;
 use DI\Definition\Resolver\EnvironmentVariableResolver;
 use EasyMock\EasyMock;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -21,7 +21,7 @@ class EnvironmentVariableResolverTest extends TestCase
     use EasyMock;
 
     private EnvironmentVariableResolver $resolver;
-    private MockObject|DefinitionResolver $parentResolver;
+    private MockObject|DefinitionResolverInterface $parentResolver;
 
     private EnvironmentVariableDefinition $definedDefinition;
     private EnvironmentVariableDefinition $undefinedDefinition;
@@ -30,7 +30,7 @@ class EnvironmentVariableResolverTest extends TestCase
 
     public function setUp(): void
     {
-        $this->parentResolver = $this->easyMock(DefinitionResolver::class);
+        $this->parentResolver = $this->easyMock(DefinitionResolverInterface::class);
 
         $variableReader = function ($variableName) {
             if ('DEFINED' === $variableName) {

--- a/tests/UnitTest/Definition/Resolver/FactoryParameterResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/FactoryParameterResolverTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace DI\Test\UnitTest\Definition\Resolver;
 
 use DI\Container;
-use DI\Factory\RequestedEntry;
+use DI\Factory\RequestedEntryInterface;
 use DI\Invoker\FactoryParameterResolver;
 use DI\Test\UnitTest\Definition\Resolver\Fixture\NoConstructor;
 use EasyMock\EasyMock;
@@ -22,13 +22,13 @@ class FactoryParameterResolverTest extends TestCase
 
     private FactoryParameterResolver $resolver;
     private MockObject|ContainerInterface $container;
-    private MockObject|RequestedEntry $requestedEntry;
+    private MockObject|RequestedEntryInterface $requestedEntry;
 
     public function setUp(): void
     {
         $this->container = $this->easyMock(ContainerInterface::class);
         $this->resolver = new FactoryParameterResolver($this->container);
-        $this->requestedEntry = $this->easyMock(RequestedEntry::class);
+        $this->requestedEntry = $this->easyMock(RequestedEntryInterface::class);
     }
 
     /**
@@ -51,7 +51,7 @@ class FactoryParameterResolverTest extends TestCase
      */
     public function should_resolve_container_and_requested_entry()
     {
-        $callable = function (ContainerInterface $c, RequestedEntry $entry) {
+        $callable = function (ContainerInterface $c, RequestedEntryInterface $entry) {
         };
         $reflection = new \ReflectionFunction($callable);
 
@@ -82,7 +82,7 @@ class FactoryParameterResolverTest extends TestCase
      */
     public function should_resolve_only_requested_entry()
     {
-        $callable = function (RequestedEntry $entry) {
+        $callable = function (RequestedEntryInterface $entry) {
         };
         $reflection = new \ReflectionFunction($callable);
 
@@ -111,12 +111,12 @@ class FactoryParameterResolverTest extends TestCase
      */
     public function should_not_overwrite_resolved_with_container_or_entry()
     {
-        $callable = function (ContainerInterface $container, RequestedEntry $entry, $other) {
+        $callable = function (ContainerInterface $container, RequestedEntryInterface $entry, $other) {
         };
         $reflection = new \ReflectionFunction($callable);
 
         $mockContainer = $this->easyMock(Container::class);
-        $mockEntry = $this->easyMock(RequestedEntry::class);
+        $mockEntry = $this->easyMock(RequestedEntryInterface::class);
 
         $resolvedParams = [$mockContainer, $mockEntry, 'Foo'];
 

--- a/tests/UnitTest/Definition/Resolver/FactoryResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/FactoryResolverTest.php
@@ -6,7 +6,7 @@ namespace DI\Test\UnitTest\Definition\Resolver;
 
 use DI\Definition\FactoryDefinition;
 use DI\Definition\ObjectDefinition;
-use DI\Definition\Resolver\DefinitionResolver;
+use DI\Definition\Resolver\DefinitionResolverInterface;
 use DI\Definition\Resolver\FactoryResolver;
 use DI\NotFoundException;
 use DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureClass;
@@ -29,7 +29,7 @@ class FactoryResolverTest extends TestCase
     public function should_resolve_callables()
     {
         $container = $this->easyMock(ContainerInterface::class);
-        $resolver = new FactoryResolver($container, $this->easyMock(DefinitionResolver::class));
+        $resolver = new FactoryResolver($container, $this->easyMock(DefinitionResolverInterface::class));
 
         $definition = new FactoryDefinition('foo', function () {
             return 'bar';
@@ -46,7 +46,7 @@ class FactoryResolverTest extends TestCase
     public function should_inject_container()
     {
         $container = $this->easyMock(ContainerInterface::class);
-        $resolver = new FactoryResolver($container, $this->easyMock(DefinitionResolver::class));
+        $resolver = new FactoryResolver($container, $this->easyMock(DefinitionResolverInterface::class));
 
         $definition = new FactoryDefinition('foo', function ($c) {
             return $c;
@@ -65,7 +65,7 @@ class FactoryResolverTest extends TestCase
         $this->expectException(InvalidDefinition::class);
         $this->expectExceptionMessage('Entry "foo" cannot be resolved: factory \'Hello world\' is neither a callable nor a valid container entry');
         $container = $this->easyMock(ContainerInterface::class);
-        $resolver = new FactoryResolver($container, $this->easyMock(DefinitionResolver::class));
+        $resolver = new FactoryResolver($container, $this->easyMock(DefinitionResolverInterface::class));
 
         $definition = new FactoryDefinition('foo', 'Hello world');
 
@@ -83,7 +83,7 @@ class FactoryResolverTest extends TestCase
         $this->expectException(InvalidDefinition::class);
         $this->expectExceptionMessage('Entry "foo" cannot be resolved: Unable to invoke the callable because no value was given for parameter 3 ($c)');
         $container = $this->easyMock(ContainerInterface::class);
-        $resolver = new FactoryResolver($container, $this->easyMock(DefinitionResolver::class));
+        $resolver = new FactoryResolver($container, $this->easyMock(DefinitionResolverInterface::class));
 
         $definition = new FactoryDefinition('foo', function ($a, $b, $c) {
         });
@@ -97,7 +97,7 @@ class FactoryResolverTest extends TestCase
     public function should_inject_parameters()
     {
         $container = $this->easyMock(ContainerInterface::class);
-        $resolver = new FactoryResolver($container, $this->easyMock(DefinitionResolver::class));
+        $resolver = new FactoryResolver($container, $this->easyMock(DefinitionResolverInterface::class));
 
         $testCase = $this;
         $definition = new FactoryDefinition('foo', function ($c, $par1, $par2, $baz) use ($testCase) {
@@ -119,7 +119,7 @@ class FactoryResolverTest extends TestCase
     public function should_resolve_nested_definition_in_parameters()
     {
         $container = $this->easyMock(ContainerInterface::class);
-        $parentResolver = $this->easyMock(DefinitionResolver::class);
+        $parentResolver = $this->easyMock(DefinitionResolverInterface::class);
         $resolver = new FactoryResolver($container, $parentResolver);
 
         $definition = new FactoryDefinition('foo', function ($par1) {

--- a/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
+++ b/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
@@ -7,7 +7,7 @@ namespace DI\Test\UnitTest\Definition\Resolver;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\ObjectDefinition\MethodInjection;
 use DI\Definition\ObjectDefinition\PropertyInjection;
-use DI\Definition\Resolver\DefinitionResolver;
+use DI\Definition\Resolver\DefinitionResolverInterface;
 use DI\Definition\Resolver\ObjectCreator;
 use DI\Proxy\ProxyFactory;
 use DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureAbstractClass;
@@ -27,14 +27,14 @@ class ObjectCreatorTest extends TestCase
 {
     use EasyMock;
 
-    private MockObject|DefinitionResolver $parentResolver;
+    private MockObject|DefinitionResolverInterface $parentResolver;
 
     private ObjectCreator $resolver;
 
     public function setUp(): void
     {
         $proxyFactory = $this->easyMock(ProxyFactory::class);
-        $this->parentResolver = $this->easyMock(DefinitionResolver::class);
+        $this->parentResolver = $this->easyMock(DefinitionResolverInterface::class);
 
         $this->resolver = new ObjectCreator($this->parentResolver, $proxyFactory);
     }

--- a/tests/UnitTest/Definition/Resolver/ResolverDispatcherTest.php
+++ b/tests/UnitTest/Definition/Resolver/ResolverDispatcherTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Test\UnitTest\Definition\Resolver;
 
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\Definition\Resolver\ResolverDispatcher;
 use DI\Definition\StringDefinition;
 use DI\Definition\ValueDefinition;
@@ -54,7 +54,7 @@ class ResolverDispatcherTest extends TestCase
     {
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('No definition resolver was configured for definition of type');
-        $this->resolver->resolve($this->easyMock(Definition::class));
+        $this->resolver->resolve($this->easyMock(DefinitionInterface::class));
     }
 
     /**

--- a/tests/UnitTest/Definition/Source/AttributeBasedAutowiringTest.php
+++ b/tests/UnitTest/Definition/Source/AttributeBasedAutowiringTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Test\UnitTest\Definition\Source;
 
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\Definition\Exception\InvalidAttribute;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\ObjectDefinition\MethodInjection;
@@ -36,7 +36,7 @@ class AttributeBasedAutowiringTest extends TestCase
     public function testProperty1()
     {
         $definition = (new AttributeBasedAutowiring)->autowire(AttributeFixture::class);
-        $this->assertInstanceOf(Definition::class, $definition);
+        $this->assertInstanceOf(DefinitionInterface::class, $definition);
 
         $properties = $definition->getPropertyInjections();
         $this->assertInstanceOf(PropertyInjection::class, $properties['property1']);
@@ -85,7 +85,7 @@ class AttributeBasedAutowiringTest extends TestCase
     public function testConstructor()
     {
         $definition = (new AttributeBasedAutowiring)->autowire(AttributeFixture::class);
-        $this->assertInstanceOf(Definition::class, $definition);
+        $this->assertInstanceOf(DefinitionInterface::class, $definition);
 
         $constructorInjection = $definition->getConstructorInjection();
         $this->assertInstanceOf(MethodInjection::class, $constructorInjection);
@@ -99,7 +99,7 @@ class AttributeBasedAutowiringTest extends TestCase
     public function testMethod1()
     {
         $definition = (new AttributeBasedAutowiring)->autowire(AttributeFixture::class);
-        $this->assertInstanceOf(Definition::class, $definition);
+        $this->assertInstanceOf(DefinitionInterface::class, $definition);
 
         $methodInjection = $this->getMethodInjection($definition, 'method1');
         $this->assertInstanceOf(MethodInjection::class, $methodInjection);
@@ -110,7 +110,7 @@ class AttributeBasedAutowiringTest extends TestCase
     public function testMethod2()
     {
         $definition = (new AttributeBasedAutowiring)->autowire(AttributeFixture::class);
-        $this->assertInstanceOf(Definition::class, $definition);
+        $this->assertInstanceOf(DefinitionInterface::class, $definition);
 
         $methodInjection = $this->getMethodInjection($definition, 'method2');
         $this->assertInstanceOf(MethodInjection::class, $methodInjection);
@@ -124,7 +124,7 @@ class AttributeBasedAutowiringTest extends TestCase
     public function testMethod3()
     {
         $definition = (new AttributeBasedAutowiring)->autowire(AttributeFixture::class);
-        $this->assertInstanceOf(Definition::class, $definition);
+        $this->assertInstanceOf(DefinitionInterface::class, $definition);
 
         $methodInjection = $this->getMethodInjection($definition, 'method3');
         $this->assertInstanceOf(MethodInjection::class, $methodInjection);
@@ -139,7 +139,7 @@ class AttributeBasedAutowiringTest extends TestCase
     public function testMethod4()
     {
         $definition = (new AttributeBasedAutowiring)->autowire(AttributeFixture::class);
-        $this->assertInstanceOf(Definition::class, $definition);
+        $this->assertInstanceOf(DefinitionInterface::class, $definition);
 
         $methodInjection = $this->getMethodInjection($definition, 'method4');
         $this->assertInstanceOf(MethodInjection::class, $methodInjection);
@@ -153,7 +153,7 @@ class AttributeBasedAutowiringTest extends TestCase
     public function testMethod5()
     {
         $definition = (new AttributeBasedAutowiring)->autowire(AttributeFixture::class);
-        $this->assertInstanceOf(Definition::class, $definition);
+        $this->assertInstanceOf(DefinitionInterface::class, $definition);
 
         $methodInjection = $this->getMethodInjection($definition, 'method5');
         $this->assertInstanceOf(MethodInjection::class, $methodInjection);
@@ -195,14 +195,14 @@ class AttributeBasedAutowiringTest extends TestCase
     public function testInjectable()
     {
         $definition = (new AttributeBasedAutowiring)->autowire(AnnotationInjectableFixture::class);
-        $this->assertInstanceOf(Definition::class, $definition);
+        $this->assertInstanceOf(DefinitionInterface::class, $definition);
         $this->assertTrue($definition->isLazy());
     }
 
     public function testMethodInjectionWithPrimitiveTypeCausesAnError()
     {
         $definition = (new AttributeBasedAutowiring)->autowire(AnnotationFixture3::class);
-        $this->assertInstanceOf(Definition::class, $definition);
+        $this->assertInstanceOf(DefinitionInterface::class, $definition);
 
         $methodInjection = $this->getMethodInjection($definition, 'method1');
         $this->assertInstanceOf(MethodInjection::class, $methodInjection);

--- a/tests/UnitTest/Definition/Source/SourceChainTest.php
+++ b/tests/UnitTest/Definition/Source/SourceChainTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DI\Test\UnitTest\Definition\Source;
 
-use DI\Definition\Definition;
+use DI\Definition\DefinitionInterface;
 use DI\Definition\Source\DefinitionArray;
 use DI\Definition\Source\SourceChain;
 use DI\Definition\ValueDefinition;
@@ -86,7 +86,7 @@ class SourceChainTest extends TestCase
         $this->assertSame($mutableSource->getDefinition('foo'), $chain->getDefinition('foo'));
     }
 
-    private function assertValueDefinition(Definition $definition, $value)
+    private function assertValueDefinition(DefinitionInterface $definition, $value)
     {
         $this->assertInstanceOf(ValueDefinition::class, $definition);
         /** @var ValueDefinition $definition */


### PR DESCRIPTION
PSR Naming Conventions

1. Interfaces MUST be suffixed by Interface: e.g. Psr\Foo\BarInterface.