### PR TITLE
Update PHP-DI to support PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         timeout-minutes: 15
         strategy:
             matrix:
-                php: [ '8.0', '8.1', '8.2', '8.3' ]
+                php: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
                 dependency-version: [ '' ]
                 include:
                     -   php: '8.0'

--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,10 @@
         "php": ">=8.0",
         "psr/container": "^1.1 || ^2.0",
         "php-di/invoker": "^2.0",
-        "laravel/serializable-closure": "^1.0"
+        "laravel/serializable-closure": "^1.0 || ^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "mnapoli/phpunit-easymock": "^1.3",
         "friendsofphp/proxy-manager-lts": "^1",
         "friendsofphp/php-cs-fixer": "^3",


### PR DESCRIPTION
PHP 8.4 came out in November.

This commit originally built upon #897 but after further investigation and rebasing, I discovered that the approach in 897 covered more than is necessary so I've created a new approach.

#897 modified the composer.json to use the latest compatible version of PHPUnit (`>=9.5`) when it is perfectly safe and stable to pin to 9.6 (`^9.6`) which supports PHP 7.3 through to PHP 8.4.

As a result the changes to stop using `willReturnConsecutive()` are no longer required (though they will be in the future in some form), and there is no need to make many of the other changes.

This changset instead:
* modifies the phpunit dependency to `^9.6`
* modifies the `laravel/serializable-closure` to `^1.0 || ^2.0`
* add a build on PHP 8.4

I believe this is all that is required to make this compatible with PHP 8.0 to PHP 8.4.