### PR TITLE
Fix tests for PHP 8.4

### DIFF
--- a/tests/IntegrationTest/Definitions/Attribute/class-php83.php
+++ b/tests/IntegrationTest/Definitions/Attribute/class-php83.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\IntegrationTest\Definitions\AttributesTest;
+
+use DI\Attribute\Inject;
+use stdClass;
+
+class NonAnnotatedClass
+{
+}
+
+class AutowiredClass
+{
+    public stdClass $entry;
+    public function __construct(stdClass $entry)
+    {
+        $this->entry = $entry;
+    }
+}
+
+class ConstructorInjection
+{
+    public $value;
+    public string $scalarValue;
+    public stdClass $typedValue;
+    public ?stdClass $typedOptionalValue;
+    public ?stdClass $typedOptionalValueDefaultNull;
+    /** @var stdClass&\ProxyManager\Proxy\LazyLoadingInterface */
+    public $lazyService;
+    public stdClass $attribute;
+    public string $optionalValue;
+
+    #[Inject(['value' => 'foo', 'scalarValue' => 'foo', 'lazyService' => 'lazyService'])]
+    public function __construct(
+        $value,
+        string $scalarValue,
+        \stdClass $typedValue,
+        \stdClass $lazyService,
+        #[Inject('attribute')]
+        \stdClass $attribute,
+        \stdClass $typedOptionalValue = null,
+        ?\stdClass $typedOptionalValueDefaultNull = null,
+        string $optionalValue = 'hello'
+    ) {
+        $this->value = $value;
+        $this->scalarValue = $scalarValue;
+        $this->typedValue = $typedValue;
+        $this->typedOptionalValue = $typedOptionalValue;
+        $this->typedOptionalValueDefaultNull = $typedOptionalValueDefaultNull;
+        $this->lazyService = $lazyService;
+        $this->attribute = $attribute;
+        $this->optionalValue = $optionalValue;
+    }
+}
+
+class PropertyInjection
+{
+    #[Inject(name: 'foo')]
+    public $value;
+    #[Inject('foo')]
+    public $value2;
+    #[Inject]
+    public stdClass $entry;
+    #[Inject('lazyService')]
+    public $lazyService;
+}
+
+class MethodInjection
+{
+    public $value;
+    public $scalarValue;
+    public $typedValue;
+    public $typedOptionalValue;
+    public $typedOptionalValueDefaultNull;
+    /** @var \ProxyManager\Proxy\LazyLoadingInterface */
+    public $lazyService;
+    public stdClass $attribute;
+    public $optionalValue;
+
+    #[Inject(['value' => 'foo', 'scalarValue' => 'foo', 'lazyService' => 'lazyService'])]
+    public function method(
+        $value,
+        string $scalarValue,
+        $untypedValue,
+        \stdClass $lazyService,
+        #[Inject('attribute')]
+        stdClass $attribute,
+        \stdClass $typedOptionalValue = null,
+        ?\stdClass $typedOptionalValueDefaultNull = null,
+        $optionalValue = 'hello'
+    ) {
+        $this->value = $value;
+        $this->scalarValue = $scalarValue;
+        $this->untypedValue = $untypedValue;
+        $this->typedOptionalValue = $typedOptionalValue;
+        $this->typedOptionalValueDefaultNull = $typedOptionalValueDefaultNull;
+        $this->lazyService = $lazyService;
+        $this->attribute = $attribute;
+        $this->optionalValue = $optionalValue;
+    }
+}

