### PR TITLE
Make it possible to extend container

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -104,7 +104,7 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
 
         // Auto-register the container
         $this->resolvedEntries = [
-            self::class => $this,
+            static::class => $this,
             ContainerInterface::class => $this->delegateContainer,
             FactoryInterface::class => $this,
             InvokerInterface::class => $this,


### PR DESCRIPTION
Make it possible to extend container by auto-registering ``static::class`` instead of ``self::class``