### PR TITLE
Update composer and tests to PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,10 @@
         "php": ">=8.0",
         "psr/container": "^1.1 || ^2.0",
         "php-di/invoker": "^2.0",
-        "laravel/serializable-closure": "^1.0"
+        "laravel/serializable-closure": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": ">=9.5",
         "mnapoli/phpunit-easymock": "^1.3",
         "friendsofphp/proxy-manager-lts": "^1",
         "friendsofphp/php-cs-fixer": "^3",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,33 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-    phpunit -c phpunit.xml
--->
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         beStrictAboutTestsThatDoNotTestAnything="false"
-         bootstrap="./vendor/autoload.php">
-
-    <testsuites>
-        <testsuite name="unit">
-            <directory>./tests/UnitTest/</directory>
-        </testsuite>
-        <testsuite name="integration">
-            <directory>./tests/IntegrationTest/</directory>
-            <exclude>./tests/IntegrationTest/BaseContainerTest.php</exclude>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-            <exclude>
-                <file>src/Compiler/Template.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	backupGlobals="false"
+	backupStaticAttributes="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	beStrictAboutTestsThatDoNotTestAnything="false"
+	bootstrap="./vendor/autoload.php"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <file>src/Compiler/Template.php</file>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="unit">
+      <directory>./tests/UnitTest/</directory>
+    </testsuite>
+    <testsuite name="integration">
+      <directory>./tests/IntegrationTest/</directory>
+      <exclude>./tests/IntegrationTest/BaseContainerTest.php</exclude>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/IntegrationTest/Definitions/AttributeTest.php
+++ b/tests/IntegrationTest/Definitions/AttributeTest.php
@@ -138,11 +138,11 @@ class ConstructorInjection
 {
     public $value;
     public string $scalarValue;
-    public stdClass $typedValue;
-    public ?stdClass $typedOptionalValue;
+    public \stdClass $typedValue;
+    public \stdClass $typedOptionalValue;
     /** @var stdClass&\ProxyManager\Proxy\LazyLoadingInterface */
     public $lazyService;
-    public stdClass $attribute;
+    public \stdClass $attribute;
     public string $optionalValue;
 
     #[Inject(['value' => 'foo', 'scalarValue' => 'foo', 'lazyService' => 'lazyService'])]
@@ -150,10 +150,10 @@ class ConstructorInjection
         $value,
         string $scalarValue,
         \stdClass $typedValue,
-        \stdClass $typedOptionalValue = null,
-        \stdClass $lazyService,
+        \stdClass $typedOptionalValue = new \stdClass(),
+        \stdClass $lazyService = new \stdClass(),
         #[Inject('attribute')]
-        \stdClass $attribute,
+        \stdClass $attribute = new \stdClass(),
         string $optionalValue = 'hello'
     ) {
         $this->value = $value;
@@ -194,11 +194,11 @@ class MethodInjection
         $value,
         string $scalarValue,
         $untypedValue,
-        \stdClass $typedOptionalValue = null,
-        \stdClass $lazyService,
+        \stdClass $typedOptionalValue = new \stdClass(),
+        \stdClass $lazyService = new \stdClass(),
         #[Inject('attribute')]
-        stdClass $attribute,
-        $optionalValue = 'hello'
+        \stdClass $attribute = new \stdClass(),
+        string $optionalValue = 'hello'
     ) {
         $this->value = $value;
         $this->scalarValue = $scalarValue;

--- a/tests/IntegrationTest/Definitions/AutowireDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/AutowireDefinitionTest.php
@@ -58,8 +58,8 @@ class AutowireDefinitionTest extends BaseContainerTest
 
         $object = $container->get(ConstructorInjection::class);
 
-        self::assertEquals(new \stdClass, $object->typedValue);
-        self::assertEquals(new \stdClass, $object->typedOptionalValue);
+        self::assertEquals(new \stdClass(), $object->typedValue);
+        self::assertEquals(new \stdClass(), $object->typedOptionalValue);
         self::assertEquals('bar', $object->value);
         self::assertInstanceOf(LazyService::class, $object->lazyService);
         self::assertInstanceOf(LazyLoadingInterface::class, $object->lazyService);
@@ -362,21 +362,15 @@ namespace DI\Test\IntegrationTest\Definitions\AutowireDefinitionTest;
 
 class NullableConstructorParameter
 {
-    public $bar;
-
-    public function __construct($bar = null)
+    public function __construct(public $bar = null)
     {
-        $this->bar = $bar;
     }
 }
 
 class NullableTypedConstructorParameter
 {
-    public $bar;
-
-    public function __construct(\stdClass $bar = null)
+    public function __construct(public ?\stdClass $bar = null)
     {
-        $this->bar = $bar;
     }
 }
 
@@ -413,9 +407,9 @@ class ConstructorInjection
     public function __construct(
         \stdClass $typedValue,
         string $value,
-        \stdClass $typedOptionalValue = null,
-        LazyService $lazyService,
-        UnknownClass $unknownTypedAndOptional = null,
+        ?\stdClass $typedOptionalValue,
+        ?LazyService $lazyService,
+        $unknownTypedAndOptional = null,
         $optionalValue = 'hello'
     ) {
         $this->value = $value;

--- a/tests/IntegrationTest/Definitions/CreateDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/CreateDefinitionTest.php
@@ -331,8 +331,8 @@ class ConstructorInjection
         $value,
         string $scalarValue,
         \stdClass $typedValue,
-        \stdClass $typedOptionalValue = null,
-        \stdClass $lazyService,
+        ?\stdClass $typedOptionalValue = null,
+        ?\stdClass $lazyService = null,
         $optionalValue = 'hello'
     ) {
         $this->value = $value;
@@ -366,8 +366,8 @@ class MethodInjection
         $value,
         string $scalarValue,
         \stdClass $typedValue,
-        \stdClass $typedOptionalValue = null,
-        \stdClass $lazyService,
+        \stdClass $typedOptionalValue = new \stdClass(),
+        \stdClass $lazyService = new \stdClass(),
         $optionalValue = 'hello'
     ) {
         $this->value = $value;

--- a/tests/IntegrationTest/Issues/Issue168Test.php
+++ b/tests/IntegrationTest/Issues/Issue168Test.php
@@ -32,7 +32,7 @@ class TestClass
      * The parameter is optional. TestInterface is not instantiable, so `null` should
      * be injected instead of getting an exception.
      */
-    public function __construct(TestInterface $param = null)
+    public function __construct(?TestInterface $param = null)
     {
     }
 }

--- a/tests/UnitTest/Definition/Resolver/ArrayResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/ArrayResolverTest.php
@@ -51,13 +51,18 @@ class ArrayResolverTest extends TestCase
      */
     public function should_resolve_nested_definitions()
     {
-        $this->parentResolver->expects($this->exactly(2))
-            ->method('resolve')
-            ->withConsecutive(
-                [$this->isInstanceOf(Reference::class)],
-                [$this->isInstanceOf(ObjectDefinition::class)]
-            )
-            ->willReturnOnConsecutiveCalls(42, new \stdClass());
+        $matcher = $this->exactly(2);
+        $this->parentResolver->expects($matcher)
+            ->method('resolve')->willReturnCallback(function (...$parameters) use ($matcher) {
+            if ($matcher->numberOfInvocations() === 1) {
+                $this->assertSame($this->isInstanceOf(Reference::class), $parameters[0]);
+                return 42;
+            }
+            if ($matcher->numberOfInvocations() === 2) {
+                $this->assertSame($this->isInstanceOf(ObjectDefinition::class), $parameters[0]);
+                return new \stdClass();
+            }
+        });
 
         $definition = new ArrayDefinition([
             'bar',

--- a/tests/UnitTest/Definition/Source/Fixtures/AttributeFixture.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AttributeFixture.php
@@ -67,7 +67,7 @@ class AttributeFixture
     }
 
     #[Inject(['foo'])]
-    public function optionalParameter(\stdClass $optional1 = null, \stdClass $optional2 = null)
+    public function optionalParameter(?\stdClass $optional1 = null, ?\stdClass $optional2 = null)
     {
     }
 

--- a/tests/UnitTest/Definition/StringDefinitionTest.php
+++ b/tests/UnitTest/Definition/StringDefinitionTest.php
@@ -71,10 +71,18 @@ class StringDefinitionTest extends TestCase
     public function should_resolve_multiple_references()
     {
         $container = $this->easySpy(ContainerInterface::class);
-        $container->expects($this->exactly(2))
-            ->method('get')
-            ->withConsecutive(['tmp'], ['logs'])
-            ->willReturnOnConsecutiveCalls('/private/tmp', 'myapp-logs');
+        $matcher = $this->exactly(2);
+        $container->expects($matcher)
+            ->method('get')->willReturnCallback(function (...$parameters) use ($matcher) {
+            if ($matcher->numberOfInvocations() === 1) {
+                $this->assertSame('tmp', $parameters[0]);
+                return '/private/tmp';
+            }
+            if ($matcher->numberOfInvocations() === 2) {
+                $this->assertSame('logs', $parameters[0]);
+                return 'myapp-logs';
+            }
+        });
 
         $definition = new StringDefinition('{tmp}/{logs}/app.log');
 

--- a/tests/UnitTest/Fixtures/FakeContainer.php
+++ b/tests/UnitTest/Fixtures/FakeContainer.php
@@ -33,7 +33,7 @@ class FakeContainer
     public function __construct(
         DefinitionSource $definitionSource,
         ProxyFactory $proxyFactory,
-        ContainerInterface $wrapperContainer = null
+        ?ContainerInterface $wrapperContainer = null
     ) {
         $this->definitionSource = $definitionSource;
         $this->proxyFactory = $proxyFactory;


### PR DESCRIPTION
I updated to the latest dependencies.  Also up updated for PHP 8.4 nullable parameter depreciation fix.

The unit tests on the master branch had one failure originally and I did not fix that.

Also upgrading PHPUnit removed the withConsecutive() method.  I used Rector to fix, but that introduced another failure.  Since I don't know (or use directly) this library, I am not sure how to fix this test or what you are actually trying to test. So you should take a look, probably an easy fix if you know what you want.