--- a/tests/IntegrationTest/Definitions/Attribute/class.php
+++ b/tests/IntegrationTest/Definitions/Attribute/class.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\IntegrationTest\Definitions\AttributesTest;
+
+use DI\Attribute\Inject;
+use stdClass;
+
+class NonAnnotatedClass
+{
+}
+
+class AutowiredClass
+{
+    public stdClass $entry;
+    public function __construct(stdClass $entry)
+    {
+        $this->entry = $entry;
+    }
+}
+
+class ConstructorInjection
+{
+    public $value;
+    public string $scalarValue;
+    public stdClass $typedValue;
+    public ?stdClass $typedOptionalValue;
+    public ?stdClass $typedOptionalValueDefaultNull;
+    /** @var stdClass&\ProxyManager\Proxy\LazyLoadingInterface */
+    public $lazyService;
+    public stdClass $attribute;
+    public string $optionalValue;
+
+    #[Inject(['value' => 'foo', 'scalarValue' => 'foo', 'lazyService' => 'lazyService'])]
+    public function __construct(
+        $value,
+        string $scalarValue,
+        \stdClass $typedValue,
+        \stdClass $lazyService,
+        #[Inject('attribute')]
+        \stdClass $attribute,
+        ?\stdClass $typedOptionalValue = new stdClass(),
+        ?\stdClass $typedOptionalValueDefaultNull = null,
+        string $optionalValue = 'hello'
+    ) {
+        $this->value = $value;
+        $this->scalarValue = $scalarValue;
+        $this->typedValue = $typedValue;
+        $this->typedOptionalValue = $typedOptionalValue;
+        $this->typedOptionalValueDefaultNull = $typedOptionalValueDefaultNull;
+        $this->lazyService = $lazyService;
+        $this->attribute = $attribute;
+        $this->optionalValue = $optionalValue;
+    }
+}
+
+class PropertyInjection
+{
+    #[Inject(name: 'foo')]
+    public $value;
+    #[Inject('foo')]
+    public $value2;
+    #[Inject]
+    public stdClass $entry;
+    #[Inject('lazyService')]
+    public $lazyService;
+}
+
+class MethodInjection
+{
+    public $value;
+    public $scalarValue;
+    public $typedValue;
+    public $typedOptionalValue;
+    public $typedOptionalValueDefaultNull;
+    /** @var \ProxyManager\Proxy\LazyLoadingInterface */
+    public $lazyService;
+    public stdClass $attribute;
+    public $optionalValue;
+
+    #[Inject(['value' => 'foo', 'scalarValue' => 'foo', 'lazyService' => 'lazyService'])]
+    public function method(
+        $value,
+        string $scalarValue,
+        $untypedValue,
+        \stdClass $lazyService,
+        #[Inject('attribute')]
+        stdClass $attribute,
+        ?\stdClass $typedOptionalValue = new stdClass,
+        ?\stdClass $typedOptionalValueDefaultNull = null,
+        $optionalValue = 'hello'
+    ) {
+        $this->value = $value;
+        $this->scalarValue = $scalarValue;
+        $this->untypedValue = $untypedValue;
+        $this->typedOptionalValue = $typedOptionalValue;
+        $this->typedOptionalValueDefaultNull = $typedOptionalValueDefaultNull;
+        $this->lazyService = $lazyService;
+        $this->attribute = $attribute;
+        $this->optionalValue = $optionalValue;
+    }
+}

