### PR TITLE
Fix documention for php definitions

### DIFF
--- a/doc/php-definitions.md
+++ b/doc/php-definitions.md
@@ -501,7 +501,7 @@ Be also aware that it isn't possible to add definitions to a container on the fl
 
 ```php
 $builder = new ContainerBuilder();
-$builder->setDefinitionCache(new ApcCache());
+$builder->enableCompilation(__DIR__ . '/var/cache');
 $container = $builder->build();
 
 // Works: you can set values


### PR DESCRIPTION
On this [page](https://php-di.org/doc/php-definitions.html#setting-definitions-in-the-container-directl)  there is a mention of 

```
$builder = new ContainerBuilder();
$builder->setDefinitionCache(new ApcCache());
```

setDefinitionCache function does not exist in ContainerBuilder. I replaced it with enableCompilation