### PR TITLE
Run tests on PHP 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         timeout-minutes: 15
         strategy:
             matrix:
-                php: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
+                php: [ '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
                 dependency-version: [ '' ]
                 include:
                     -   php: '8.0'

--- a/src/Definition/Resolver/DefinitionResolver.php
+++ b/src/Definition/Resolver/DefinitionResolver.php
@@ -22,8 +22,8 @@ interface DefinitionResolver
      * Resolve a definition to a value.
      *
      * @param Definition $definition Object that defines how the value should be obtained.
-     * @psalm-param T $definition
      * @param array      $parameters Optional parameters to use to build the entry.
+     * @psalm-param T $definition
      * @return mixed Value obtained from the definition.
      *
      * @throws InvalidDefinition If the definition cannot be resolved.
@@ -35,8 +35,8 @@ interface DefinitionResolver
      * Check if a definition can be resolved.
      *
      * @param Definition $definition Object that defines how the value should be obtained.
-     * @psalm-param T $definition
      * @param array      $parameters Optional parameters to use to build the entry.
+     * @psalm-param T $definition
      */
     public function isResolvable(Definition $definition, array $parameters = []) : bool;
 }

--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -38,7 +38,7 @@ class ProxyFactory implements ProxyFactoryInterface
      *
      * {@inheritDoc}
      */
-    public function createProxy(string $className, \Closure $createFunction): object
+    public function createProxy(string $className, \Closure $createFunction) : object
     {
         return $this->proxyManager()->createProxy(
             $className,

--- a/tests/UnitTest/ContainerBuilderTest.php
+++ b/tests/UnitTest/ContainerBuilderTest.php
@@ -27,7 +27,7 @@ class ContainerBuilderTest extends TestCase
 	private static function getProperty(object $object, string $propertyName)
 	{
 		return (function (string $propertyName) {
-			return $this->$propertyName;
+			return $this->$propertyName ?? null;
 		})->bindTo($object, $object)($propertyName);
 	}
 


### PR DESCRIPTION
This PR adds PHP 8.5, now a stable release, to the list of PHP versions tested in CI.

I also fixed a warning in the test code.