--- a/tests/IntegrationTest/Definitions/AttributeTest.php
+++ b/tests/IntegrationTest/Definitions/AttributeTest.php
@@ -21,6 +21,15 @@ use function DI\create;
  */
 class AttributeTest extends BaseContainerTest
 {
+    public static function setUpBeforeClass(): void
+    {
+        if (PHP_VERSION_ID < 80400) {
+            require_once __DIR__ . '/Attribute/class-php83.php';
+        } else {
+            require_once __DIR__ . '/Attribute/class.php';
+        }
+    }
+
     /**
      * @dataProvider provideContainer
      */
@@ -46,7 +55,7 @@ class AttributeTest extends BaseContainerTest
         $object = $container->get(ConstructorInjection::class);
 
         self::assertEquals(new \stdClass, $object->typedValue);
-        self::assertEquals(new \stdClass, $object->typedOptionalValue);
+        self::assertEquals(PHP_VERSION_ID < 80400 ? null : new \stdClass, $object->typedOptionalValue);
         self::assertNull($object->typedOptionalValueDefaultNull);
         self::assertEquals('bar', $object->value);
         self::assertInstanceOf(\stdClass::class, $object->lazyService);
@@ -107,7 +116,7 @@ class AttributeTest extends BaseContainerTest
         $object = $container->get(ConstructorInjection::class);
 
         self::assertEquals(new \stdClass, $object->typedValue);
-        self::assertEquals(new \stdClass, $object->typedOptionalValue);
+        self::assertEquals(PHP_VERSION_ID < 80400 ? null : new \stdClass, $object->typedOptionalValue);
         self::assertNull($object->typedOptionalValueDefaultNull);
         self::assertEquals('bar', $object->value);
         self::assertInstanceOf(\stdClass::class, $object->lazyService);
@@ -115,105 +124,5 @@ class AttributeTest extends BaseContainerTest
         self::assertFalse($object->lazyService->isProxyInitialized());
         self::assertSame($container->get('attribute'), $object->attribute);
         self::assertEquals('hello', $object->optionalValue);
-    }
-}
-
-namespace DI\Test\IntegrationTest\Definitions\AttributesTest;
-
-use DI\Attribute\Inject;
-use stdClass;
-
-class NonAnnotatedClass
-{
-}
-
-class AutowiredClass
-{
-    public stdClass $entry;
-    public function __construct(stdClass $entry)
-    {
-        $this->entry = $entry;
-    }
-}
-
-class ConstructorInjection
-{
-    public $value;
-    public string $scalarValue;
-    public stdClass $typedValue;
-    public ?stdClass $typedOptionalValue;
-    public ?stdClass $typedOptionalValueDefaultNull;
-    /** @var stdClass&\ProxyManager\Proxy\LazyLoadingInterface */
-    public $lazyService;
-    public stdClass $attribute;
-    public string $optionalValue;
-
-    #[Inject(['value' => 'foo', 'scalarValue' => 'foo', 'lazyService' => 'lazyService'])]
-    public function __construct(
-        $value,
-        string $scalarValue,
-        \stdClass $typedValue,
-        \stdClass $lazyService,
-        #[Inject('attribute')]
-        \stdClass $attribute,
-        ?\stdClass $typedOptionalValue = new stdClass(),
-        ?\stdClass $typedOptionalValueDefaultNull = null,
-        string $optionalValue = 'hello'
-    ) {
-        $this->value = $value;
-        $this->scalarValue = $scalarValue;
-        $this->typedValue = $typedValue;
-        $this->typedOptionalValue = $typedOptionalValue;
-        $this->typedOptionalValueDefaultNull = $typedOptionalValueDefaultNull;
-        $this->lazyService = $lazyService;
-        $this->attribute = $attribute;
-        $this->optionalValue = $optionalValue;
-    }
-}
-
-class PropertyInjection
-{
-    #[Inject(name: 'foo')]
-    public $value;
-    #[Inject('foo')]
-    public $value2;
-    #[Inject]
-    public stdClass $entry;
-    #[Inject('lazyService')]
-    public $lazyService;
-}
-
-class MethodInjection
-{
-    public $value;
-    public $scalarValue;
-    public $typedValue;
-    public $typedOptionalValue;
-    public $typedOptionalValueDefaultNull;
-    /** @var \ProxyManager\Proxy\LazyLoadingInterface */
-    public $lazyService;
-    public stdClass $attribute;
-    public $optionalValue;
-
-    #[Inject(['value' => 'foo', 'scalarValue' => 'foo', 'lazyService' => 'lazyService'])]
-    public function method(
-        $value,
-        string $scalarValue,
-        $untypedValue,
-        \stdClass $lazyService,
-        #[Inject('attribute')]
-        stdClass $attribute,
-        ?\stdClass $typedOptionalValue = new stdClass,
-        ?\stdClass $typedOptionalValueDefaultNull = null,
-        $optionalValue = 'hello'
-    ) {
-        $this->value = $value;
-        $this->scalarValue = $scalarValue;
-        $this->untypedValue = $untypedValue;
-        $this->typedOptionalValue = $typedOptionalValue;
-        $this->typedOptionalValueDefaultNull = $typedOptionalValueDefaultNull;
-        $this->lazyService = $lazyService;
-        $this->attribute = $attribute;
-        $this->optionalValue = $optionalValue;
     }
 }

--- a/tests/IntegrationTest/Definitions/AttributeTest.php
+++ b/tests/IntegrationTest/Definitions/AttributeTest.php
@@ -47,6 +47,7 @@ class AttributeTest extends BaseContainerTest
 
         self::assertEquals(new \stdClass, $object->typedValue);
         self::assertEquals(new \stdClass, $object->typedOptionalValue);
