### PR TITLE
Show circular list of depedencies on circular dependancy error message

### DIFF
--- a/src/CompiledContainer.php
+++ b/src/CompiledContainer.php
@@ -46,7 +46,8 @@ abstract class CompiledContainer extends Container
         if ($method !== null) {
             // Check if we are already getting this entry -> circular dependency
             if (isset($this->entriesBeingResolved[$id])) {
-                throw new DependencyException("Circular dependency detected while trying to resolve entry '$id'");
+                $idList = implode(" -> ", [...array_keys($this->entriesBeingResolved), $id]);
+                throw new DependencyException("Circular dependency detected while trying to resolve entry '$id': Dependencies: " . $idList);
             }
             $this->entriesBeingResolved[$id] = true;
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -344,7 +344,8 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
 
         // Check if we are already getting this entry -> circular dependency
         if (isset($this->entriesBeingResolved[$entryName])) {
-            throw new DependencyException("Circular dependency detected while trying to resolve entry '$entryName'");
+            $entryList = implode(" -> ", [...array_keys($this->entriesBeingResolved), $entryName]);
+            throw new DependencyException("Circular dependency detected while trying to resolve entry '$entryName': Dependencies: " . $entryList);
         }
         $this->entriesBeingResolved[$entryName] = true;
 

--- a/tests/IntegrationTest/CircularDependencyTest.php
+++ b/tests/IntegrationTest/CircularDependencyTest.php
@@ -52,7 +52,7 @@ class CircularDependencyTest extends BaseContainerTest
     public function circular_dependencies_with_attributes_throw_exceptions(ContainerBuilder $builder)
     {
         $this->expectException(DependencyException::class);
-        $this->expectExceptionMessage('Circular dependency detected while trying to resolve entry \'DI\Test\UnitTest\Fixtures\Class1CircularDependencies\'');
+        $this->expectExceptionMessage("Circular dependency detected while trying to resolve entry 'DI\Test\UnitTest\Fixtures\Class1CircularDependencies': Dependencies: DI\Test\UnitTest\Fixtures\Class1CircularDependencies -> DI\Test\UnitTest\Fixtures\Class2CircularDependencies -> DI\Test\UnitTest\Fixtures\Class1CircularDependencies");
         $builder->useAttributes(true);
         $builder->build()->get(Class1CircularDependencies::class);
     }
@@ -64,7 +64,7 @@ class CircularDependencyTest extends BaseContainerTest
     public function circular_dependencies_because_of_self_alias_throw_exceptions(ContainerBuilder $builder)
     {
         $this->expectException(DependencyException::class);
-        $this->expectExceptionMessage('Circular dependency detected while trying to resolve entry \'foo\'');
+        $this->expectExceptionMessage("Circular dependency detected while trying to resolve entry 'foo': Dependencies: foo -> foo");
         $builder->addDefinitions([
             // Alias to itself -> infinite recursive loop
             'foo' => get('foo'),

--- a/tests/IntegrationTest/ContainerMakeTest.php
+++ b/tests/IntegrationTest/ContainerMakeTest.php
@@ -71,7 +71,7 @@ class ContainerMakeTest extends BaseContainerTest
     public function testCircularDependencyException(ContainerBuilder $builder)
     {
         $this->expectException(DependencyException::class);
-        $this->expectExceptionMessage('Circular dependency detected while trying to resolve entry \'DI\Test\UnitTest\Fixtures\Class1CircularDependencies\'');
+        $this->expectExceptionMessage('Circular dependency detected while trying to resolve entry \'DI\Test\UnitTest\Fixtures\Class1CircularDependencies\': Dependencies: DI\Test\UnitTest\Fixtures\Class1CircularDependencies -> DI\Test\UnitTest\Fixtures\Class2CircularDependencies -> DI\Test\UnitTest\Fixtures\Class1CircularDependencies');
         $builder->useAttributes(true);
         $container = $builder->build();
         $container->make(Class1CircularDependencies::class);
@@ -83,7 +83,7 @@ class ContainerMakeTest extends BaseContainerTest
     public function testCircularDependencyExceptionWithAlias(ContainerBuilder $builder)
     {
         $this->expectException(DependencyException::class);
-        $this->expectExceptionMessage('Circular dependency detected while trying to resolve entry \'foo\'');
+        $this->expectExceptionMessage('Circular dependency detected while trying to resolve entry \'foo\': Dependencies: foo -> foo');
         $builder->addDefinitions([
             // Alias to itself -> infinite recursive loop
             'foo' => \DI\get('foo'),


### PR DESCRIPTION
Sometimes it can take a while to trace through the dependencies to find a circle. But the container knows the dependencies its trying to resolve when it throws this error, so outputting that in the exception message should help.

May need a bit more work to only show the circle instead of the full list of dependencies being resolved.
