### PR TITLE
Resolve variadic parameters.

### DIFF
--- a/src/Definition/Resolver/ParameterResolver.php
+++ b/src/Definition/Resolver/ParameterResolver.php
@@ -48,6 +48,26 @@ class ParameterResolver
                 // Look in the $parameters array
                 $value = &$parameters[$parameter->getName()];
             } elseif (array_key_exists($index, $definitionParameters)) {
+                if ($parameter->isVariadic()) {
+                    $args = array_merge(
+                        $args,
+                        // Resolve definitions, if any
+                        array_map(
+                            function ($arg) {
+                                if ($arg instanceof Definition) {
+                                    return $this->definitionResolver->resolve($arg);
+                                }
+
+                                return $arg;
+                            },
+                            // Parameters that are left
+                            array_slice($definitionParameters, $index)
+                        )
+                    );
+
+                    break;
+                }
+
                 // Look in the definition
                 $value = &$definitionParameters[$index];
             } else {

--- a/tests/UnitTest/Definition/Resolver/Fixture/FixtureClass.php
+++ b/tests/UnitTest/Definition/Resolver/Fixture/FixtureClass.php
@@ -10,6 +10,7 @@ class FixtureClass
     public $constructorParam1;
     public $methodParam1;
     public $methodParam2;
+    public $methodParam3;
 
     public function __construct($param1)
     {
@@ -24,5 +25,10 @@ class FixtureClass
     public function methodDefaultValue($param = 'defaultValue')
     {
         $this->methodParam2 = $param;
+    }
+
+    public function methodWithVariadicParameter($param1, ...$param2)
+    {
+        $this->methodParam3 = [$param1, ...$param2];
     }
 }

--- a/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
+++ b/tests/UnitTest/Definition/Resolver/ObjectCreatorTest.php
@@ -54,6 +54,18 @@ class ObjectCreatorTest extends TestCase
         $this->assertEquals('value3', $object->methodParam1);
     }
 
+    public function testResolveWithVariadicParameter()
+    {
+        $definition = new ObjectDefinition(FixtureClass::class);
+        $definition->setConstructorInjection(MethodInjection::constructor(['value1']));
+        $definition->addMethodInjection(new MethodInjection('methodWithVariadicParameter', ['value1', 'value2', 'value3']));
+
+        $object = $this->resolver->resolve($definition);
+
+        $this->assertInstanceOf(FixtureClass::class, $object);
+        $this->assertEquals(['value1', 'value2', 'value3'], $object->methodParam3);
+    }
+
     public function testResolveNoConstructorClass()
     {
         $definition = new ObjectDefinition(NoConstructor::class);


### PR DESCRIPTION
`ParameterResolver::resolveParameters()` was iterating through the reflection parameters and fetching appropriate values from either named parameters or definition parameters. This meant the number of resolved arguments matched the number of reflection parameters, even if a parameter was variadic. This change adds a check for variadic parameters and adds the rest of the parameters to the `args` array accordingly.