+        self::assertNull($object->typedOptionalValueDefaultNull);
         self::assertEquals('bar', $object->value);
         self::assertInstanceOf(\stdClass::class, $object->lazyService);
         self::assertInstanceOf(LazyLoadingInterface::class, $object->lazyService);
@@ -107,6 +108,7 @@ class AttributeTest extends BaseContainerTest
 
         self::assertEquals(new \stdClass, $object->typedValue);
         self::assertEquals(new \stdClass, $object->typedOptionalValue);
+        self::assertNull($object->typedOptionalValueDefaultNull);
         self::assertEquals('bar', $object->value);
         self::assertInstanceOf(\stdClass::class, $object->lazyService);
         self::assertInstanceOf(LazyLoadingInterface::class, $object->lazyService);
@@ -140,6 +142,7 @@ class ConstructorInjection
     public string $scalarValue;
     public stdClass $typedValue;
     public ?stdClass $typedOptionalValue;
+    public ?stdClass $typedOptionalValueDefaultNull;
     /** @var stdClass&\ProxyManager\Proxy\LazyLoadingInterface */
     public $lazyService;
     public stdClass $attribute;
@@ -150,16 +153,18 @@ class ConstructorInjection
         $value,
         string $scalarValue,
         \stdClass $typedValue,
-        \stdClass $typedOptionalValue = null,
         \stdClass $lazyService,
         #[Inject('attribute')]
         \stdClass $attribute,
