### PR TITLE
fix: Stripped final from class def

### DIFF
--- a/src/Attribute/Inject.php
+++ b/src/Attribute/Inject.php
@@ -17,7 +17,7 @@ use DI\Definition\Exception\InvalidAttribute;
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD | Attribute::TARGET_PARAMETER)]
-final class Inject
+class Inject
 {
     /**
      * Entry name.

--- a/src/Attribute/Injectable.php
+++ b/src/Attribute/Injectable.php
@@ -17,7 +17,7 @@ use Attribute;
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class Injectable
+class Injectable
 {
     /**
      * @param bool|null $lazy Should the object be lazy-loaded.


### PR DESCRIPTION
Removed final keyword from class definitions of `Inject` and `Injectable` attributes.

Final keyword prevents extending these classes which goes against the open-closed principle.

Fixes #902 