+        ?\stdClass $typedOptionalValue = new stdClass(),
+        ?\stdClass $typedOptionalValueDefaultNull = null,
         string $optionalValue = 'hello'
     ) {
         $this->value = $value;
         $this->scalarValue = $scalarValue;
         $this->typedValue = $typedValue;
         $this->typedOptionalValue = $typedOptionalValue;
+        $this->typedOptionalValueDefaultNull = $typedOptionalValueDefaultNull;
         $this->lazyService = $lazyService;
         $this->attribute = $attribute;
         $this->optionalValue = $optionalValue;
@@ -184,6 +189,7 @@ class MethodInjection
     public $scalarValue;
     public $typedValue;
     public $typedOptionalValue;
+    public $typedOptionalValueDefaultNull;
     /** @var \ProxyManager\Proxy\LazyLoadingInterface */
     public $lazyService;
     public stdClass $attribute;
@@ -194,16 +200,18 @@ class MethodInjection
         $value,
         string $scalarValue,
         $untypedValue,
-        \stdClass $typedOptionalValue = null,
         \stdClass $lazyService,
         #[Inject('attribute')]
         stdClass $attribute,
+        ?\stdClass $typedOptionalValue = new stdClass,
+        ?\stdClass $typedOptionalValueDefaultNull = null,
         $optionalValue = 'hello'
     ) {
         $this->value = $value;
         $this->scalarValue = $scalarValue;
         $this->untypedValue = $untypedValue;
         $this->typedOptionalValue = $typedOptionalValue;
+        $this->typedOptionalValueDefaultNull = $typedOptionalValueDefaultNull;
         $this->lazyService = $lazyService;
         $this->attribute = $attribute;
         $this->optionalValue = $optionalValue;

--- a/tests/IntegrationTest/Definitions/AutowireDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/AutowireDefinitionTest.php
@@ -59,7 +59,7 @@ class AutowireDefinitionTest extends BaseContainerTest
         $object = $container->get(ConstructorInjection::class);
 
         self::assertEquals(new \stdClass, $object->typedValue);
-        self::assertEquals(new \stdClass, $object->typedOptionalValue);
+        self::assertNull($object->typedOptionalValue);
         self::assertEquals('bar', $object->value);
         self::assertInstanceOf(LazyService::class, $object->lazyService);
         self::assertInstanceOf(LazyLoadingInterface::class, $object->lazyService);
@@ -374,7 +374,7 @@ class NullableTypedConstructorParameter
 {
     public $bar;
 
-    public function __construct(\stdClass $bar = null)
+    public function __construct(?\stdClass $bar = null)
     {
         $this->bar = $bar;
     }
@@ -413,9 +413,9 @@ class ConstructorInjection
     public function __construct(
         \stdClass $typedValue,
         string $value,
-        \stdClass $typedOptionalValue = null,
         LazyService $lazyService,
-        UnknownClass $unknownTypedAndOptional = null,
+        ?\stdClass $typedOptionalValue = null,
+        ?UnknownClass $unknownTypedAndOptional = null,
         $optionalValue = 'hello'
     ) {
         $this->value = $value;

--- a/tests/IntegrationTest/Definitions/CreateDefinition/class-php83.php
+++ b/tests/IntegrationTest/Definitions/CreateDefinition/class-php83.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\IntegrationTest\Definitions\CreateDefinitionTest;
+
+class Property
+{
+    public $foo;
+}
+
+class ConstructorInjection
+{
+    public $value;
+    public $scalarValue;
+    public $typedValue;
+    public $typedOptionalValue;
+    public $typedOptionalValueDefaultNull;
+    /** @var \ProxyManager\Proxy\LazyLoadingInterface */
+    public $lazyService;
+    public $optionalValue;
+
+    public function __construct(
+        $value,
+        string $scalarValue,
+        \stdClass $typedValue,
+        \stdClass $lazyService,
+        \stdClass $typedOptionalValue = null,
+        ?\stdClass $typedOptionalValueDefaultNull = null,
+        $optionalValue = 'hello'
+    ) {
+        $this->value = $value;
+        $this->scalarValue = $scalarValue;
+        $this->typedValue = $typedValue;
+        $this->typedOptionalValue = $typedOptionalValue;
+        $this->typedOptionalValueDefaultNull = $typedOptionalValueDefaultNull;
+        $this->lazyService = $lazyService;
+        $this->optionalValue = $optionalValue;
+    }
+}
+
+class PropertyInjection
+{
+    public $value;
+    public $entry;
+    /** @var \ProxyManager\Proxy\LazyLoadingInterface */
+    public $lazyService;
+}
+
+class MethodInjection
+{
+    public $value;
+    public $scalarValue;
+    public $typedValue;
+    public $typedOptionalValue;
+    public $typedOptionalValueDefaultNull;
+    /** @var \ProxyManager\Proxy\LazyLoadingInterface */
+    public $lazyService;
+    public $optionalValue;
+
+    public function method(
+        $value,
+        string $scalarValue,
+        \stdClass $typedValue,
+        \stdClass $lazyService,
+        \stdClass $typedOptionalValue = null,
+        ?\stdClass $typedOptionalValueDefaultNull = null,
+        $optionalValue = 'hello'
+    ) {
+        $this->value = $value;
+        $this->scalarValue = $scalarValue;
+        $this->typedValue = $typedValue;
+        $this->typedOptionalValue = $typedOptionalValue;
+        $this->typedOptionalValueDefaultNull = $typedOptionalValueDefaultNull;
+        $this->lazyService = $lazyService;
+        $this->optionalValue = $optionalValue;
+    }
+}
+
+class PrivatePropertyInjection
+{
+    private $private;
+    protected $protected;
+
+    public function getPrivate()
+    {
+        return $this->private;
+    }
+
+    public function getProtected()
+    {
+        return $this->protected;
+    }
+}
+
+class PrivatePropertyInjectionSubClass extends PrivatePropertyInjection
+{
+    private $private;
+
+    public function getSubClassPrivate()
+    {
+        return $this->private;
+    }
+}

--- a/tests/IntegrationTest/Definitions/CreateDefinition/class.php
+++ b/tests/IntegrationTest/Definitions/CreateDefinition/class.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\IntegrationTest\Definitions\CreateDefinitionTest;
+
+class Property
+{
+    public $foo;
+}
+
+class ConstructorInjection
+{
+    public $value;
+    public $scalarValue;
+    public $typedValue;
+    public $typedOptionalValue;
+    public $typedOptionalValueDefaultNull;
+    /** @var \ProxyManager\Proxy\LazyLoadingInterface */
+    public $lazyService;
+    public $optionalValue;
+
+    public function __construct(
+        $value,
+        string $scalarValue,
+        \stdClass $typedValue,
+        \stdClass $lazyService,
+        ?\stdClass $typedOptionalValue = new \stdClass(),
+        ?\stdClass $typedOptionalValueDefaultNull = null,
+        $optionalValue = 'hello'
+    ) {
+        $this->value = $value;
+        $this->scalarValue = $scalarValue;
+        $this->typedValue = $typedValue;
+        $this->typedOptionalValue = $typedOptionalValue;
+        $this->typedOptionalValueDefaultNull = $typedOptionalValueDefaultNull;
+        $this->lazyService = $lazyService;
+        $this->optionalValue = $optionalValue;
+    }
+}
+
+class PropertyInjection
+{
+    public $value;
+    public $entry;
+    /** @var \ProxyManager\Proxy\LazyLoadingInterface */
+    public $lazyService;
+}
+
+class MethodInjection
+{
+    public $value;
+    public $scalarValue;
+    public $typedValue;
+    public $typedOptionalValue;
+    public $typedOptionalValueDefaultNull;
+    /** @var \ProxyManager\Proxy\LazyLoadingInterface */
+    public $lazyService;
+    public $optionalValue;
+
+    public function method(
+        $value,
+        string $scalarValue,
+        \stdClass $typedValue,
+        \stdClass $lazyService,
+        ?\stdClass $typedOptionalValue = new stdClass(),
+        ?\stdClass $typedOptionalValueDefaultNull = null,
+        $optionalValue = 'hello'
+    ) {
+        $this->value = $value;
+        $this->scalarValue = $scalarValue;
+        $this->typedValue = $typedValue;
+        $this->typedOptionalValue = $typedOptionalValue;
+        $this->typedOptionalValueDefaultNull = $typedOptionalValueDefaultNull;
+        $this->lazyService = $lazyService;
+        $this->optionalValue = $optionalValue;
+    }
+}
+
+class PrivatePropertyInjection
+{
+    private $private;
+    protected $protected;
+
+    public function getPrivate()
+    {
+        return $this->private;
+    }
+
+    public function getProtected()
+    {
+        return $this->protected;
+    }
+}
+
+class PrivatePropertyInjectionSubClass extends PrivatePropertyInjection
+{
+    private $private;
+
+    public function getSubClassPrivate()
+    {
+        return $this->private;
+    }
+}

--- a/tests/IntegrationTest/Definitions/CreateDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/CreateDefinitionTest.php
@@ -59,8 +59,8 @@ class CreateDefinitionTest extends BaseContainerTest
                     123,
                     get('foo'),
                     get(\stdClass::class),
+                    get('lazyService'),
                     get(\stdClass::class),
-                    get('lazyService')
                 ),
             'foo' => 'bar',
             'lazyService' => create(\stdClass::class)->lazy(),
@@ -118,8 +118,8 @@ class CreateDefinitionTest extends BaseContainerTest
                     123,
                     get('foo'),
                     get(\stdClass::class),
+                    get('lazyService'),
                     get(\stdClass::class),
-                    get('lazyService')
                 ),
             'foo' => 'bar',
             'lazyService' => create(\stdClass::class)->lazy(),
@@ -323,6 +323,7 @@ class ConstructorInjection
     public $scalarValue;
     public $typedValue;
     public $typedOptionalValue;
+    public $typedOptionalValueDefaultNull;
     /** @var \ProxyManager\Proxy\LazyLoadingInterface */
     public $lazyService;
     public $optionalValue;
@@ -331,14 +332,16 @@ class ConstructorInjection
         $value,
         string $scalarValue,
         \stdClass $typedValue,
-        \stdClass $typedOptionalValue = null,
         \stdClass $lazyService,
+        ?\stdClass $typedOptionalValue = new \stdClass(),
+        ?\stdClass $typedOptionalValueDefaultNull = null,
         $optionalValue = 'hello'
     ) {
         $this->value = $value;
         $this->scalarValue = $scalarValue;
         $this->typedValue = $typedValue;
         $this->typedOptionalValue = $typedOptionalValue;
+        $this->typedOptionalValueDefaultNull = $typedOptionalValueDefaultNull;
         $this->lazyService = $lazyService;
         $this->optionalValue = $optionalValue;
     }
@@ -358,6 +361,7 @@ class MethodInjection
     public $scalarValue;
     public $typedValue;
     public $typedOptionalValue;
+    public $typedOptionalValueDefaultNull;
     /** @var \ProxyManager\Proxy\LazyLoadingInterface */
     public $lazyService;
     public $optionalValue;
@@ -366,14 +370,16 @@ class MethodInjection
         $value,
         string $scalarValue,
         \stdClass $typedValue,
-        \stdClass $typedOptionalValue = null,
         \stdClass $lazyService,
+        ?\stdClass $typedOptionalValue = new stdClass(),
+        ?\stdClass $typedOptionalValueDefaultNull = null,
         $optionalValue = 'hello'
     ) {
         $this->value = $value;
         $this->scalarValue = $scalarValue;
         $this->typedValue = $typedValue;
         $this->typedOptionalValue = $typedOptionalValue;
+        $this->typedOptionalValueDefaultNull = $typedOptionalValueDefaultNull;
         $this->lazyService = $lazyService;
         $this->optionalValue = $optionalValue;
     }

--- a/tests/IntegrationTest/Definitions/CreateDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/CreateDefinitionTest.php
@@ -25,6 +25,15 @@ use DI\Definition\Exception\InvalidDefinition;
  */
 class CreateDefinitionTest extends BaseContainerTest
 {
+    public static function setUpBeforeClass(): void
+    {
+        if (PHP_VERSION_ID < 80400) {
+            require_once __DIR__ . '/CreateDefinition/class-php83.php';
+        } else {
+            require_once __DIR__ . '/CreateDefinition/class.php';
+        }
+    }
+
     /**
      * @dataProvider provideContainer
      */
@@ -307,106 +316,5 @@ class CreateDefinitionTest extends BaseContainerTest
 
         self::assertEntryIsCompiled($container, 'foo');
         self::assertInstanceOf(Property::class, $container->get('foo')['bar']);
-    }
-}
-
-namespace DI\Test\IntegrationTest\Definitions\CreateDefinitionTest;
-
-class Property
-{
-    public $foo;
-}
-
-class ConstructorInjection
-{
-    public $value;
-    public $scalarValue;
-    public $typedValue;
-    public $typedOptionalValue;
-    public $typedOptionalValueDefaultNull;
-    /** @var \ProxyManager\Proxy\LazyLoadingInterface */
-    public $lazyService;
-    public $optionalValue;
-
-    public function __construct(
-        $value,
-        string $scalarValue,
-        \stdClass $typedValue,
-        \stdClass $lazyService,
-        ?\stdClass $typedOptionalValue = new \stdClass(),
-        ?\stdClass $typedOptionalValueDefaultNull = null,
-        $optionalValue = 'hello'
-    ) {
-        $this->value = $value;
-        $this->scalarValue = $scalarValue;
-        $this->typedValue = $typedValue;
-        $this->typedOptionalValue = $typedOptionalValue;
-        $this->typedOptionalValueDefaultNull = $typedOptionalValueDefaultNull;
-        $this->lazyService = $lazyService;
-        $this->optionalValue = $optionalValue;
-    }
-}
-
-class PropertyInjection
-{
-    public $value;
-    public $entry;
-    /** @var \ProxyManager\Proxy\LazyLoadingInterface */
-    public $lazyService;
-}
-
-class MethodInjection
-{
-    public $value;
-    public $scalarValue;
-    public $typedValue;
-    public $typedOptionalValue;
-    public $typedOptionalValueDefaultNull;
-    /** @var \ProxyManager\Proxy\LazyLoadingInterface */
-    public $lazyService;
-    public $optionalValue;
-
-    public function method(
-        $value,
-        string $scalarValue,
-        \stdClass $typedValue,
-        \stdClass $lazyService,
-        ?\stdClass $typedOptionalValue = new stdClass(),
-        ?\stdClass $typedOptionalValueDefaultNull = null,
-        $optionalValue = 'hello'
-    ) {
-        $this->value = $value;
-        $this->scalarValue = $scalarValue;
-        $this->typedValue = $typedValue;
-        $this->typedOptionalValue = $typedOptionalValue;
-        $this->typedOptionalValueDefaultNull = $typedOptionalValueDefaultNull;
-        $this->lazyService = $lazyService;
-        $this->optionalValue = $optionalValue;
-    }
-}
-
-class PrivatePropertyInjection
-{
-    private $private;
-    protected $protected;
-
-    public function getPrivate()
-    {
-        return $this->private;
-    }
-
-    public function getProtected()
-    {
-        return $this->protected;
-    }
-}
-
-class PrivatePropertyInjectionSubClass extends PrivatePropertyInjection
-{
-    private $private;
-
-    public function getSubClassPrivate()
-    {
-        return $this->private;
     }
 }

--- a/tests/IntegrationTest/Issues/Issue168/class-php83.php
+++ b/tests/IntegrationTest/Issues/Issue168/class-php83.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\IntegrationTest\Issues\Issue168;
+
+class TestClass83
+{
+    /**
+     * The parameter is optional. TestInterface is not instantiable, so `null` should
+     * be injected instead of getting an exception.
+     */
+    public function __construct(TestInterface83 $param = null)
+    {
+    }
+}
+
+interface TestInterface83
+{
+}

--- a/tests/IntegrationTest/Issues/Issue168/class.php
+++ b/tests/IntegrationTest/Issues/Issue168/class.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DI\Test\IntegrationTest\Issues\Issue168;
+
+class TestClass
+{
+    /**
+     * The parameter is optional. TestInterface is not instantiable, so `null` should
+     * be injected instead of getting an exception.
+     */
+    public function __construct(?TestInterface $param = null)
+    {
+    }
+}
+
+interface TestInterface
+{
+}

--- a/tests/IntegrationTest/Issues/Issue168Test.php
+++ b/tests/IntegrationTest/Issues/Issue168Test.php
@@ -20,23 +20,23 @@ class Issue168Test extends BaseContainerTest
      */
     public function testInterfaceOptionalParameter(ContainerBuilder $builder)
     {
+        require_once __DIR__ . '/Issue168/class.php';
+
         $container = $builder->build();
-        $object = $container->get(TestClass::class);
-        $this->assertInstanceOf(TestClass::class, $object);
+        $object = $container->get(Issue168\TestClass::class);
+        $this->assertInstanceOf(Issue168\TestClass::class, $object);
     }
-}
 
-class TestClass
-{
     /**
-     * The parameter is optional. TestInterface is not instantiable, so `null` should
-     * be injected instead of getting an exception.
+     * @dataProvider provideContainer
+     * @requires PHP < 8.4.0
      */
-    public function __construct(TestInterface $param = null)
+    public function testInterfaceOptionalParameterForPHP83(ContainerBuilder $builder)
     {
-    }
-}
+        require_once __DIR__ . '/Issue168/class-php83.php';
 
-interface TestInterface
-{
+        $container = $builder->build();
+        $object = $container->get(Issue168\TestClass83::class);
+        $this->assertInstanceOf(Issue168\TestClass83::class, $object);
+    }
 }

--- a/tests/UnitTest/Definition/Source/Fixtures/AttributeFixture.php
+++ b/tests/UnitTest/Definition/Source/Fixtures/AttributeFixture.php
@@ -67,7 +67,7 @@ class AttributeFixture
     }
 
     #[Inject(['foo'])]
-    public function optionalParameter(\stdClass $optional1 = null, \stdClass $optional2 = null)
+    public function optionalParameter(?\stdClass $optional1 = null, ?\stdClass $optional2 = null)
     {
     }
 

--- a/tests/UnitTest/Fixtures/FakeContainer.php
+++ b/tests/UnitTest/Fixtures/FakeContainer.php
@@ -33,7 +33,7 @@ class FakeContainer
     public function __construct(
         DefinitionSource $definitionSource,
         ProxyFactory $proxyFactory,
-        ContainerInterface $wrapperContainer = null
+        ?ContainerInterface $wrapperContainer = null,
     ) {
         $this->definitionSource = $definitionSource;
         $this->proxyFactory = $proxyFactory;


### PR DESCRIPTION
Make to ensure compatibility with PHP 8.4:

 * Explicitly add `?` nullable type to optional parameters.
 * Moves optional parameters (with default values) after required parameters.
 * For regression testing, we will separate test cases for PHP 8.3 and earlier from newer PHP versions. 

It is similar to https://github.com/PHP-DI/PHP-DI/pull/897, but this PR is focused only on PHP 8.4 support.